### PR TITLE
Set up dev environment + add AGENTS.md cloud instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+interaqt is a TypeScript library (a declarative reactive backend framework), not a
+runnable server/UI app. "Running it" means executing the framework via tests or a
+small script; there is no dev server. Standard commands live in `package.json`
+scripts and the `README.md` "Development" section — use those.
+
+- Package manager is npm. There is **no committed lockfile** (`package-lock.json`
+  is gitignored), so installs resolve fresh each time.
+- `npm install` fails with `ERESOLVE` because `@release-it/conventional-changelog`
+  (release-only tooling) wants `release-it@^17` while the repo pins `release-it@^19`.
+  Install with `npm install --legacy-peer-deps`. This does not affect
+  lint/test/build/runtime, which do not use release-it.
+- Type-check (this repo's "lint"): `npm run check:all` (per-layer tsc). Build:
+  `npm run build` (Vite → `dist/`, then a prod tsc check). Tests: `npm test`
+  (Vitest). See `package.json` for scoped variants (`test:runtime`, `test:storage`,
+  `test:core`, `test:builtins`).
+- Tests use in-memory drivers (`PGLiteDB` / `SQLiteDB` from `@drivers`), so no
+  external database is required. PostgreSQL-specific tests are gated behind the
+  `INTERAQT_POSTGRES_DATABASE` env var and are skipped without it.
+- Flaky-timeout gotcha: the full suite occasionally reports one failure —
+  `tests/runtime/migration.spec.ts > ... "approved changed and unchanged decisions
+  control built-in global aggregate rebuilds"`. It genuinely runs ~5.5s and can
+  exceed Vitest's default 5s timeout on loaded VMs. It is not a real failure;
+  re-run with a larger timeout, e.g.
+  `npx vitest run tests/runtime/migration.spec.ts -t "approved changed and unchanged decisions control built-in global aggregate rebuilds" --testTimeout=60000`.
+- To smoke-test the framework end-to-end without the test runner, write a short
+  `tsx` script that imports from `./src/index.js` and `./src/drivers/index.js`
+  (e.g. `MonoSystem` + `PGLiteDB` + a `Controller`), and polyfill
+  `globalThis.crypto` from `node:crypto` at the top (mirrors
+  `scripts/vitest.setup.js`) since UUID generation needs it in plain Node.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `interaqt` framework and documents non-obvious setup caveats for future cloud agents.

interaqt is a TypeScript reactive backend framework (library) — there is no dev server/UI. "Running" it means executing the framework via tests or a small script.

### Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: the `--legacy-peer-deps` install requirement, the missing committed lockfile, lint/test/build commands, in-memory test drivers, and a known flaky-timeout migration test.

### Environment setup
- Update script: `npm install --legacy-peer-deps` (plain `npm install` fails with `ERESOLVE` due to a release-only `release-it` peer conflict).

## Verification

- ✅ `npm install --legacy-peer-deps`
- ✅ `npm run check:all` (type-check / lint)
- ✅ `npm run build`
- ✅ `npm test` — 1569 passed, 26 skipped; the single failure is a known ~5.5s test exceeding Vitest's default 5s timeout, which passes with `--testTimeout=60000`.
- ✅ Hello-world end-to-end: dispatched `CreatePost` + `LikePost` interactions and confirmed the reactive `likeCount` auto-updated to 1.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8eaa11de-e67d-4562-8653-ce81a70495ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8eaa11de-e67d-4562-8653-ce81a70495ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

