### PR TITLE
fix(storage): resolve fatal bugs F1–F8 in erstorage

### DIFF
--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -26,6 +26,8 @@ export class MysqlDB implements Database{
     idSystem!: IDSystem
     logger: DatabaseLogger
     db!: Connection
+    // MySQL 8.0+ 支持 SELECT ... FOR UPDATE OF <alias>
+    supportsSelectForUpdate = true
     transactionCapability: TransactionCapability = {
         transactions: false,
         isolationLevels: [],
@@ -163,9 +165,10 @@ export class MysqlDB implements Database{
         if (fieldType === 'JSON') {
             if (value[0].toLowerCase() === 'contains') {
                 const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                // CAUTION 匹配值必须走参数绑定，不能字符串拼接进 SQL（否则存在 SQL 注入）。
                 return {
-                    fieldValue: `IS NOT NULL AND JSON_CONTAINS(${fieldNameWithQuotes}, '${JSON.stringify(value[1])}', '$')`,
-                    fieldParams: []
+                    fieldValue: `IS NOT NULL AND JSON_CONTAINS(${fieldNameWithQuotes}, ${p()}, '$')`,
+                    fieldParams: [JSON.stringify(value[1])]
                 }
             }
         }

--- a/src/storage/erstorage/CreationExecutor.ts
+++ b/src/storage/erstorage/CreationExecutor.ts
@@ -392,7 +392,11 @@ export class CreationExecutor {
             ...attributes
         })
 
-        return this.createRecord(newLinkData, `create link record ${linkInfo.name}`, events)
+        const linkRecord = await this.createRecord(newLinkData, `create link record ${linkInfo.name}`, events)
+        // CAUTION 关系建立会改变依赖该关系的 filtered entity 的成员资格，必须显式传播。
+        //  放在这里而不是 RecordQueryAgent.addLink，是为了同时覆盖 addLinkFromRecord 等直接调用本方法的入口。
+        await this.filteredEntityManager.propagateLinkChange(linkInfo.name, sourceId, targetId, events)
+        return linkRecord
     }
 
     /**

--- a/src/storage/erstorage/FilteredEntityManager.ts
+++ b/src/storage/erstorage/FilteredEntityManager.ts
@@ -80,53 +80,54 @@ export class FilteredEntityManager {
             const matchAtom = boolExp.data as MatchAtom
             const key = matchAtom.key
             const pathParts = key.split('.')
-            
-            // 如果路径只有一个部分，说明是源实体自身的属性
-            if (pathParts.length === 1) {
-                const existing = dependencies.find(d => d.entityName === entityName && d.path.length === 0)
+
+            const addDependency = (depEntityName: string, depPath: string[], attribute: string) => {
+                const existing = dependencies.find(d =>
+                    d.entityName === depEntityName &&
+                    JSON.stringify(d.path) === JSON.stringify(depPath)
+                )
                 if (existing) {
-                    if (!existing.attributes.includes(pathParts[0])) {
-                        existing.attributes.push(pathParts[0])
+                    if (!existing.attributes.includes(attribute)) {
+                        existing.attributes.push(attribute)
                     }
                 } else {
                     dependencies.push({
-                        entityName,
-                        path: [],
-                        attributes: [pathParts[0]]
+                        entityName: depEntityName,
+                        path: depPath,
+                        attributes: [attribute]
                     })
                 }
+            }
+
+            // 如果路径只有一个部分，说明是源实体自身的属性
+            if (pathParts.length === 1) {
+                addDependency(entityName, [], pathParts[0])
             } else {
-                // 路径包含多个部分，需要解析关联实体
+                // 路径包含多个部分（跨实体过滤）。这里要登记两类依赖：
+                // 1. 末端值属性所在实体的该属性（例如 team.department.budget -> Department.budget）
+                // 2. 路径上"每一段关系"本身。因为关系（link）的建立/解除同样会改变成员资格，
+                //    而之前的实现只登记了末端属性，忽略了关系边，导致关系变更时 filtered entity
+                //    的标记和事件不更新（脏状态）。
                 const fullPath = [entityName].concat(pathParts)
-                
-                // 获取路径中每个节点的信息
-                for (let i = 1; i < fullPath.length - 1; i++) {
-                    const currentPath = fullPath.slice(0, i + 1)
-                    const info = this.map.getInfoByPath(currentPath)
-                    
+
+                // 逐段登记关系依赖：owner 实体的关系属性变化会影响成员资格。
+                // i 对应关系段在 pathParts 中的下标；owner 是该关系所属实体，ownerPath 是从 base 到 owner 的路径。
+                let ownerEntity = entityName
+                for (let i = 0; i < pathParts.length - 1; i++) {
+                    const relationAttr = pathParts[i]
+                    const ownerPath = pathParts.slice(0, i) // 从 base 到 owner 的关系路径
+                    const info = this.map.getInfoByPath(fullPath.slice(0, i + 2))
+                    // 关系段本身作为依赖：owner.relationAttr 变化 -> 需要反查回 base 重新求值
+                    addDependency(ownerEntity, ownerPath, relationAttr)
                     if (info && info.isRecord) {
-                        const depEntityName = info.recordName
-                        const depPath = pathParts.slice(0, i)
-                        const attribute = pathParts[pathParts.length - 1]
-                        
-                        const existing = dependencies.find(d => 
-                            d.entityName === depEntityName && 
-                            JSON.stringify(d.path) === JSON.stringify(depPath)
-                        )
-                        
-                        if (existing) {
-                            if (!existing.attributes.includes(attribute)) {
-                                existing.attributes.push(attribute)
-                            }
-                        } else {
-                            dependencies.push({
-                                entityName: depEntityName,
-                                path: depPath,
-                                attributes: [attribute]
-                            })
-                        }
+                        ownerEntity = info.recordName
                     }
                 }
+
+                // 末端值属性：所在实体是路径倒数第二段指向的实体（即上面循环结束时的 ownerEntity）
+                const valueAttribute = pathParts[pathParts.length - 1]
+                const valuePath = pathParts.slice(0, pathParts.length - 1)
+                addDependency(ownerEntity, valuePath, valueAttribute)
             }
         }
     }
@@ -173,6 +174,17 @@ export class FilteredEntityManager {
             return [{ id: changedRecordId }]
         }
         
+        return this.findSourceRecordsByReversePath(dependency, depInfo, changedRecordId)
+    }
+
+    /**
+     * 根据依赖路径反向查询受影响的源记录（path.length > 0 的跨实体场景）
+     */
+    private async findSourceRecordsByReversePath(
+        dependency: FilteredEntityDependency,
+        depInfo: FilteredEntityDependency['dependencies'][number],
+        changedRecordId: string
+    ): Promise<{ id: string }[]> {
         // 构建反向查询，从变更的实体查找到源实体
         // path 已经是从源实体到目标实体的关系路径
         // 例如：对于 User 依赖 Team.type，path = ['team']
@@ -263,6 +275,36 @@ export class FilteredEntityManager {
         return result;
     }
     
+    /**
+     * 关系（link）建立/解除后，重新评估依赖该关系的 filtered entity。
+     * CAUTION 关系的变化同样会改变成员资格（例如 filter 为 team.type='tech'，用户换了 team）。
+     *  但关系变更不会经过实体的 update/create/delete，所以这里显式在 link 变更处传播。
+     *  依赖 __filtered_entities 标记的幂等性：即使与实体 update 路径重复触发，也只会在标记真正变化时产生一次事件。
+     * @param linkName 关系名
+     * @param sourceId 关系 source 端实体 id
+     * @param targetId 关系 target 端实体 id
+     */
+    async propagateLinkChange(
+        linkName: string,
+        sourceId: string | undefined,
+        targetId: string | undefined,
+        events: RecordMutationEvent[] = []
+    ): Promise<void> {
+        const link = this.map.data.links[linkName]
+        if (!link) return
+        // 虚拟 link（relation 与 entity 之间的）不承载真实关系语义，跳过。
+        if (link.isSourceRelation) return
+
+        // source 端：owner 实体是 sourceRecord，关系属性是 sourceProperty
+        if (sourceId !== undefined && link.sourceRecord && link.sourceProperty) {
+            await this.updateFilteredEntityFlags(link.sourceRecord, sourceId, events, undefined, false, [link.sourceProperty])
+        }
+        // target 端：owner 实体是 targetRecord，关系属性是 targetProperty（可能不存在）
+        if (targetId !== undefined && link.targetRecord && link.targetProperty) {
+            await this.updateFilteredEntityFlags(link.targetRecord, targetId, events, undefined, false, [link.targetProperty])
+        }
+    }
+
     /**
      * 更新记录的 filtered entity 标记（主入口方法）
      */

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -255,7 +255,11 @@ export class MatchExp {
         return [fieldValue, fieldParams!]
     }
 
-    buildFieldMatchExpression(p: PlaceholderGen, db?: Database): BoolExp<FieldMatchAtom> | null {
+    // CAUTION fnMatchHandler 必须在遍历原子时"就地"处理函数匹配（EXIST 子查询）。
+    //  因为对于 PostgreSQL 这类使用编号占位符（$1/$2...）的数据库，占位符的分配顺序必须和
+    //  buildWhereClause 收集参数的树序完全一致。如果先给所有值原子分配编号、再回头给 EXIST
+    //  内层子查询分配，EXIST 之后的值原子编号就会和参数数组错位，导致查询结果静默错误。
+    buildFieldMatchExpression(p: PlaceholderGen, db?: Database, fnMatchHandler?: (atomData: FieldMatchAtom) => FieldMatchAtom): BoolExp<FieldMatchAtom> | null {
         if (!this.data) return null
         // 1. 所有 key 要 build 成 field
         // 2. x:n 关系中的 EXIST 要增加查询范围限制，要把 value 中对上层引用也 build 成 field。
@@ -314,27 +318,28 @@ export class MatchExp {
 
                 // CAUTION 函数匹配的情况不管了，因为可能未来涉及到使用 cursor 实现更强的功能，这就涉及到查询计划的修改了。统统扔到上层去做。
                 //  注意，子查询中也可能对上层的引用，这个也放到上层好像能力有点重叠了。
+                const handleFnMatch = fnMatchHandler || ((data: FieldMatchAtom) => data)
                 if (!symmetricPaths) {
-                    return {
+                    return handleFnMatch({
                         ...exp.data,
                         namePath,
                         isFunctionMatch: true,
-                    }
+                    })
                 }
 
                 const sourceNamePath = [this.entityName].concat(sourcePath!)
                 const targetNamePath = [this.entityName].concat(targetPath!)
                 assert(sourceNamePath!.length === namePath.length, `symmetric entity match can only be last, ${sourceNamePath} ${namePath}`)
 
-                return BoolExp.atom<FieldMatchAtom>({
+                return BoolExp.atom<FieldMatchAtom>(handleFnMatch({
                     ...exp.data,
                     namePath:sourceNamePath!,
                     isFunctionMatch: true,
-                }).or({
+                })).or(handleFnMatch({
                     ...exp.data,
                     namePath:targetNamePath!,
                     isFunctionMatch: true,
-                })
+                }))
 
             }
         })

--- a/src/storage/erstorage/MergedItemProcessor.ts
+++ b/src/storage/erstorage/MergedItemProcessor.ts
@@ -153,16 +153,75 @@ function processSingleMergedItem<T extends MergedItem>(
 
         // 处理 input items。让所有 input item 都是 virtual base item 的 filtered item。
         if (inputItems) {
+            // rootBaseName -> 共享该 root base 的 input 名称集合，用于修复被 input 覆盖的 root base 身份
+            const rootBaseToInputs = new Map<string, string[]>();
             for (const inputItem of inputItems) {
                 processInputItem(
                     inputItem,
                     virtualBaseItem!,
                     inputTypeFieldName,
                     refContainer,
-                    isEntity
+                    isEntity,
+                    rootBaseToInputs
                 );
             }
+
+            // CAUTION 修复 F3：filtered input 的 root base entity（例如 CustomerBase）必须保留自身身份。
+            //  旧实现直接把 root base 的槽位替换成"带 input tag 的 filtered entity"，导致：
+            //  1) 通过 root base 名创建的记录在任何实体里都查不到（黑洞）；
+            //  2) root base 丢失了自己的谓词。
+            //  这里为每个 distinct root base 单独生成一个 filtered entity，成员条件是
+            //  "tag 属于自己或其任一子 input"，从而保持可查询与 IS-A 语义。
+            if (isEntity) {
+                for (const [rootBaseName, inputNames] of rootBaseToInputs) {
+                    rebaseRootBaseEntity(rootBaseName, inputNames, virtualBaseItem as EntityInstance, inputTypeFieldName, refContainer);
+                }
+            }
         }
+    }
+
+/**
+ * 计算 filtered entity 从自身到 root base（不含）的完整谓词，并返回 root base。
+ */
+function collectFilteredEntityChain(inputEntity: EntityInstance): { rootBase: EntityInstance, match: MatchExpressionData | undefined } {
+        let current: EntityInstance = inputEntity;
+        let match: MatchExpressionData | undefined = undefined;
+        while (current.baseEntity) {
+            const currentMatch = (current as any).matchExpression as MatchExpressionData | undefined;
+            if (currentMatch) {
+                match = match ? match.and(currentMatch) : currentMatch;
+            }
+            current = current.baseEntity as EntityInstance;
+        }
+        return { rootBase: current, match };
+}
+
+/**
+ * 为 filtered input 的 root base entity 重新生成 filtered entity，使其保留自身可查询性。
+ */
+function rebaseRootBaseEntity(
+        rootBaseName: string,
+        inputNames: string[],
+        virtualBaseItem: EntityInstance,
+        inputFieldName: string,
+        refContainer: RefContainer
+    ): void {
+        // root base 就是 virtual base 本身时无需处理
+        if (rootBaseName === virtualBaseItem.name) return;
+        const existing = refContainer.getEntityByName(rootBaseName);
+        // root base 未作为独立实体注册（匿名 base）则无需处理
+        if (!existing) return;
+
+        // 成员条件：tag 属于 root base 自己，或其任一子 input（IS-A 语义）
+        const tagNames = [rootBaseName, ...inputNames];
+        const rootFiltered = Entity.clone(existing, true);
+        rootFiltered.name = rootBaseName;
+        rootFiltered.baseEntity = virtualBaseItem;
+        rootFiltered.matchExpression = MatchExp.fromArray(
+            tagNames.map(name => ({ key: inputFieldName, value: ['contains', name] as [string, any] }))
+        );
+        rootFiltered.inputEntities = undefined;
+        refContainer.replace(rootFiltered, existing);
     }
     
 /**
@@ -173,29 +232,82 @@ function processInputItem(
         virtualBaseItem: MergedItem,
         inputTypeFieldName: string,
         refContainer: RefContainer,
-        isEntity: boolean
+        isEntity: boolean,
+        rootBaseToInputs?: Map<string, string[]>
     ): void {
+        if (isEntity) {
+            processInputEntity(
+                inputItem as EntityInstance,
+                virtualBaseItem as EntityInstance,
+                inputTypeFieldName,
+                refContainer,
+                rootBaseToInputs
+            );
+            return;
+        }
+
+        // Relation 处理（保持原有逻辑）
         const [filteredItem, baseItem] = createFilteredItemFromInput(
             inputItem,
             virtualBaseItem,
             inputTypeFieldName
         );
-        
+
         // Relation 特殊处理：检查是否就是 input 本身
-        if (!isEntity && filteredItem === inputItem) {
+        if (filteredItem === inputItem) {
             return;
         }
-        
-        // 获取 base item 的名称
+
         const baseItemName = getItemName(baseItem);
-        
-        // 查找并替换已存在的 item
-        const existingItem = isEntity 
-            ? refContainer.getEntityByName(baseItemName)
-            : refContainer.getRelationByName(baseItemName);
-            
+        const existingItem = refContainer.getRelationByName(baseItemName);
         if (existingItem) {
             refContainer.replace(filteredItem, existingItem);
+        }
+    }
+
+/**
+ * 处理 merged entity 的单个 input entity。
+ * - 普通 input：克隆自身，rebase 到 virtual base，成员条件为 tag contains(自身名)。
+ * - filtered input：rebase input 自身到 virtual base，成员条件为 (自身完整谓词) AND tag contains(自身名)，
+ *   谓词得以保留（修复 F3'）；同时记录其 root base，稍后由 rebaseRootBaseEntity 保留 root base 的可查询性（修复 F3）。
+ */
+function processInputEntity(
+        inputEntity: EntityInstance,
+        virtualBaseItem: EntityInstance,
+        inputFieldName: string,
+        refContainer: RefContainer,
+        rootBaseToInputs?: Map<string, string[]>
+    ): void {
+        const inputName = inputEntity.name;
+        const existing = refContainer.getEntityByName(inputName);
+        if (!existing) return;
+
+        const tagAtom = MatchExp.atom({ key: inputFieldName, value: ['contains', inputName] });
+
+        if (inputEntity.baseEntity) {
+            // filtered input：保留其自身谓词，并直接 rebase 到 virtual base
+            const { rootBase, match } = collectFilteredEntityChain(inputEntity);
+            const filtered = Entity.clone(rootBase, true);
+            filtered.name = inputName;
+            filtered.baseEntity = virtualBaseItem;
+            filtered.matchExpression = match ? match.and(tagAtom) : tagAtom;
+            filtered.inputEntities = undefined;
+            refContainer.replace(filtered, existing);
+
+            // 记录 root base，稍后统一保留其身份
+            if (rootBaseToInputs && rootBase.name !== inputName) {
+                const list = rootBaseToInputs.get(rootBase.name) || [];
+                list.push(inputName);
+                rootBaseToInputs.set(rootBase.name, list);
+            }
+        } else {
+            // 普通 input：克隆自身作为 virtual base 的 filtered entity
+            const filtered = Entity.clone(inputEntity, true);
+            filtered.name = inputName;
+            filtered.baseEntity = virtualBaseItem;
+            filtered.matchExpression = tagAtom;
+            filtered.inputEntities = undefined;
+            refContainer.replace(filtered, existing);
         }
     }
     

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -67,21 +67,46 @@ export class QueryExecutor {
     /**
      * 结构化原始返回结果
      * @param rawReturns 数据库返回的原始结果
-     * @param JSONFields JSON 字段列表
+     * @param recordName 根记录名（用于解析各级路径上的 JSON 字段）
      * @param fieldAliasMap 字段别名映射
      * @returns 结构化的 Record 数组
      */
     private structureRawReturns(
         rawReturns: { [k: string]: unknown }[],
-        JSONFields: string[],
+        recordName: string,
         fieldAliasMap: FieldAliasMap
     ): Record[] {
+        // CAUTION JSON 反序列化必须按完整路径解析字段类型，不能只看根记录的 JSONFields。
+        //  否则关联记录（x:1 JOIN 查出）上的 JSON 字段在 SQLite/MySQL 这类返回字符串的 driver 上不会被解析，
+        //  导致同一 API 在不同 driver 下返回类型不一致。
+        const rootJSONFields = this.map.getRecordInfo(recordName).JSONFields
+        const jsonPathCache = new Map<string, boolean>()
+        const isJSONPath = (attributePath: string[]): boolean => {
+            if (attributePath.length === 1) return rootJSONFields.includes(attributePath[0])
+            const cacheKey = attributePath.join('.')
+            const cached = jsonPathCache.get(cacheKey)
+            if (cached !== undefined) return cached
+            let result = false
+            try {
+                const info = this.map.getInfoByPath([recordName, ...attributePath])
+                if (info && info.isValue) {
+                    const data = info.data as { collection?: boolean, type?: string }
+                    result = !!data.collection || data.type === 'object' || data.type === 'json'
+                }
+            } catch (e) {
+                // 无法解析的路径（例如别名等特殊字段）保持原样返回
+                result = false
+            }
+            jsonPathCache.set(cacheKey, result)
+            return result
+        }
+
         return rawReturns.map(rawReturn => {
             const obj = {}
             Object.entries(rawReturn).forEach(([key, value]) => {
                 // CAUTION 注意这里去掉了最开始的 entityName
                 const attributePath = fieldAliasMap.getPath(key)!.slice(1, Infinity)
-                if (attributePath.length === 1 && JSONFields.includes(attributePath[0]) && typeof value === 'string') {
+                if (typeof value === 'string' && isJSONPath(attributePath)) {
                     value = JSON.parse(value)
                 }
                 if (value !== null) {
@@ -90,6 +115,25 @@ export class QueryExecutor {
             })
             return obj as Record
         })
+    }
+
+    /**
+     * 去除完全相同的原始行（等价于 SQL DISTINCT）
+     * 用于消除 match 中出现 x:n 路径时 LEFT JOIN 产生的 fan-out 重复。
+     * 因为 SELECT 始终包含各级记录的 id，真正不同的记录必然有列差异，所以完全相同的行一定是重复行。
+     */
+    private dedupeIdenticalRows(rawReturns: { [k: string]: unknown }[]): { [k: string]: unknown }[] {
+        if (rawReturns.length < 2) return rawReturns
+        const seen = new Set<string>()
+        const result: { [k: string]: unknown }[] = []
+        for (const row of rawReturns) {
+            // 用稳定的 key 序列化，避免键顺序影响判等
+            const key = JSON.stringify(Object.keys(row).sort().map(k => [k, row[k]]))
+            if (seen.has(key)) continue
+            seen.add(key)
+            result.push(row)
+        }
+        return result
     }
 
     /**
@@ -138,13 +182,20 @@ export class QueryExecutor {
         //  这个 x:1 是递归的，把一次性能通过 join 查到的都查了。
         // x:n 的查询是通过二次查询获取的。
         const [querySQL, params, fieldAliasMap] = this.sqlBuilder.buildXToOneFindQuery(entityQuery, '')
-        const supportsForUpdate = this.database.constructor.name !== 'SQLiteDB'
+        // CAUTION 能力判断优先使用 driver 的显式声明，仅在未声明时退回旧的启发式判断（兼容外部 driver）。
+        const supportsForUpdate = this.database.supportsSelectForUpdate ?? (this.database.constructor.name !== 'SQLiteDB')
+        // CAUTION FOR UPDATE 必须限定主表（FOR UPDATE OF <主表别名>）。
+        //  因为 x:1 关联查询使用 LEFT JOIN，PostgreSQL 不允许对 outer join 的可空侧加锁。
         const rawReturns: { [k: string]: unknown }[] = await this.database.query(
-            forUpdate && supportsForUpdate ? `${querySQL}\nFOR UPDATE` : querySQL,
+            forUpdate && supportsForUpdate ? `${querySQL}\nFOR UPDATE OF "${entityQuery.recordName}"` : querySQL,
             params,
             queryName
         )
-        const records = this.structureRawReturns(rawReturns, this.map.getRecordInfo(entityQuery.recordName).JSONFields, fieldAliasMap)
+        // CAUTION 通过 x:n 路径做 match 时，LEFT JOIN 会让同一条根记录产生多行完全相同的结果（fan-out）。
+        //  这里按"整行完全相同"去重（等价于 SQL DISTINCT 的语义）。
+        //  不会误伤合法数据：SELECT 永远包含各级记录（含关系记录）的 id 字段，真正不同的行必然有字段差异。
+        const dedupedRawReturns = this.dedupeIdenticalRows(rawReturns)
+        const records = this.structureRawReturns(dedupedRawReturns, entityQuery.recordName, fieldAliasMap)
 
         // 如果当前的 query 有 label，那么下面任何遍历 record 的地方都要 Push stack。
         const nextRecursiveContext = (entityQuery.label && entityQuery.label !== context.label) ? context.spawn(entityQuery.label) : context

--- a/src/storage/erstorage/RecordQueryAgent.ts
+++ b/src/storage/erstorage/RecordQueryAgent.ts
@@ -172,6 +172,9 @@ export class RecordQueryAgent {
      */
     async flashOutCombinedRecordsAndMergedLinks(newEntityData: NewRecordData, events?: RecordMutationEvent[], reason = ''): Promise<{ [k: string]: RawEntityData }> {
         const result: { [k: string]: RawEntityData } = {}
+        // CAUTION 没有需要抢夺的三表合一记录时必须直接返回。
+        //  否则下面的 match 为 undefined，会生成 WHERE 1=1 的全表查询，导致每次 create/update 都全表扫描。
+        if (!newEntityData.combinedRecordIdRefs.length) return result
         // CAUTION 这里是从 newEntityData 里读，不是从 newEntityDataWithIds，那里面是刚分配id 的，还没数据。
         let match: MatchExpressionData | undefined
         // 这里的目的是抢夺 combined record 上的所有数据，那么一定穷尽 combined record 的同表数据才行。
@@ -302,7 +305,7 @@ export class RecordQueryAgent {
         return this.creationExecutor.addLinkFromRecord(entity, attribute, entityId, relatedEntityId, attributes, events)
     }
 
-    // 委托给 CreationExecutor
+    // 委托给 CreationExecutor（传播在 CreationExecutor.addLink 内统一处理，覆盖 addLinkFromRecord 等所有入口）
     async addLink(linkName: string, sourceId: string, targetId: string, attributes: RawEntityData = {}, moveSource = false, events?: RecordMutationEvent[]) {
         return this.creationExecutor.addLink(linkName, sourceId, targetId, attributes, moveSource, events)
     }
@@ -310,7 +313,17 @@ export class RecordQueryAgent {
 
     // 委托给 DeletionExecutor
     async unlink(linkName: string, matchExpressionData: MatchExpressionData, moveSource = false, reason = '', events?: RecordMutationEvent[]): Promise<Record[]> {
-        return this.deletionExecutor.unlink(linkName, matchExpressionData, moveSource, reason, events)
+        const removedLinks = await this.deletionExecutor.unlink(linkName, matchExpressionData, moveSource, reason, events)
+        // CAUTION 关系解除同样会改变依赖该关系的 filtered entity 的成员资格，逐条传播受影响的两端实体。
+        for (const link of removedLinks) {
+            await this.filteredEntityManager.propagateLinkChange(
+                linkName,
+                link.source?.id,
+                link.target?.id,
+                events
+            )
+        }
+        return removedLinks
     }
 
     /**

--- a/src/storage/erstorage/SQLBuilder.ts
+++ b/src/storage/erstorage/SQLBuilder.ts
@@ -70,10 +70,16 @@ export class SQLBuilder {
         const joinTables = this.getJoinTables(finalQueryTree, [recordQuery.recordName])
 
         const p = parentP || this.getPlaceholder()
-        const fieldMatchExp = recordQuery.matchExpression.buildFieldMatchExpression(p, this.database)
+        // CAUTION EXIST 子查询必须在遍历原子的过程中"就地"构建（通过 fnMatchHandler），
+        //  保证编号型占位符（$1/$2...）的分配顺序和 buildWhereClause 收集参数的树序一致。
+        const fieldMatchExp = recordQuery.matchExpression.buildFieldMatchExpression(
+            p,
+            this.database,
+            (atomData) => this.parseFunctionMatchAtom(recordQuery.recordName, atomData, recordQuery.contextRootEntity, p)
+        )
 
         const [whereClause, params] = this.buildWhereClause(
-            this.parseMatchExpressionValue(recordQuery.recordName, fieldMatchExp, recordQuery.contextRootEntity, p),
+            fieldMatchExp,
             prefix,
             p
         )
@@ -199,9 +205,22 @@ ${modifierClause}
     ): string {
         const { limit, offset, orderBy } = modifier
         const clauses: string[] = []
-        
+
+        // CAUTION limit/offset/order 会被直接插值进 SQL（LIMIT/OFFSET 不支持所有数据库的参数绑定），
+        //  而 modifier 常来自外部输入，必须做运行时校验防止注入。
+        if (limit !== undefined && limit !== null && (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 0)) {
+            throw new Error(`modifier.limit must be a non-negative integer, got: ${JSON.stringify(limit)}`)
+        }
+        if (offset !== undefined && offset !== null && (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0)) {
+            throw new Error(`modifier.offset must be a non-negative integer, got: ${JSON.stringify(offset)}`)
+        }
+
         if (orderBy.length) {
             clauses.push(`ORDER BY ${orderBy.map(({ attribute, recordName, order }) => {
+                const normalizedOrder = String(order).toUpperCase()
+                if (normalizedOrder !== 'ASC' && normalizedOrder !== 'DESC') {
+                    throw new Error(`orderBy value must be 'ASC' or 'DESC', got: ${JSON.stringify(order)} for attribute ${attribute}`)
+                }
                 // 解析 attribute，支持路径（如 'leader.age'）
                 const pathParts = attribute.split('.')
                 
@@ -229,7 +248,7 @@ ${modifierClause}
                 )
                 
                 const fullFieldRef = `${this.withPrefix(prefix)}${tableAlias}`
-                return `"${fullFieldRef}"."${fieldName}" ${order}`
+                return `"${fullFieldRef}"."${fieldName}" ${normalizedOrder}`
             }).join(',')}`)
         }
 
@@ -358,7 +377,64 @@ ${modifierClause}
     }
     
     /**
+     * 解析单个函数匹配原子（EXIST 子查询）
+     * CAUTION 必须在 buildFieldMatchExpression 遍历原子时就地调用，
+     *  这样 EXIST 内层子查询消耗的占位符编号才能和外层值原子保持树序一致（PG 系编号占位符依赖这一点）。
+     */
+    parseFunctionMatchAtom(
+        entityName: string,
+        atomData: FieldMatchAtom,
+        contextRootEntity: string | undefined,
+        p: PlaceholderGen
+    ): FieldMatchAtom {
+        if (!Array.isArray(atomData.value)) {
+            throw new Error(`match value is not a array ${atomData.key}`)
+        }
+
+        if (atomData.value[0].toLowerCase() !== 'exist') {
+            throw new Error(`we only support Exist function match on entity for now. yours: ${atomData.key} ${atomData.value[0]} ${atomData.value[1]}`)
+        }
+
+        const info = this.map.getInfoByPath(atomData.namePath!)!
+        const { alias: currentAlias } = this.map.getTableAndAliasStack(atomData.namePath!).at(-1)!
+        const reverseAttributeName = this.map.getReverseAttribute(info.parentEntityName, info.attributeName)
+
+        // 注意这里去掉了 namePath 里面根部的 entityName，因为后面计算 referenceValue 的时候会加上
+        const parentAttributeNamePath = atomData.namePath!.slice(1, -1)
+
+        const existEntityQuery = RecordQuery.create(
+            info.recordName,
+            this.map,
+            {
+                matchExpression: MatchExp.atom({
+                    key: `${reverseAttributeName}.id`,
+                    value: ['=', parentAttributeNamePath.concat('id').join('.')],
+                    isReferenceValue: true
+                }).and(atomData.value[1])
+            },
+            // 如果上层还有，就继承上层的，如果没有， context 就只这一层
+            contextRootEntity || entityName
+        )
+
+        const [innerQuerySQL, innerParams] = this.buildXToOneFindQuery(existEntityQuery, currentAlias, p)
+
+        return {
+            ...atomData,
+            isInnerQuery: true,
+            fieldValue: `
+EXISTS (
+${innerQuerySQL}
+)
+`,
+            fieldParams: innerParams,
+        }
+    }
+
+    /**
      * 解析匹配表达式中的 EXIST 子查询
+     * CAUTION 该方法保留用于外部（测试等）单独调用。注意在使用编号型占位符的数据库上，
+     *  应通过 buildFieldMatchExpression 的 fnMatchHandler 就地处理（见 buildXToOneFindQuery），
+     *  否则占位符编号会和参数收集顺序错位。
      */
     parseMatchExpressionValue(
         entityName: string,
@@ -375,43 +451,7 @@ ${modifierClause}
 
             if (!exp.data.isFunctionMatch) return { ...exp.data }
 
-            if (exp.data.value[0].toLowerCase() !== 'exist') {
-                throw new Error(`we only support Exist function match on entity for now. yours: ${exp.data.key} ${exp.data.value[0]} ${exp.data.value[1]}`)
-            }
-
-            const info = this.map.getInfoByPath(exp.data.namePath!)!
-            const { alias: currentAlias } = this.map.getTableAndAliasStack(exp.data.namePath!).at(-1)!
-            const reverseAttributeName = this.map.getReverseAttribute(info.parentEntityName, info.attributeName)
-
-            // 注意这里去掉了 namePath 里面根部的 entityName，因为后面计算 referenceValue 的时候会加上
-            const parentAttributeNamePath = exp.data.namePath!.slice(1, -1)
-
-            const existEntityQuery = RecordQuery.create(
-                info.recordName,
-                this.map,
-                {
-                    matchExpression: MatchExp.atom({
-                        key: `${reverseAttributeName}.id`,
-                        value: ['=', parentAttributeNamePath.concat('id').join('.')],
-                        isReferenceValue: true
-                    }).and(exp.data.value[1])
-                },
-                // 如果上层还有，就继承上层的，如果没有， context 就只这一层
-                contextRootEntity || entityName
-            )
-
-            const [innerQuerySQL, innerParams] = this.buildXToOneFindQuery(existEntityQuery, currentAlias, p)
-
-            return {
-                ...exp.data,
-                isInnerQuery: true,
-                fieldValue: `
-EXISTS (
-${innerQuerySQL}
-)
-`,
-                fieldParams: innerParams,
-            }
+            return this.parseFunctionMatchAtom(entityName, exp.data, contextRootEntity, p)
         })
     }
     

--- a/tests/storage/fatalBugFixes.spec.ts
+++ b/tests/storage/fatalBugFixes.spec.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { DBSetup, EntityToTableMap, MatchExp, EntityQueryHandle } from "@storage";
+import { Entity, Property, Relation } from '@core';
+import TestLogger from "./testLogger.js";
+import { PGLiteDB, SQLiteDB } from '@drivers';
+
+/**
+ * 针对 storage 层致命错误修复的回归测试。
+ * 每个 describe 对应分析报告中的一个致命问题（F1~F8）。
+ */
+
+describe('F1: EXIST subquery placeholder ordering on numbered-placeholder DB (PGLite/PG)', () => {
+    let db: PGLiteDB;
+    let handle: EntityQueryHandle;
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'age', type: 'number' })
+            ]
+        });
+        const teamEntity = Entity.create({
+            name: 'Team',
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        });
+        Relation.create({ source: userEntity, sourceProperty: 'teams', target: teamEntity, targetProperty: 'members', type: 'n:n' });
+        const relations = Relation.instances.filter(r => r.source === userEntity || r.target === userEntity);
+        db = new PGLiteDB(undefined, { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([userEntity, teamEntity], relations, db);
+        await setup.createTables();
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+    });
+    afterEach(async () => { await db.close(); });
+
+    test('value conditions before AND after an EXIST bind to the correct params', async () => {
+        const alpha = await handle.create('Team', { name: 'Alpha' });
+        await handle.create('User', { name: 'Bob', age: 30, teams: [alpha] });
+        await handle.create('User', { name: 'Eve', age: 50 });
+
+        const match = MatchExp.atom({ key: 'age', value: ['>', 20] })
+            .and({ key: 'teams', value: ['exist', MatchExp.atom({ key: 'name', value: ['=', 'Alpha'] })] })
+            .and({ key: 'name', value: ['=', 'Bob'] });
+
+        const found = await handle.find('User', match, undefined, ['name', 'age']);
+        expect(found).toHaveLength(1);
+        expect(found[0].name).toBe('Bob');
+    });
+
+    test('two EXIST conditions with surrounding value conditions', async () => {
+        const alpha = await handle.create('Team', { name: 'Alpha' });
+        const beta = await handle.create('Team', { name: 'Beta' });
+        await handle.create('User', { name: 'Bob', age: 30, teams: [alpha, beta] });
+        await handle.create('User', { name: 'Carol', age: 30, teams: [alpha] });
+
+        const match = MatchExp.atom({ key: 'age', value: ['=', 30] })
+            .and({ key: 'teams', value: ['exist', MatchExp.atom({ key: 'name', value: ['=', 'Alpha'] })] })
+            .and({ key: 'teams', value: ['exist', MatchExp.atom({ key: 'name', value: ['=', 'Beta'] })] })
+            .and({ key: 'name', value: ['=', 'Bob'] });
+
+        const found = await handle.find('User', match, undefined, ['name']);
+        expect(found.map(u => u.name)).toEqual(['Bob']);
+    });
+});
+
+describe('F4: create/update must not run an unfiltered full-table scan', () => {
+    test('creating an independent record issues no WHERE 1=1 select', async () => {
+        const userEntity = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        const queries: { sql: string }[] = [];
+        const logger: any = {
+            info: (arg: any) => { if (arg?.sql) queries.push({ sql: arg.sql }); },
+            error: () => {},
+            child() { return this; }
+        };
+        const db = new SQLiteDB(':memory:', { logger });
+        await db.open();
+        const setup = new DBSetup([userEntity], [], db);
+        await setup.createTables();
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+
+        await handle.create('User', { name: 'a' });
+        queries.length = 0;
+        await handle.create('User', { name: 'b' });
+
+        const fullScans = queries.filter(q => /WHERE\s*\n?\s*1=/.test(q.sql));
+        expect(fullScans).toHaveLength(0);
+        await db.close();
+    });
+});
+
+describe('F5: matching over x:n path must not return duplicate rows', () => {
+    let db: PGLiteDB;
+    let handle: EntityQueryHandle;
+    beforeEach(async () => {
+        const userEntity = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        const teamEntity = Entity.create({ name: 'Team', properties: [Property.create({ name: 'name', type: 'string' })] });
+        Relation.create({ source: userEntity, sourceProperty: 'teams', target: teamEntity, targetProperty: 'members', type: 'n:n' });
+        const relations = Relation.instances.filter(r => r.source === userEntity || r.target === userEntity);
+        db = new PGLiteDB(undefined, { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([userEntity, teamEntity], relations, db);
+        await setup.createTables();
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+    });
+    afterEach(async () => { await db.close(); });
+
+    test('user in multiple matching teams appears once', async () => {
+        const t1 = await handle.create('Team', { name: 'Alpha X' });
+        const t2 = await handle.create('Team', { name: 'Alpha Y' });
+        await handle.create('User', { name: 'Bob', teams: [t1, t2] });
+        await handle.create('User', { name: 'Eve', teams: [t1] });
+
+        const found = await handle.find('User', MatchExp.atom({ key: 'teams.name', value: ['like', 'Alpha%'] }), undefined, ['name']);
+        expect(found.map(u => u.name).sort()).toEqual(['Bob', 'Eve']);
+    });
+});
+
+describe('F6: lock (FOR UPDATE) works with x:1 related attributeQuery', () => {
+    let db: PGLiteDB;
+    let handle: EntityQueryHandle;
+    beforeEach(async () => {
+        const teamEntity = Entity.create({ name: 'Team', properties: [Property.create({ name: 'name', type: 'string' })] });
+        const userEntity = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        Relation.create({ source: userEntity, sourceProperty: 'team', target: teamEntity, targetProperty: 'members', type: 'n:1' });
+        const relations = Relation.instances.filter(r => r.source === userEntity || r.target === userEntity);
+        db = new PGLiteDB(undefined, { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([userEntity, teamEntity], relations, db);
+        await setup.createTables();
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+    });
+    afterEach(async () => { await db.close(); });
+
+    test('lock with joined x:1 relation does not error on outer join', async () => {
+        const team = await handle.create('Team', { name: 'T' });
+        await handle.create('User', { name: 'Dan', team });
+        const locked = await handle.lock('User', undefined, ['name', ['team', { attributeQuery: ['name'] }]]);
+        expect(locked).toHaveLength(1);
+        expect(locked[0].team.name).toBe('T');
+    });
+});
+
+describe('F7: JSON fields of related records are deserialized (SQLite)', () => {
+    let db: SQLiteDB;
+    let handle: EntityQueryHandle;
+    beforeEach(async () => {
+        const profileEntity = Entity.create({ name: 'Profile', properties: [Property.create({ name: 'tags', type: 'string', collection: true })] });
+        const userEntity = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        Relation.create({ source: userEntity, sourceProperty: 'profile', target: profileEntity, targetProperty: 'owner', type: '1:1' });
+        const relations = Relation.instances.filter(r => r.source === userEntity || r.target === userEntity);
+        db = new SQLiteDB(':memory:', { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([userEntity, profileEntity], relations, db);
+        await setup.createTables();
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+    });
+    afterEach(async () => { await db.close(); });
+
+    test('related record JSON collection is parsed to an array', async () => {
+        await handle.create('User', { name: 'Carl', profile: { tags: ['a', 'b'] } });
+        const found = await handle.findOne('User', undefined, undefined, ['name', ['profile', { attributeQuery: ['tags'] }]]);
+        expect(Array.isArray(found.profile.tags)).toBe(true);
+        expect(found.profile.tags).toEqual(['a', 'b']);
+    });
+});
+
+describe('F8: modifier validation & injection safety', () => {
+    let db: SQLiteDB;
+    let handle: EntityQueryHandle;
+    beforeEach(async () => {
+        const userEntity = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        db = new SQLiteDB(':memory:', { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([userEntity], [], db);
+        await setup.createTables();
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+    });
+    afterEach(async () => { await db.close(); });
+
+    test('non-integer limit is rejected', async () => {
+        await handle.create('User', { name: 'a' });
+        await expect(handle.find('User', undefined, { limit: '1; DROP TABLE User' as any }, ['name'])).rejects.toThrow(/limit/);
+    });
+    test('negative offset is rejected', async () => {
+        await expect(handle.find('User', undefined, { offset: -5 }, ['name'])).rejects.toThrow(/offset/);
+    });
+    test('invalid orderBy direction is rejected', async () => {
+        await expect(handle.find('User', undefined, { orderBy: { name: 'DROP' as any } }, ['name'])).rejects.toThrow(/ASC|DESC/);
+    });
+    test('lowercase order direction still works', async () => {
+        await handle.create('User', { name: 'a' });
+        await handle.create('User', { name: 'b' });
+        const r = await handle.find('User', undefined, { orderBy: { name: 'desc' as any } }, ['name']);
+        expect(r.map(x => x.name)).toEqual(['b', 'a']);
+    });
+});
+
+describe('F2: filtered entity membership updates on relation change', () => {
+    let db: PGLiteDB;
+    let handle: EntityQueryHandle;
+    beforeEach(async () => {
+        const userEntity = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        const teamEntity = Entity.create({ name: 'Team', properties: [Property.create({ name: 'name', type: 'string' }), Property.create({ name: 'type', type: 'string' })] });
+        Relation.create({ source: userEntity, sourceProperty: 'team', target: teamEntity, targetProperty: 'members', type: 'n:1' });
+        const techUsers = Entity.create({ name: 'TechTeamUsers', baseEntity: userEntity, matchExpression: MatchExp.atom({ key: 'team.type', value: ['=', 'tech'] }) });
+        const relations = Relation.instances.filter(r => [userEntity, teamEntity].includes(r.source as any) || [userEntity, teamEntity].includes(r.target as any));
+        db = new PGLiteDB(undefined, { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([userEntity, teamEntity, techUsers], relations, db);
+        await setup.createTables();
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+    });
+    afterEach(async () => { await db.close(); });
+
+    test('changing the related record (team.type) updates membership + events', async () => {
+        const team = await handle.create('Team', { name: 'T', type: 'sales' });
+        const user = await handle.create('User', { name: 'David', team });
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(0);
+
+        const events: any[] = [];
+        await handle.update('Team', MatchExp.atom({ key: 'id', value: ['=', team.id] }), { type: 'tech' }, events);
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(1);
+        expect(events.filter(e => e.type === 'create' && e.recordName === 'TechTeamUsers')).toHaveLength(1);
+    });
+
+    test('moving a record out of the matching relation emits delete + clears stale flag', async () => {
+        const techTeam = await handle.create('Team', { name: 'T1', type: 'tech' });
+        const salesTeam = await handle.create('Team', { name: 'T2', type: 'sales' });
+        const user = await handle.create('User', { name: 'Alice', team: techTeam });
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(1);
+
+        const events: any[] = [];
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), { team: salesTeam }, events);
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(0);
+        expect(events.filter(e => e.type === 'delete' && e.recordName === 'TechTeamUsers')).toHaveLength(1);
+
+        // no stale flag -> deleting the (now non-member) user emits no filtered-entity delete
+        const events2: any[] = [];
+        await handle.delete('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), events2);
+        expect(events2.filter(e => e.type === 'delete' && e.recordName === 'TechTeamUsers')).toHaveLength(0);
+    });
+
+    test('addRelation / removeRelation propagate membership', async () => {
+        const techTeam = await handle.create('Team', { name: 'T1', type: 'tech' });
+        const user = await handle.create('User', { name: 'Bob' });
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(0);
+
+        const addEvents: any[] = [];
+        await handle.addRelationById('User', 'team', user.id, techTeam.id, undefined, addEvents);
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(1);
+        expect(addEvents.filter(e => e.type === 'create' && e.recordName === 'TechTeamUsers')).toHaveLength(1);
+
+        const relName = handle.getRelationName('User', 'team');
+        const rmEvents: any[] = [];
+        await handle.removeRelationByName(relName, MatchExp.atom({ key: 'source.id', value: ['=', user.id] }), rmEvents);
+        expect(await handle.find('TechTeamUsers', undefined, undefined, ['name'])).toHaveLength(0);
+        expect(rmEvents.filter(e => e.type === 'delete' && e.recordName === 'TechTeamUsers')).toHaveLength(1);
+    });
+});
+
+describe('F3: merged entity with filtered input preserves base identity & predicate', () => {
+    async function build() {
+        const base = Entity.create({ name: 'CustomerBase', properties: [Property.create({ name: 'name', type: 'string' }), Property.create({ name: 'isActive', type: 'boolean' })] });
+        const active = Entity.create({ name: 'ActiveCustomer', baseEntity: base, matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }) });
+        const other = Entity.create({ name: 'Other', properties: [Property.create({ name: 'name', type: 'string' }), Property.create({ name: 'isActive', type: 'boolean' })] });
+        const merged = Entity.create({ name: 'Contact', inputEntities: [active, other] });
+        const db = new SQLiteDB(':memory:', { logger: new TestLogger('', true) });
+        await db.open();
+        const setup = new DBSetup([base, active, other, merged], [], db);
+        await setup.createTables();
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+        return { db, handle };
+    }
+
+    test('records created via base name remain queryable via base (no black hole)', async () => {
+        const { db, handle } = await build();
+        await handle.create('CustomerBase', { name: 'honest', isActive: true });
+        const base = await handle.find('CustomerBase', undefined, undefined, ['name']);
+        expect(base.map(r => r.name)).toContain('honest');
+        await db.close();
+    });
+
+    test('filtered input keeps its own predicate', async () => {
+        const { db, handle } = await build();
+        await handle.create('ActiveCustomer', { name: 'a1', isActive: true });
+        await handle.create('Other', { name: 'o1', isActive: false });
+        expect((await handle.find('ActiveCustomer', undefined, undefined, ['name'])).map(r => r.name)).toEqual(['a1']);
+        expect((await handle.find('Contact', undefined, undefined, ['name'])).map(r => r.name).sort()).toEqual(['a1', 'o1']);
+        await db.close();
+    });
+
+    test('merged entity contains only declared inputs, not base records', async () => {
+        const { db, handle } = await build();
+        await handle.create('CustomerBase', { name: 'baseRec', isActive: true });
+        await handle.create('ActiveCustomer', { name: 'activeRec', isActive: true });
+        const merged = await handle.find('Contact', undefined, undefined, ['name']);
+        expect(merged.map(r => r.name)).toEqual(['activeRec']);
+        await db.close();
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the eight fatal bugs identified in the storage-package deep analysis. All fixes are covered by new regression tests in `tests/storage/fatalBugFixes.spec.ts` (16 tests). The full existing suite still passes: **storage 460/460**, and full repo **1585 passed / 26 skipped** (the single flaky `migration.spec.ts` timeout is pre-existing — it also times out on the unmodified base at the default 5s limit and passes with a larger timeout).

## Fixes

- **F1 — EXIST subquery placeholder ordering (PG/PGLite), silently wrong results.** EXIST subqueries are now built in-place during atom traversal (`buildFieldMatchExpression` `fnMatchHandler` → `SQLBuilder.parseFunctionMatchAtom`), so `$1/$2…` numbering matches the tree-order in which `buildWhereClause` collects params. Previously all value atoms were numbered first and EXIST inner params appended later, shifting bindings when a value condition followed an EXIST.
- **F2 — filtered entity goes permanently stale on relation change.** The dependency graph now registers each relation segment on a cross-entity filter path (not just the leaf attribute), and `addLink`/`unlink` propagate membership re-evaluation via `FilteredEntityManager.propagateLinkChange`. Fixes stale `__filtered_entities` flags plus missing create/delete events (and the spurious delete on a later record deletion).
- **F3 — merged entity with filtered inputs corrupts the root base.** Filtered inputs are rebased onto the virtual base while preserving their own predicate; the root base entity keeps its own identity (still queryable, IS-A semantics) instead of being overwritten with an input tag. Fixes the black-holed records and the dropped predicate.
- **F4 — full-table scan on every create/update.** `flashOutCombinedRecordsAndMergedLinks` returns early when there are no combined records, eliminating the `WHERE 1=1` scan.
- **F5 — duplicate rows when matching over an x:n path.** Identical result rows are deduped (equivalent to SQL DISTINCT), removing LEFT JOIN fan-out duplicates.
- **F6 — `FOR UPDATE` crashes with x:1 attributeQuery on PG.** Uses `FOR UPDATE OF <mainTable>` and the driver's `supportsSelectForUpdate` capability instead of a constructor-name string check. MySQL driver declares the capability.
- **F7 — related-record JSON fields not deserialized (SQLite/MySQL).** JSON detection resolves each field's full path, so all drivers return parsed values consistently.
- **F8 — SQL injection + missing validation in modifiers.** MySQL JSON `contains` binds its value as a parameter; `limit`/`offset` are validated as non-negative integers and `orderBy` direction is whitelisted (case-insensitive) at the SQL boundary.

## Files
- `src/storage/erstorage/SQLBuilder.ts`, `MatchExp.ts` — F1, F8 (modifier validation)
- `src/storage/erstorage/FilteredEntityManager.ts`, `RecordQueryAgent.ts`, `CreationExecutor.ts` — F2
- `src/storage/erstorage/MergedItemProcessor.ts` — F3
- `src/storage/erstorage/RecordQueryAgent.ts` — F4
- `src/storage/erstorage/QueryExecutor.ts` — F5, F6, F7
- `src/drivers/Mysql.ts` — F6 capability, F8 injection
- `tests/storage/fatalBugFixes.spec.ts` — regression tests

## Notes
The deeper F3' concern (filtered-entity semantics vs. creation-time tags in merged entities) is a design-level item and is intentionally out of scope here; this PR fixes the concrete data-loss/incorrectness bugs while keeping the existing merged/filtered behavior and tests intact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88dee89e-d135-4e6f-80a5-70b5ee2ea7c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88dee89e-d135-4e6f-80a5-70b5ee2ea7c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

