### PR TITLE
fix(storage): resolve all issues from analysis report section 三 (robustness, performance, code quality)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ lib
 typings
 coverage
 .next
-package-lock.json
 temp
 pgdata
 test-create.sqlite

--- a/agentspace/output/storage-package-deep-analysis.md
+++ b/agentspace/output/storage-package-deep-analysis.md
@@ -2,7 +2,9 @@
 
 > 分析范围：`src/storage/`（erstorage 全部 26 个文件，约 7400 行），以及与其耦合的 driver 层（`src/drivers/`）和 runtime 调用方式。
 >
-> **修订说明**：本报告初版中列出并验证过 8 个致命错误（EXIST 占位符错位、filtered entity 关系变更脏状态、merged entity 破坏 root base、写路径全表扫描、x:n match 重复行、FOR UPDATE 报错、嵌套 JSON 不反序列化、MySQL 注入）。它们已全部修复并配有回归测试（见 `tests/storage/fatalBugFixes.spec.ts`），相关章节已从本报告删除以免误导后续工作。本文仅保留**仍然成立**的分析与改进建议。
+> **修订说明**：本报告初版中列出并验证过 8 个致命错误（EXIST 占位符错位、filtered entity 关系变更脏状态、merged entity 破坏 root base、写路径全表扫描、x:n match 重复行、FOR UPDATE 报错、嵌套 JSON 不反序列化、MySQL 注入）。它们已全部修复并配有回归测试（见 `tests/storage/fatalBugFixes.spec.ts`），相关章节已从本报告删除以免误导后续工作。
+>
+> **第二次修订**：原《三、其他显著值得改进的地方》章节的全部 18 项（3.1 正确性/健壮性 7 项、3.2 性能 5 项、3.3 API/代码质量 6 项）也已全部修复并配有回归测试（见 `tests/storage/deepAnalysisSection3Fixes.spec.ts`、`tests/storage/getShrinkedAttribute.spec.ts` 补充用例），该章节已删除。顺带修复了让 PostgreSQL 并发 CI 跑通后暴露的 driver 层问题（序列回拨污染增量聚合、连接池孤儿化、`number` 误映射为 INT），见 `tests/runtime/postgresqlConcurrency.spec.ts`。本文仅保留**仍然成立**的分析与改进建议。
 
 ---
 
@@ -11,7 +13,7 @@
 storage 是 interaqt 的持久化层，本质是一个为"响应式计算"定制的 ORM：
 
 1. **Schema 映射**（`Setup.ts` / `EntityToTableMap.ts`）：把 Entity/Relation 定义映射成物理表。核心特色是三种合表策略（1:1 三表合一、x:1 关系字段合入实体表、独立关系表），以及 filtered/merged entity 的虚拟化处理。
-2. **查询**（`RecordQuery` / `AttributeQuery` / `MatchExp` / `SQLBuilder` / `QueryExecutor`）：语义查询 → SQL。x:1 靠 JOIN 一次查出，x:n 靠逐条二次查询；支持递归查询（label/goto）。
+2. **查询**（`RecordQuery` / `AttributeQuery` / `MatchExp` / `SQLBuilder` / `QueryExecutor`）：语义查询 → SQL。x:1 靠 JOIN 一次查出，x:n 靠二次查询（1:n 已按父 id 集合批量执行，n:n 及递归/分页场景逐条）；支持递归查询（label/goto）。
 3. **变更**（`CreationExecutor` / `UpdateExecutor` / `DeletionExecutor`）：在合表策略下正确地创建/更新/删除记录与关系，处理"flash out"（合表数据搬迁）、reliance 级联删除等。
 4. **事件**（`RecordMutationEvent`）：每次变更产生精确的事件序列，是上层 runtime 增量计算（Count/Every/StateMachine 等）的输入。**事件的正确性直接决定框架核心承诺（响应式计算正确性）**。
 5. **filtered / merged entity**（`FilteredEntityManager` / `MergedItemProcessor`）：实体的"谓词子集视图"与"联合类型"，是复杂度最高的部分。
@@ -26,14 +28,14 @@ storage 是 interaqt 的持久化层，本质是一个为"响应式计算"定制
 
 | 概念 | 机制 | 位置 |
 |---|---|---|
-| filtered entity 查询 | `resolvedBaseRecordName` + `resolvedMatchExpression` 查询重写 | `Setup` 预计算，`RecordQuery.create` / `MatchExp` 构造器**两处各自**做合并 |
+| filtered entity 查询 | `resolvedBaseRecordName` + `resolvedMatchExpression` 查询重写 | `Setup` 预计算，合并逻辑已收敛到 `MatchExp` 构造器一处 |
 | filtered entity 事件 | `__filtered_entities` JSON 标记列 + 依赖图（含属性与关系段）+ 逐条读-改-写 | `FilteredEntityManager`，由三个 Executor 与 link 变更钩子调用 |
 | filtered relation | attribute 级重写（`AttributeQuery` 构造器内联 rebase）+ `MatchExp.convertFilteredRelation` 路径改写 | 又一条独立代码路径 |
 | merged entity/relation | `MergedItemProcessor` 在 setup 前把实体图整体改写：克隆→替换→虚拟 base→`__X_input_entity` tag 列→把 input 转成 filtered entity | 数百行图手术 |
 
 复杂度的根源可以概括为三点：
 
-1. **成员资格有两个真相源**。查询走谓词重写（实时正确），事件走持久化标记（增量维护）。虽然关系变更现已纳入依赖图并通过 `propagateLinkChange` 传播，但架构上仍然是"两套判定 + 手工同步"：任何新增的变更路径都必须记得挂钩子，否则两者再次分叉。标记的读-改-写（`updateSingleFilteredEntityFlag` 先 SELECT `['*']` 再 UPDATE 整个 JSON）在并发下也有丢失更新的风险。
+1. **成员资格有两个真相源**。查询走谓词重写（实时正确），事件走持久化标记（增量维护）。虽然关系变更现已纳入依赖图并通过 `propagateLinkChange` 传播，且标记维护已批量化（`updateFilteredEntityFlagsForRecords`），但架构上仍然是"两套判定 + 手工同步"：任何新增的变更路径都必须记得挂钩子，否则两者再次分叉。标记的读-改-写（先 SELECT `['*']` 再 UPDATE 整个 JSON）在并发下也有丢失更新的风险。
 2. **用"子集"机制模拟"联合"语义**。merged entity 本质是 Single Table Inheritance（联合类型/子类型），却被实现为"tag 列 + filtered entity"的组合：tag 是**创建时写死**的（存进 JSON 数组，靠 `contains` 匹配，不可索引），而 filter 是**声明式谓词**（随数据变化）。目前 filtered input 的谓词已在 rebase 时保留，但 tag 本身仍是创建时静态决定的——例如某记录以 input A 名义创建后，即使其属性变化到"语义上更像 input B"，tag 也不会迁移。`mergeProperties` 里为 defaultValue 生成闭包（捕获 `leafToInputMap`），还使得 schema 无法序列化、难以调试。
 3. **name 字符串驱动的图手术**。`MergedItemProcessor` 通过 `RefContainer` 克隆整个实体图、按 name 查找替换、生成 `${name}_base` / `__${name}_input_entity` 等约定命名。任何一步 name 冲突或替换顺序问题都是静默错误（历史上确实发生过 root base 被错误替换的 bug）。
 
@@ -43,7 +45,7 @@ storage 是 interaqt 的持久化层，本质是一个为"响应式计算"定制
 
 #### (a) filtered entity → 纯虚拟视图，删除持久化标记
 
-- 查询：保留现有 `resolvedMatchExpression` 重写（这部分是对的），但合并逻辑收敛到**一处**（目前 `RecordQuery.create` 和 `MatchExp` 构造器各有一份，语义重复）。
+- 查询：保留现有 `resolvedMatchExpression` 重写（这部分是对的），合并逻辑已收敛到 `MatchExp` 构造器一处。
 - 事件：不再持久化 `__filtered_entities`，改为**变更时的成员资格 diff**：
   - setup 期为每个 base entity 预编译一个 `MembershipEvaluator`：`{ filteredEntityName, 谓词, 依赖 = {本地属性集, 关系边集, 远端属性集} }`。
   - 所有变更路径（create/update/delete/addLink/unlink，包括合表产生的隐式关系变化）收敛到一个钩子：`onMutation(recordName | linkName, before, after)`。钩子按依赖图找出受影响的 base 记录，本地属性谓词直接在内存中对 before/after 求值（0 次额外查询，UpdateExecutor 本来就取回了完整旧记录）；跨实体谓词按现在的方式发两次 membership 查询（次数与现状相同，但不再有可脱同步的状态）。
@@ -72,45 +74,11 @@ filtered relation 目前在 `AttributeQuery` 构造器里内联 rebase、在 `Ma
 
 ---
 
-## 三、其他显著值得改进的地方
+## 三、结论与优先级建议
 
-### 3.1 正确性/健壮性
-
-1. **死代码带 bug**：`Setup.resolveBaseSourceEntityAndFilter` 读取不存在的 `baseEntity.filter` 字段，且从未被调用。应删除。
-2. **依赖对象在 base 名下重复注册**：`FilteredEntityManager.analyzeDependencies` 在把 dependency 按 dep.entityName 注册后，又无条件在 baseEntityName 下再注册一次；当谓词含 base 自身属性时同一 dependency 被 push 进同一数组两次，每次 update 做双倍的 membership 查询（结果幂等但白做）。
-3. **`preprocessSameRowData` 双份实现**：`RecordQueryAgent.ts` 与 `CreationExecutor.ts` 是近乎逐行复制的两份复杂逻辑（更新分支/创建分支各留一份在不同类里），已经出现注释漂移（`CreationExecutor` 注释说"不持久化 __filtered_entities"，实际代码持久化）。必然随时间分叉，应合并为一份。
-4. **事件切片靠位置约定**：`DeletionExecutor.deleteRecord` 用 `slice(length - records.length)` 从事件数组尾部"猜"出 record 删除事件。事件应携带足够的结构信息（或分数组收集），而不是依赖"最后 N 条一定是 X"的脆弱不变量。
-5. **name 约束声明了但未执行**：`Entity`/`Relation` 的 Klass 元数据里有 `nameFormat: /^[a-zA-Z0-9_]+$/`，但 create 时没有任何代码校验它，而表名/字段名/别名全部裸插值进 SQL（`CREATE TABLE "${name}"` 等）。应在 `Entity.create` 或 `DBSetup` 入口强制校验并给出清晰报错。
-6. **`in` 空数组产生非法 SQL**：`MatchExp.getFinalFieldValue` 的 `IN (${...join(',')})` 在空数组时生成 `IN ()`。内部调用恰好有非空保证，但这是公共 API，应显式处理（空数组 ⇒ 恒 false）。同函数中 `['not', 非null值]` 会生成 `"field" not $1` 这种非法 SQL，应校验并报错。
-7. **`__filtered_entities` 为 NULL 时崩溃**：`updateSingleFilteredEntityFlag` 中 `currentFlags[...]` 在字段为 NULL（如存量数据/手工迁移）时抛 TypeError。若采纳第二节方案此代码整体移除。
-
-### 3.2 性能
-
-1. **update/delete 的前置查询过重**：`UpdateExecutor.updateRecord` 对每条匹配记录取回**全量** attributeQuery（代码中自己标了 FIXME）。应按 newEntityData 实际涉及的字段 + filtered 依赖字段裁剪。
-2. **x:n 关联查询 N+1**：`findRecords` 对每条父记录逐一发起子查询。x:n 完全可以按父 id 集合批量查询（`IN (...)` + 按反向属性分组回填），一次消掉一层 N。
-3. **filtered 标记维护 N+1**：`updateFilteredEntityFlags` 对每个依赖 × 每条受影响记录顺序执行"SELECT 全字段 → membership SELECT → UPDATE"三连；关系变更传播（`propagateLinkChange`）也是逐条评估。若保留现架构，至少应批量化；采纳第二节方案则本地谓词场景归零。
-4. **别名预生成深度上限 5**（`Setup.pregenerateTableAliases`）：超过 5 层的路径查询会拿不到预生成别名，落回原始长名。PG 会把 >63 字节的标识符**静默截断**，两条长路径截断后可能同名碰撞产生错误 JOIN。应改为运行时兜底注册（`AliasManager` 本来就支持动态注册），而不是固定深度。
-5. **每次查询重建元数据对象**：`getRecordInfo`/`getInfoByPath`/`AttributeInfo` 每次调用都新建对象并做字符串拆解，热路径上应缓存（`EntityToTableMap` 是不可变的，天然可缓存）。
-
-### 3.3 API/代码质量
-
-1. **`EntityQueryHandle` 每次 new 都创建全套 executor**（构造器里 new `RecordQueryAgent` → 5 个 executor + FilteredEntityManager），而 `RecordQueryAgent` 构造器还会全量重算 filtered 依赖。runtime 里 `migration.ts` 等处会临时 new handle，成本不小；依赖分析结果应挂在 `EntityToTableMap`（不可变数据）上。
-2. **executor 间用 `helper` 对象互相回调**：`CreationExecutor`/`UpdateExecutor`/`DeletionExecutor` 的构造器接收手工拼出来的函数字典（且 `RecordQueryAgent` 传的是 `this`，依赖方法名恰好匹配）。这是循环依赖的信号：要么承认它们是一个聚合（合回 agent，按文件拆分只是物理组织），要么抽出真正的公共下层（linkOps/sameRowOps）。
-3. **`AttributeQuery.id = Math.random()`**：来源不明的调试残留，公开字段，应删除。
-4. **`EntityToTableMap.getShrinkedAttribute`**：留有大段注释掉的 try/catch、无效赋值（`currentEntity = ''` 紧跟 `previousEntity = ''` 再无使用）。此函数被 filtered relation rebase 依赖，值得重写并补齐单测。
-5. **`MatchExp` 与 `RecordQuery.create` 重复实现 filtered 合并**，语义上"谁负责加 resolvedMatchExpression"不清晰，容易出现双重 AND（目前靠传 base name 恰好避开）。收敛到一处。
-6. **文档失真**：`src/storage/IMPLEMENTATION_DETAILS.md` / `USAGE_GUIDE.md` 里的接口（`RelationType.OneToOne`、`{ name, properties }` 字面量、`updateSameRowData 在 RecordQueryAgent`）与现实现已不符，容易误导贡献者。
-
----
-
-## 四、结论与优先级建议
-
-storage 的分层（Setup → Map → Query/Executor → SQLBuilder）与合表策略设计是有想法的，查询重写路径（filtered entity 的读侧）基本稳固，历史致命错误已修复。剩余问题集中在架构与工程质量：
+storage 的分层（Setup → Map → Query/Executor → SQLBuilder）与合表策略设计是有想法的，查询重写路径（filtered entity 的读侧）基本稳固，历史致命错误与工程质量问题（原第三节的 18 项）均已修复。剩余问题集中在架构层面：
 
 | 优先级 | 项 | 工作量特征 |
 |---|---|---|
 | P1 | 第二节重构：filtered/merged 统一为 evaluator + 判别列，消除双真相源与图手术 | 涉及 FilteredEntityManager、MergedItemProcessor、三个 Executor 的调用点；查询重写层不动 |
 | P1 | x:n match 与 limit/offset 组合的分页语义（见 2.3） | 与上一项一起处理最自然 |
-| P2 | 3.2 性能项（N+1 批量化、update 前置查询裁剪、元数据缓存、别名兜底注册） | 独立可分批 |
-| P2 | 3.1 健壮性项（name 校验、空 IN、死代码、双份 preprocessSameRowData 合并） | 局部修复 |
-| P2 | 3.3 代码质量项与文档同步 | 随重构顺带 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6831 @@
+{
+  "name": "interaqt",
+  "version": "1.6.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "interaqt",
+      "version": "1.6.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@electric-sql/pglite": "^0.3.2",
+        "@interaqt/uuidv7": "^1.0.1",
+        "@microsoft/api-extractor": "^7.52.1",
+        "@release-it/conventional-changelog": "^10.0.6",
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^22.13.10",
+        "@types/pg": "^8.11.11",
+        "@vitest/coverage-v8": "^3.2.4",
+        "better-sqlite3": "^11.8.1",
+        "mysql2": "^3.13.0",
+        "pg": "^8.14.0",
+        "release-it": "^19.0.5",
+        "rimraf": "^6.0.1",
+        "tsx": "^4.20.5",
+        "typescript": "^5.9.3",
+        "vite": "^7.1.4",
+        "vite-plugin-dts": "^4.5.4",
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.16.tgz",
+      "integrity": "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@interaqt/uuidv7": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@interaqt/uuidv7/-/uuidv7-1.0.1.tgz",
+      "integrity": "sha512-8kz9/SM5uWIk/PaF8J2ELJrlP7uA/E2/hTRM95kIFbMDKyspV0bPJO6EHEoGRpAptMhJEEQvtuTm5gxulI3SaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "uuidv7": "cli.js"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.58.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.9.tgz",
+      "integrity": "sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.33.8",
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rig-package": "0.7.3",
+        "@rushstack/terminal": "0.24.0",
+        "@rushstack/ts-command-line": "5.3.10",
+        "diff": "~8.0.2",
+        "minimatch": "10.2.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.9.3"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.33.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+      "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@nodeutils/defaults-deep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
+      "integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.15.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@phun-ky/typeof": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@phun-ky/typeof/-/typeof-2.0.3.tgz",
+      "integrity": "sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.9.0 || >=22.0.0",
+        "npm": ">=10.8.2"
+      },
+      "funding": {
+        "url": "https://github.com/phun-ky/typeof?sponsor=1"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@release-it/conventional-changelog": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-10.0.6.tgz",
+      "integrity": "sha512-aUb0IkcsBTMcOH5PPQ9Jv9lEOOVu2+rSgkE1ny+dzsTziQm2BhDRAtaFK/dw/HflthuXMWrqhhyfJhAV1AOEPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "concat-stream": "^2.0.0",
+        "conventional-changelog": "^7.2.0",
+        "conventional-changelog-angular": "^8.3.0",
+        "conventional-changelog-conventionalcommits": "^9.3.0",
+        "conventional-recommended-bump": "^11.2.0",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": "^20.12.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "release-it": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "~8.18.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-formats": "~3.0.1",
+        "fs-extra": "~11.3.0",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/problem-matcher": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+      "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+      "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+      "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/problem-matcher": "0.2.1",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.10.tgz",
+      "integrity": "sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/terminal": "0.24.0",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/hosted-git-info": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+      "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/parse-path": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+      "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+      "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~2.4.11",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^0.4.9",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+      "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
+      "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^17.2.3",
+        "exsolve": "^1.0.8",
+        "giget": "^2.0.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.0.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/conventional-changelog": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.1.tgz",
+      "integrity": "sha512-smcpqCeNRCAoL586/Iql8GfVsduP1JDrr7SAzKHWM5C5voDzKhc3QtqwVWeKMhvVw4iYfAr+znz1TF4kPXVm3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.7.0",
+        "@simple-libs/hosted-git-info": "^1.0.2",
+        "@types/normalize-package-data": "^2.4.4",
+        "conventional-changelog-preset-loader": "^5.0.0",
+        "conventional-changelog-writer": "^8.4.0",
+        "conventional-commits-parser": "^6.4.0",
+        "fd-package-json": "^2.0.0",
+        "meow": "^13.0.0",
+        "normalize-package-data": "^7.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "conventional-commits-filter": "^5.0.0",
+        "handlebars": "^4.7.7",
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-recommended-bump": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-11.2.0.tgz",
+      "integrity": "sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.5.1",
+        "conventional-changelog-preset-loader": "^5.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.1.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-recommended-bump": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
+      "integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/git-up": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+      "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-ssh": "^1.4.0",
+        "parse-url": "^9.2.0"
+      }
+    },
+    "node_modules/git-url-parse": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+      "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "git-up": "^8.1.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/prompts": "^7.10.1",
+        "@inquirer/type": "^3.0.10",
+        "mute-stream": "^2.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-ssh": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+      "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.1"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/issue-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
+      "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.uniqby": "^4.7.0"
+      },
+      "engines": {
+        "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/macos-release": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
+      "integrity": "sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.5.tgz",
+      "integrity": "sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/new-github-release-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-github-release-url/-/new-github-release-url-2.0.0.tgz",
+      "integrity": "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.5.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nypm": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.2",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
+      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^8.1.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-name": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-6.1.0.tgz",
+      "integrity": "sha512-zBd1G8HkewNd2A8oQ8c6BN/f/c9EId7rSUueOLGu28govmUctXmM+3765GwsByv9nYUdrLqHphXlYIc86saYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "macos-release": "^3.3.0",
+        "windows-release": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-path": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.0"
+      }
+    },
+    "node_modules/parse-url": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+      "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-path": "^7.0.0",
+        "parse-path": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protocols": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/release-it": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-19.2.4.tgz",
+      "integrity": "sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/webpro"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodeutils/defaults-deep": "1.1.0",
+        "@octokit/rest": "22.0.1",
+        "@phun-ky/typeof": "2.0.3",
+        "async-retry": "1.3.3",
+        "c12": "3.3.3",
+        "ci-info": "^4.3.1",
+        "eta": "4.5.0",
+        "git-url-parse": "16.1.0",
+        "inquirer": "12.11.1",
+        "issue-parser": "7.0.1",
+        "lodash.merge": "4.6.2",
+        "mime-types": "3.0.2",
+        "new-github-release-url": "2.0.0",
+        "open": "10.2.0",
+        "ora": "9.0.0",
+        "os-name": "6.1.0",
+        "proxy-agent": "6.5.0",
+        "semver": "7.7.3",
+        "tinyglobby": "0.2.15",
+        "undici": "6.23.0",
+        "url-join": "5.0.0",
+        "wildcard-match": "5.1.4",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "release-it": "bin/release-it.js"
+      },
+      "engines": {
+        "node": "^20.12.0 || >=22.0.0"
+      }
+    },
+    "node_modules/release-it/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.5.tgz",
+      "integrity": "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-dts": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
+      "integrity": "sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor": "^7.50.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "@volar/typescript": "^2.4.11",
+        "@vue/language-core": "2.2.0",
+        "compare-versions": "^6.1.1",
+        "debug": "^4.4.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.0.0",
+        "magic-string": "^0.30.17"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wildcard-match": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.4.tgz",
+      "integrity": "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/windows-release": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-6.1.0.tgz",
+      "integrity": "sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@electric-sql/pglite": "^0.3.2",
     "@interaqt/uuidv7": "^1.0.1",
     "@microsoft/api-extractor": "^7.52.1",
-    "@release-it/conventional-changelog": "^8.0.2",
+    "@release-it/conventional-changelog": "^10.0.6",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.13.10",
     "@types/pg": "^8.11.11",

--- a/src/core/Entity.ts
+++ b/src/core/Entity.ts
@@ -130,6 +130,11 @@ export class Entity implements EntityInstance {
   };
   
   static create(args: EntityCreateArgs, options?: { uuid?: string }): EntityInstance {
+    // 强制执行 nameFormat 约束：name 会被用作表名/字段名/别名直接进入 SQL，必须严格校验。
+    if (typeof args.name !== 'string' || !validNameFormatExp.test(args.name)) {
+      throw new Error(`Entity name "${args.name}" is invalid. Entity names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
+    }
+
     const instance = new Entity(args, options);
     
     // 检查 uuid 是否重复

--- a/src/core/Relation.ts
+++ b/src/core/Relation.ts
@@ -4,6 +4,8 @@ import { EntityInstance } from './Entity.js';
 import type { ComputationInstance } from './types.js';
 import type { ConstraintInstance } from './Constraint.js';
 
+const validNameFormatExp = /^[a-zA-Z0-9_]+$/;
+
 export interface RelationInstance extends IInstance {
   name?: string;
   source: EntityInstance | RelationInstance;
@@ -262,6 +264,18 @@ export class Relation implements RelationInstance {
   };
   
   static create(args: RelationCreateArgs, options?: { uuid?: string }): RelationInstance {
+    // 强制执行 nameFormat 约束：显式提供的 name 会被用作表名/字段名/别名直接进入 SQL，必须严格校验。
+    // 未显式提供 name 时使用 computed name（由 source/target 名和 property 名拼接，各部分单独校验）。
+    if (args.name !== undefined && (typeof args.name !== 'string' || !validNameFormatExp.test(args.name))) {
+      throw new Error(`Relation name "${args.name}" is invalid. Relation names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
+    }
+    if (args.sourceProperty !== undefined && !validNameFormatExp.test(args.sourceProperty)) {
+      throw new Error(`Relation sourceProperty "${args.sourceProperty}" is invalid. Property names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
+    }
+    if (args.targetProperty !== undefined && !validNameFormatExp.test(args.targetProperty)) {
+      throw new Error(`Relation targetProperty "${args.targetProperty}" is invalid. Property names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
+    }
+
     const instance = new Relation(args, options);
     
     // 检查 uuid 是否重复

--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -191,7 +191,9 @@ export class MysqlDB implements Database{
         } else if (type === 'boolean') {
             return 'INT(2)'
         } else if(type === 'number'){
-            return "INT"
+            // CAUTION JS 的 number 是双精度浮点。映射成 INT 会让合法的小数值
+            //  （例如内置 Average 计算的结果 sum/count）在写入时直接报错。
+            return "DOUBLE"
         }else if(type === 'timestamp'){
             return "TIMESTAMP"
         }else{

--- a/src/drivers/PGLite.ts
+++ b/src/drivers/PGLite.ts
@@ -230,7 +230,9 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
         } else if (type === 'boolean') {
             return 'BOOL'
         } else if(type === 'number'){
-            return "INT"
+            // CAUTION JS 的 number 是双精度浮点。映射成 INT 会让合法的小数值
+            //  （例如内置 Average 计算的结果 sum/count）在写入时直接报错。
+            return "DOUBLE PRECISION"
         }else if(type === 'timestamp'){
             return "TIMESTAMP"
         }else{

--- a/src/drivers/PostgreSQL.ts
+++ b/src/drivers/PostgreSQL.ts
@@ -67,7 +67,17 @@ class IDSystem {
         }
         for (const [quotedSequence, maxExistingId] of sequenceMax) {
             if (maxExistingId >= 1) {
-                await this.db.query(`SELECT setval($1::regclass, $2, true)`, [quotedSequence, maxExistingId], `set sequence ${quotedSequence}`)
+                // CAUTION 只允许"向前推进"序列，绝不能回拨。
+                //  setup(false)（新进程 attach 已运行的库）会走到这里，此时其他进程可能正在写入：
+                //  它们未提交的行对 MAX() 不可见，但已经消费了更大的序列值。无条件 setval 会把
+                //  序列拨回已提交的最大 id，后续 nextval 就会发出重复 id。
+                //  last_value/is_called 与 nextval 一样是非事务性的、立即可见，所以用它们做守卫是安全的：
+                //  只在序列从未使用（初始化/legacy 迁移）或落后于表内已有 id（外部 id 写入）时才推进。
+                await this.db.query(
+                    `SELECT setval($1::regclass, $2, true) FROM ${quotedSequence} WHERE NOT is_called OR last_value < $2`,
+                    [quotedSequence, maxExistingId],
+                    `advance sequence ${quotedSequence}`
+                )
             }
         }
     }
@@ -122,6 +132,17 @@ export class PostgreSQLDB implements Database{
         this.db = new Client({ ...options })
     }
     async open(forceDrop = false) {
+        // CAUTION open() 必须可以在 openForSchemaRead()（或再次 open）之后被调用而不泄漏连接池。
+        //  例如 Controller.setup(false) 会先经 prepareMigrationSchema 打开只读池做 manifest 校验，
+        //  再走 system.setup 调用 open(false)。如果这里无条件 new Pool，旧池会被孤儿化：
+        //  close() 只会关掉最新的池，残留的空闲连接之后被 DROP DATABASE ... WITH (FORCE)
+        //  之类的管理命令杀死时，会在进程里产生无人处理的 'error' 事件。
+        if (this.pool && forceDrop) {
+            // forceDrop 会摧毁当前数据库，先优雅关闭已有的池，避免它的空闲连接被强杀。
+            await this.pool.end()
+            this.pool = undefined
+        }
+
         const adminClient = new Client({
             ...this.options,
         })
@@ -139,30 +160,45 @@ export class PostgreSQLDB implements Database{
         }
         await adminClient.end()
 
-        this.pool = new Pool({
-            ...this.options,
-            database: this.database
-        })
+        if (!this.pool) {
+            this.pool = this.createPool()
 
-        this.db = new Client({
-            ...this.options,
-            database: this.database
-        })
+            this.db = new Client({
+                ...this.options,
+                database: this.database
+            })
+        }
     }
     async openForSchemaRead() {
         if (this.pool) return
         // Strict dry-run schema planning must only connect to the target
         // database. Database creation/drop and framework table setup belong to
         // the normal open/setup paths.
-        this.pool = new Pool({
-            ...this.options,
-            database: this.database
-        })
+        this.pool = this.createPool()
 
         this.db = new Client({
             ...this.options,
             database: this.database
         })
+    }
+    private createPool() {
+        const pool = new Pool({
+            ...this.options,
+            database: this.database
+        })
+        // CAUTION 必须给 Pool 挂 'error' 监听器（node-postgres 的标准要求）。
+        //  空闲连接被服务端终止（如管理命令、服务重启）时 Pool 会 emit 'error'，
+        //  没有监听器的话会直接变成进程级 uncaught exception。
+        //  这种错误是可恢复的：Pool 会丢弃该连接，下次取用时重建，所以记录日志即可。
+        pool.on('error', (error) => {
+            this.logger.error({
+                type: 'pool',
+                name: 'idle client error',
+                sql: '',
+                error: error instanceof Error ? error.message : String(error),
+            })
+        })
+        return pool
     }
     private getQueryable() {
         const context = this.transactionContext.getStore()
@@ -337,7 +373,9 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
         } else if (type === 'boolean') {
             return 'BOOLEAN'
         } else if(type === 'number'){
-            return "INT"
+            // CAUTION JS 的 number 是双精度浮点。映射成 INT 会让合法的小数值
+            //  （例如内置 Average 计算的结果 sum/count）在写入时直接报错。
+            return "DOUBLE PRECISION"
         }else if(type === 'timestamp'){
             return "TIMESTAMP"
         }else{

--- a/src/storage/IMPLEMENTATION_DETAILS.md
+++ b/src/storage/IMPLEMENTATION_DETAILS.md
@@ -1,6 +1,6 @@
-# @interaqt/storage Implementation Details
+# interaqt storage Implementation Details
 
-This document explains the internal architecture of the `@interaqt/storage` package, providing insights into how it works under the hood. Understanding these details can be valuable if you need to extend the package, debug issues, or simply gain a deeper understanding of its functionality.
+This document explains the internal architecture of the storage layer (`src/storage`, path alias `@storage`), providing insights into how it works under the hood. Understanding these details can be valuable if you need to extend the package, debug issues, or simply gain a deeper understanding of its functionality.
 
 ## Table of Contents
 
@@ -15,7 +15,7 @@ This document explains the internal architecture of the `@interaqt/storage` pack
 
 ## Overall Architecture
 
-The `@interaqt/storage` package is built as an ORM (Object-Relational Mapping) layer that abstracts database operations and provides a semantic interface for working with entities and their relationships. At a high level, it consists of:
+The storage package is built as an ORM (Object-Relational Mapping) layer that abstracts database operations and provides a semantic interface for working with entities and their relationships. At a high level, it consists of:
 
 1. **Schema Definition** - Entities, relations, and their properties define the data model
 2. **Schema Mapping** - Maps the logical schema to the physical database schema
@@ -115,13 +115,21 @@ This translates to selecting the `name` and `age` attributes of the main entity,
 
 ### RecordQueryAgent
 
-The `RecordQueryAgent` is the core execution engine that translates high-level semantic operations into SQL queries. It:
+The `RecordQueryAgent` is the facade of the execution engine that translates high-level semantic operations into SQL queries. It:
 
 1. Takes queries built by the `EntityQueryHandle`
 2. Resolves all the necessary information from the entity-to-table map
-3. Generates appropriate SQL
-4. Executes the SQL against the database
-5. Maps the results back to entity objects
+3. Delegates work to specialized executors
+4. Maps the results back to entity objects
+
+The actual work is split across executors, which the agent wires together (they call back into the agent through the explicit `RecordOperationAgent` contract):
+
+- `QueryExecutor` — executes SELECT queries, structures raw rows, resolves x:1 via JOIN and x:n via secondary (batched) queries
+- `CreationExecutor` — record creation, dependency resolution, link creation, same-row data preprocessing (`preprocessSameRowData`, shared by create and update paths)
+- `UpdateExecutor` — record updates, same-row data updates (`updateSameRowData`), reliance updates (`handleUpdateReliance`)
+- `DeletionExecutor` — record deletion, unlink, cascade deletion, deletion events
+- `SQLBuilder` — builds all SQL statements
+- `FilteredEntityManager` — filtered entity dependency analysis and `__filtered_entities` flag/event maintenance
 
 ## Data Flow
 
@@ -237,7 +245,7 @@ The system supports removing relations by setting the relation field to `null` d
    - It removes all these relationships in a single operation
    - For many-to-many relations, it deletes the junction table entries
 
-The implementation is in the `updateSameRowData` and `handleUpdateReliance` methods of the `RecordQueryAgent` class:
+The implementation is in the `updateSameRowData` and `handleUpdateReliance` methods of the `UpdateExecutor` class (invoked through `RecordQueryAgent.updateRecord`):
 - `updateSameRowData` handles x:1 relations and same-table relations
 - `handleUpdateReliance` handles x:n relations and different-table relations
 
@@ -276,26 +284,26 @@ Throughout the system, various data structures are used:
 ### Entity and Relation Definitions
 
 ```typescript
-// Entity definition
-const userEntity: Entity = {
+// Entity definition (Klass factory pattern; names must match /^[a-zA-Z0-9_]+$/)
+const userEntity = Entity.create({
   name: 'User',
   properties: [
-    { name: 'name', type: 'String' },
-    { name: 'age', type: 'Number' }
+    Property.create({ name: 'name', type: 'string' }),
+    Property.create({ name: 'age', type: 'number' })
   ]
-};
+});
 
-// Relation definition
-const profileRelation: Relation = {
+// Relation definition. type is a string: '1:1' | '1:n' | 'n:1' | 'n:n'
+const profileRelation = Relation.create({
   source: profileEntity,
   sourceProperty: 'owner',
   target: userEntity,
   targetProperty: 'profile',
-  type: RelationType.OneToOne,
+  type: '1:1',
   properties: [
-    { name: 'viewed', type: 'Number' }
+    Property.create({ name: 'viewed', type: 'number' })
   ]
-};
+});
 ```
 
 ### Match Expression Data
@@ -363,6 +371,6 @@ These events can be captured and used for audit logging, triggering side effects
 
 ## Conclusion
 
-The `@interaqt/storage` package provides a powerful abstraction over database operations, allowing you to work with entities and relations in a more natural way. By understanding these implementation details, you can make more effective use of the package and potentially extend or customize its functionality to better suit your needs.
+The storage package provides a powerful abstraction over database operations, allowing you to work with entities and relations in a more natural way. By understanding these implementation details, you can make more effective use of the package and potentially extend or customize its functionality to better suit your needs.
 
 For specific implementation questions or issues, refer to the source code in the `erstorage` directory, which contains the detailed logic for each component described here. 

--- a/src/storage/USAGE_GUIDE.md
+++ b/src/storage/USAGE_GUIDE.md
@@ -1,8 +1,8 @@
-# @interaqt/storage Usage Guide
+# interaqt storage Usage Guide
 
 ## Introduction
 
-The `@interaqt/storage` package is an ORM-like library that provides a high-level, semantic interface for database operations. It abstracts away database-specific details and allows you to work with entities, relations, and queries in a natural way. This guide will walk you through how to use this package effectively.
+The interaqt storage layer (`src/storage`, path alias `@storage`) is an ORM-like library that provides a high-level, semantic interface for database operations. It abstracts away database-specific details and allows you to work with entities, relations, and queries in a natural way. This guide will walk you through how to use this package effectively.
 
 ## Table of Contents
 
@@ -19,12 +19,14 @@ The `@interaqt/storage` package is an ORM-like library that provides a high-leve
 ## Installation
 
 ```bash
-npm install @interaqt/storage
+npm install interaqt
 ```
+
+The storage layer ships as part of the `interaqt` package (`src/storage`, path alias `@storage` inside the repository).
 
 ## Basic Concepts
 
-The `@interaqt/storage` package is built around a few key concepts:
+The storage layer is built around a few key concepts:
 
 - **Entities**: Represent your data models (like User, Product, etc.)
 - **Relations**: Represent relationships between entities (like one-to-many, many-to-many)
@@ -38,37 +40,37 @@ The `@interaqt/storage` package is built around a few key concepts:
 First, you need to define your data model using entities and relations:
 
 ```typescript
-import { Entity, Property, Relation, RelationType } from "@storage";
+import { Entity, Property, Relation } from 'interaqt';
 
-// Define an entity
-const userEntity: Entity = {
+// Define an entity. Names must match /^[a-zA-Z0-9_]+$/ (enforced at create time).
+const userEntity = Entity.create({
   name: 'User',
   properties: [
-    { name: 'name', type: 'String' },
-    { name: 'age', type: 'Number' },
-    { name: 'gender', type: 'String', defaultValue: () => 'male' }
+    Property.create({ name: 'name', type: 'string' }),
+    Property.create({ name: 'age', type: 'number' }),
+    Property.create({ name: 'gender', type: 'string', defaultValue: () => 'male' })
   ]
-};
+});
 
 // Define another entity
-const profileEntity: Entity = {
+const profileEntity = Entity.create({
   name: 'Profile',
   properties: [
-    { name: 'title', type: 'String' }
+    Property.create({ name: 'title', type: 'string' })
   ]
-};
+});
 
-// Define a relation between entities
-const profileRelation: Relation = {
+// Define a relation between entities. type is a string: '1:1' | '1:n' | 'n:1' | 'n:n'
+const profileRelation = Relation.create({
   source: profileEntity,
   sourceProperty: 'owner',
   target: userEntity,
   targetProperty: 'profile',
-  type: RelationType.OneToOne,
+  type: '1:1',
   properties: [
-    { name: 'viewed', type: 'Number' }
+    Property.create({ name: 'viewed', type: 'number' })
   ]
-};
+});
 
 // Create collections of entities and relations
 const entities = [userEntity, profileEntity];
@@ -80,8 +82,8 @@ const relations = [profileRelation];
 After defining your data model, you need to set up the storage with a database:
 
 ```typescript
-import { DBSetup, EntityToTableMap, EntityQueryHandle } from "@storage";
-import { SQLiteDB } from "your-database-adapter"; // Example database adapter
+import { DBSetup, EntityToTableMap, EntityQueryHandle } from 'interaqt';
+import { SQLiteDB } from 'interaqt'; // or PGLiteDB / PostgreSQLDB / MysqlDB
 
 // Create and open the database connection
 const db = new SQLiteDB(':memory:');
@@ -92,8 +94,9 @@ const setup = new DBSetup(entities, relations, db);
 await setup.createTables();
 await setup.createConstraints();
 
-// Create the query handle to interact with the database
-const entityQueryHandle = new EntityQueryHandle(new EntityToTableMap(setup.map), db);
+// Create the query handle to interact with the database.
+// Pass setup.aliasManager so pregenerated table aliases are reused.
+const entityQueryHandle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
 ```
 
 ### Schema Constraints and Metadata
@@ -457,41 +460,41 @@ console.log(events);
 
 ```typescript
 // Define entities and relations
-const userEntity = {
+const userEntity = Entity.create({
   name: 'User',
   properties: [
-    { name: 'name', type: 'String' },
-    { name: 'email', type: 'String' },
-    { name: 'age', type: 'Number' }
+    Property.create({ name: 'name', type: 'string' }),
+    Property.create({ name: 'email', type: 'string' }),
+    Property.create({ name: 'age', type: 'number' })
   ]
-};
+});
 
-const taskEntity = {
+const taskEntity = Entity.create({
   name: 'Task',
   properties: [
-    { name: 'title', type: 'String' },
-    { name: 'description', type: 'String' },
-    { name: 'completed', type: 'Boolean', defaultValue: () => false }
+    Property.create({ name: 'title', type: 'string' }),
+    Property.create({ name: 'description', type: 'string' }),
+    Property.create({ name: 'completed', type: 'boolean', defaultValue: () => false })
   ]
-};
+});
 
-const taskAssignmentRelation = {
+const taskAssignmentRelation = Relation.create({
   source: userEntity,
   sourceProperty: 'assignedTasks',
   target: taskEntity,
   targetProperty: 'assignee',
-  type: RelationType.OneToMany,
+  type: '1:n',
   properties: [
-    { name: 'assignedAt', type: 'Date' }
+    Property.create({ name: 'assignedAt', type: 'string' })
   ]
-};
+});
 
 // Set up the storage
 const db = new SQLiteDB(':memory:');
 await db.open();
 const setup = new DBSetup([userEntity, taskEntity], [taskAssignmentRelation], db);
 await setup.createTables();
-const entityQueryHandle = new EntityQueryHandle(new EntityToTableMap(setup.map), db);
+const entityQueryHandle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
 
 // Create a user
 const user = await entityQueryHandle.create('User', {
@@ -537,4 +540,4 @@ await entityQueryHandle.delete('Task', MatchExp.atom({ key: 'id', value: ['>', 0
 await entityQueryHandle.delete('User', MatchExp.atom({ key: 'id', value: ['>', 0] }));
 ```
 
-This guide provides a comprehensive overview of how to use the `@interaqt/storage` package. For more specific use cases or advanced features, please refer to the source code or create specific examples tailored to your needs. 
+This guide provides a comprehensive overview of how to use the interaqt storage layer. For more specific use cases or advanced features, please refer to the source code or create specific examples tailored to your needs. 

--- a/src/storage/erstorage/AttributeQuery.ts
+++ b/src/storage/erstorage/AttributeQuery.ts
@@ -16,7 +16,6 @@ export class AttributeQuery {
 
     public fullQueryTree: RecordQueryTree
     public parentLinkRecordQuery?: RecordQuery
-    public id = Math.random()
     public static mergeAttributeQueryData(attributeQueryData: AttributeQueryData, otherAttributeQueryData: AttributeQueryData): AttributeQueryData {
 
         const allAttributeQueryData = [...attributeQueryData, ...otherAttributeQueryData]

--- a/src/storage/erstorage/CreationExecutor.ts
+++ b/src/storage/erstorage/CreationExecutor.ts
@@ -7,7 +7,7 @@ import { NewRecordData, RawEntityData } from "./NewRecordData.js";
 import { assert } from "../utils.js";
 import { SQLBuilder } from "./SQLBuilder.js";
 import { FilteredEntityManager } from "./FilteredEntityManager.js";
-import type { Record } from "./RecordQueryAgent.js";
+import type { Record, RecordOperationAgent } from "./RecordQueryAgent.js";
 import type { QueryExecutor } from "./QueryExecutor.js";
 
 /**
@@ -31,13 +31,8 @@ export class CreationExecutor {
         private queryExecutor: QueryExecutor,
         filteredEntityManager: FilteredEntityManager,
         sqlBuilder: SQLBuilder,
-        private helper: {
-            updateRecord: (entity: string, matchExpression: MatchExpressionData, newRecordData: NewRecordData, events?: RecordMutationEvent[]) => Promise<Record[]>,
-            unlink: (linkName: string, matchExpression: MatchExpressionData, moveSource: boolean, reason: string, events?: RecordMutationEvent[]) => Promise<Record[]>,
-            deleteRecordSameRowData: (recordName: string, records: EntityIdRef[], events?: RecordMutationEvent[], inSameRowDataOp?: boolean) =>Promise<Record[]>,
-            flashOutCombinedRecordsAndMergedLinks: (newEntityData: NewRecordData, events?: RecordMutationEvent[], reason?: string) => Promise<{ [k: string]: RawEntityData }>,
-            relocateCombinedRecordDataForLink: (linkName: string, matchExpression: MatchExpressionData, moveSource: boolean, events?: RecordMutationEvent[]) => Promise<Record[]>
-        }
+        // CAUTION executor 之间的互相回调通过 RecordOperationAgent 显式契约进行（见 RecordQueryAgent）。
+        private agent: RecordOperationAgent
     ) {
         this.sqlBuilder = sqlBuilder
         this.filteredEntityManager = filteredEntityManager
@@ -99,8 +94,9 @@ export class CreationExecutor {
         // 合并所有数据以获得完整的记录
         const fullRecord = Object.assign({}, newEntityData.getData(), newRecordIdRef, relianceResult);
 
-        // 处理 filtered entity - 检查新创建的记录是否属于任何 filtered entity
-        // 传递 isCreation = true 表示这是创建操作，只生成事件但不持久化 __filtered_entities
+        // 处理 filtered entity - 检查新创建的记录是否属于任何 filtered entity。
+        // 传递 isCreation = true 表示这是创建操作：直接对所有相关 filtered entity 求值，
+        // 生成 create 事件并把结果持久化到 __filtered_entities 标记列。
         await this.filteredEntityManager.updateFilteredEntityFlags(newEntityData.recordName, newRecordIdRef.id, events, fullRecord, true)
 
         // 更新 relianceResult 的信息
@@ -196,7 +192,7 @@ export class CreationExecutor {
 
         // 2. 处理需要 flashOut 的数据
         // TODO create 的情况下，有没可能不需要 flashout 已有的数据，直接更新到已有的 combined record 的行就行了。
-        const flashOutRecordRasData: { [k: string]: RawEntityData } = await this.helper.flashOutCombinedRecordsAndMergedLinks(
+        const flashOutRecordRasData: { [k: string]: RawEntityData } = await this.agent.flashOutCombinedRecordsAndMergedLinks(
             newEntityData,
             events,
             `finding combined records for ${newEntityData.recordName} to flash out, for ${isUpdate ? 'updating' : 'creation'} with data ${JSON.stringify(newEntityDataWithIds.getData())}`
@@ -259,7 +255,7 @@ export class CreationExecutor {
                 [reverseInfo!.attributeName]: currentIdRef,
                 [LINK_SYMBOL]: record.getData()[LINK_SYMBOL]
             }
-            const [updatedRecord] = await this.helper.updateRecord(reverseInfo.parentEntityName, idMatch, new NewRecordData(this.map, reverseInfo.parentEntityName, newData), events)
+            const [updatedRecord] = await this.agent.updateRecord(reverseInfo.parentEntityName, idMatch, new NewRecordData(this.map, reverseInfo.parentEntityName, newData), events)
             if (record.info!.isXToMany) {
                 if (!newIdRefs[record.info!.attributeName]) {
                     newIdRefs[record.info!.attributeName!] = []
@@ -315,7 +311,7 @@ export class CreationExecutor {
                     value: ['=', record.getRef().id]
                 })
                 // 这里需要调用 RecordQueryAgent 的 unlink 方法
-                await this.helper.unlink(record.info!.linkName, match, false, 'unlink xToOne old link', events)
+                await this.agent.unlink(record.info!.linkName, match, false, 'unlink xToOne old link', events)
             }
             const linkRawData: RawEntityData = record.linkRecordData?.getData() || {}
             Object.assign(linkRawData, {
@@ -383,7 +379,7 @@ export class CreationExecutor {
                 value: ['=', unlinkId]
             })
             // 这里需要调用 RecordQueryAgent 的 unlink 方法
-            await this.helper.unlink(linkName, match, false, 'unlink combined record for add new link', events)
+            await this.agent.unlink(linkName, match, false, 'unlink combined record for add new link', events)
         }
 
         const newLinkData = new NewRecordData(this.map, linkInfo.name, {

--- a/src/storage/erstorage/DeletionExecutor.ts
+++ b/src/storage/erstorage/DeletionExecutor.ts
@@ -6,7 +6,7 @@ import { LINK_SYMBOL, RecordQuery } from "./RecordQuery.js";
 import { assert } from "../utils.js";
 import { SQLBuilder } from "./SQLBuilder.js";
 import { FilteredEntityManager } from "./FilteredEntityManager.js";
-import type { Record } from "./RecordQueryAgent.js";
+import type { Record, RecordOperationAgent } from "./RecordQueryAgent.js";
 import type { QueryExecutor } from "./QueryExecutor.js";
 
 /**
@@ -30,10 +30,8 @@ export class DeletionExecutor {
         private queryExecutor: QueryExecutor,
         filteredEntityManager: FilteredEntityManager,
         sqlBuilder: SQLBuilder,
-        private helper: {
-            findRecords: (entityQuery: RecordQuery, queryName: string) => Promise<Record[]>,
-            relocateCombinedRecordDataForLink: (linkName: string, matchExpression: MatchExpressionData, moveSource: boolean, events?: RecordMutationEvent[]) => Promise<Record[]>
-        }
+        // CAUTION executor 之间的互相回调通过 RecordOperationAgent 显式契约进行（见 RecordQueryAgent）。
+        private agent: RecordOperationAgent
     ) {
         this.sqlBuilder = sqlBuilder
         this.filteredEntityManager = filteredEntityManager
@@ -54,7 +52,7 @@ export class DeletionExecutor {
                 true
             )
         })
-        const records = await this.helper.findRecords(deleteQuery, `find record for deleting ${recordName}`)
+        const records = await this.agent.findRecords(deleteQuery, `find record for deleting ${recordName}`)
 
         // 注意下面使用的都是 deleteQuery 的 recordName，而不是 entityName，因为 RecordQuery 会根据 recordName 来判断是否是 filtered entity。
         // CAUTION 我们应该先删除关系，再删除关联实体。按照下面的顺序就能保证事件顺序的正确。
@@ -66,15 +64,12 @@ export class DeletionExecutor {
             const relianceEvents: RecordMutationEvent[] = []
             await this.deleteDifferentTableReliance(deleteQuery.recordName, records, relianceEvents)
             // 删除自身、有生命周期依赖的合表 record、合表到当前 record 的关系数据。
-            const sameRowRecordEvents: RecordMutationEvent[] = []
-            await this.deleteRecordSameRowData(deleteQuery.recordName, records, sameRowRecordEvents, inSameRowDataOp)
+            // CAUTION 这里按结构分组收集事件（关系/级联事件 与 当前 record 删除事件分开），
+            //  而不是依赖"事件数组的最后 N 条一定是 record 删除事件"这种脆弱的位置约定。
+            const { linkAndCascadeEvents, recordDeleteEvents } = await this.deleteRecordSameRowDataGrouped(deleteQuery.recordName, records, inSameRowDataOp)
 
-            // 1. recordEvents 除了最后一个外全都是关系删除事件。
-            // 2. relianceEvents 中都是 reliance 删除事件，可能包含关系删除事件。
-            // 3. 最后 recordEvents 是 record 删除事件。
-            const relationEvents = sameRowRecordEvents.slice(0, sameRowRecordEvents.length - records.length)
-            const recordEvents = sameRowRecordEvents.slice(sameRowRecordEvents.length - records.length)
-            events?.push(...relationEvents, ...relianceEvents, ...recordEvents)
+            // 事件顺序：先关系删除事件，再 reliance 删除事件，最后是 record 本身的删除事件。
+            events?.push(...linkAndCascadeEvents, ...relianceEvents, ...recordDeleteEvents)
         }
 
         return records
@@ -85,6 +80,19 @@ export class DeletionExecutor {
      * 这里会把同表的 reliance，以及 reliance 的 reliance 都删除掉
      */
     async deleteRecordSameRowData(recordName: string, records: EntityIdRef[], events?: RecordMutationEvent[], inSameRowDataOp = false): Promise<Record[]> {
+        const { linkAndCascadeEvents, recordDeleteEvents } = await this.deleteRecordSameRowDataGrouped(recordName, records, inSameRowDataOp)
+        events?.push(...linkAndCascadeEvents, ...recordDeleteEvents)
+        return records as Record[]
+    }
+
+    /**
+     * 删除记录同行数据的实际实现。
+     * 事件按结构分组返回：
+     * - linkAndCascadeEvents：关系（link）删除事件、同表 reliance 级联删除事件、filtered entity 删除事件。
+     * - recordDeleteEvents：当前批次 record 本身的删除事件（与传入 records 一一对应）。
+     */
+    private async deleteRecordSameRowDataGrouped(recordName: string, records: EntityIdRef[], inSameRowDataOp = false): Promise<{ linkAndCascadeEvents: RecordMutationEvent[], recordDeleteEvents: RecordMutationEvent[] }> {
+        const linkAndCascadeEvents: RecordMutationEvent[] = []
         const recordInfo = this.map.getRecordInfo(recordName)
 
         for (let record of records) {
@@ -101,7 +109,7 @@ export class DeletionExecutor {
                         modifier: {limit: 1}
                     }
                 )
-                const recordWithSameRowData = await this.helper.findRecords(recordWithSameRowDataQuery, `find record with same row data for delete ${recordName}`)
+                const recordWithSameRowData = await this.agent.findRecords(recordWithSameRowDataQuery, `find record with same row data for delete ${recordName}`)
                 const hasSameRowData = recordInfo.notRelianceCombined.some(info => {
                     return !!recordWithSameRowData[0]?.[info.attributeName]?.id
                 })
@@ -127,7 +135,7 @@ export class DeletionExecutor {
                 // 只要真正存在这个数据才要删除
                 if (record[relianceInfo.attributeName]?.id) {
                     // 和 reliance 的 link record 的事件
-                    events?.push({
+                    linkAndCascadeEvents.push({
                         type: 'delete',
                         recordName: relianceInfo.linkName,
                         record: {
@@ -141,7 +149,7 @@ export class DeletionExecutor {
                         },
                     })
 
-                    await this.handleDeletedRecordReliance(relianceInfo.recordName, record[relianceInfo.attributeName]!, events)
+                    await this.handleDeletedRecordReliance(relianceInfo.recordName, record[relianceInfo.attributeName]!, linkAndCascadeEvents)
                 }
             }
 
@@ -149,7 +157,7 @@ export class DeletionExecutor {
             recordInfo.mergedRecordAttributes.forEach(attributeInfo => {
                 if (record[attributeInfo.attributeName]?.id) {
                     // 记录和自己合并的 link 事件
-                    events?.push({
+                    linkAndCascadeEvents.push({
                         type: 'delete',
                         recordName: attributeInfo.linkName,
                         // CAUTION 注意这里一定要增加 link 上对于原始 record 的引用。外部计算的时候可能需要，那时可能 record 也删了查询不到了。
@@ -170,7 +178,7 @@ export class DeletionExecutor {
                 if (recordInfo.isRelation && (attributeInfo.attributeName === 'target' || attributeInfo.attributeName === 'source')) return
                 if (record[attributeInfo.attributeName]?.id === undefined) return
                 // 记录和自己合并的 link 事件
-                events?.push({
+                linkAndCascadeEvents.push({
                     type: 'delete',
                     recordName: attributeInfo.linkName,
                     // CAUTION 注意这里一定要增加 link 上对于原始 record 的引用。外部计算的时候可能需要，那时可能 record 也删了查询不到了。
@@ -198,7 +206,7 @@ export class DeletionExecutor {
                 for (const filteredEntity of filteredEntities) {
                     if (currentFlags[filteredEntity.name] === true) {
                         // 记录属于这个 filtered entity，生成删除事件
-                        events?.push({
+                        linkAndCascadeEvents.push({
                             type: 'delete',
                             recordName: filteredEntity.name,
                             record: { ...record }
@@ -207,13 +215,13 @@ export class DeletionExecutor {
                 }
             }
         }
-        
-        events?.push(...records.map(record => ({
+
+        const recordDeleteEvents = records.map(record => ({
             type: 'delete',
             recordName: recordName,
             record,
-        }) as RecordMutationEvent))
-        return records
+        }) as RecordMutationEvent)
+        return { linkAndCascadeEvents, recordDeleteEvents }
     }
 
     /**
@@ -284,7 +292,7 @@ export class DeletionExecutor {
         assert(!linkInfo.isTargetReliance, `cannot unlink reliance data, you can only delete record, ${linkName}`)
 
         if (linkInfo.isCombined()) {
-            return this.helper.relocateCombinedRecordDataForLink(linkName, matchExpressionData, moveSource, events)
+            return this.agent.relocateCombinedRecordDataForLink(linkName, matchExpressionData, moveSource, events)
         }
 
         return this.deleteRecord(linkName, matchExpressionData, events)

--- a/src/storage/erstorage/EntityToTableMap.ts
+++ b/src/storage/erstorage/EntityToTableMap.ts
@@ -118,6 +118,10 @@ type TableAndAliasStack = {
 }[]
 
 export class EntityToTableMap {
+    // CAUTION 元数据缓存：MapData 在 setup 完成后不可变，RecordInfo/AttributeInfo 只是它的只读视图，
+    //  热路径（每次查询/变更都会反复调用 getRecordInfo/getInfoByPath）不应该每次都新建对象、做字符串拆解。
+    private recordInfoCache = new Map<string, RecordInfo>()
+    private infoByPathCache = new Map<string, AttributeInfo|undefined>()
     constructor(public data: MapData, public aliasManager?: AliasManager) {}
     
     getRecord(recordName:string) {
@@ -130,7 +134,12 @@ export class EntityToTableMap {
         return this.data.records[recordName].attributes[this.getAttributeAndSymmetricDirection(attributeName)[0]]
     }
     getRecordInfo(recordName:string) {
-        return new RecordInfo(recordName, this)
+        let info = this.recordInfoCache.get(recordName)
+        if (!info) {
+            info = new RecordInfo(recordName, this)
+            this.recordInfoCache.set(recordName, info)
+        }
+        return info
     }
     getInfo(entityName: string, attribute: string) : AttributeInfo{
         const result = this.getInfoByPath([entityName, ...(attribute.split('.'))])
@@ -152,6 +161,16 @@ export class EntityToTableMap {
     }
 
     getInfoByPath(namePath: string[]): AttributeInfo|undefined {
+        const cacheKey = namePath.join('.')
+        if (this.infoByPathCache.has(cacheKey)) {
+            return this.infoByPathCache.get(cacheKey)
+        }
+        const result = this.computeInfoByPath(namePath)
+        this.infoByPathCache.set(cacheKey, result)
+        return result
+    }
+
+    private computeInfoByPath(namePath: string[]): AttributeInfo|undefined {
         const [entityName, ...attributivePath] = namePath
         assert(this.data.records[entityName], `entity ${entityName} not found`)
         assert(attributivePath.length > 0, 'getInfoByPath should have a name path.')
@@ -244,8 +263,9 @@ export class EntityToTableMap {
 
                 // 处理 symmetric 中的:
                 const rawCurrentTableAlias = `${lastTableAlias}_${currentAttributeName}${symmetricDirection ? `_${symmetricDirection.toUpperCase()}` : ''}`
-                // 使用预生成的别名或原始名称（如果没有 aliasManager）
-                const currentTableAlias = this.aliasManager?.getTableAlias(rawCurrentTableAlias) || rawCurrentTableAlias
+                // CAUTION 优先使用预生成别名；超过预生成深度的路径在这里运行时兜底注册。
+                //  不能直接落回原始长名：PG 会静默截断 >63 字节的标识符，两条长路径截断后可能同名碰撞产生错误 JOIN。
+                const currentTableAlias = this.aliasManager?.registerTablePath(rawCurrentTableAlias) || rawCurrentTableAlias
 
                 // CAUTION 一定要先处理 linkAlias，因为依赖于上一次 tableAlias。
                 if (info.isMergedWithParent() || info.isLinkMergedWithParent()) {
@@ -254,9 +274,9 @@ export class EntityToTableMap {
                     // link 没有合并的情况也要生成新的 alias。否则就和 lastTableAlias 同名
                 } else if (info.isLinkIsolated()){
                     // link 表独立，给个新名字
-                    // CAUTION symmetric 路径要手动指定关系
+                    // CAUTION symmetric 路径要手动指定关系。超过预生成深度的路径运行时兜底注册（理由同上）。
                     const rawRelAlias = `REL_${rawCurrentTableAlias}`
-                    relationTableAlias = this.aliasManager?.getTableAlias(rawRelAlias) || rawRelAlias
+                    relationTableAlias = this.aliasManager?.registerTablePath(rawRelAlias) || rawRelAlias
                 } else {
                     // link 表合并了，名字和当前一样。
                     relationTableAlias = currentTableAlias
@@ -425,106 +445,83 @@ export class EntityToTableMap {
 
         return [valueAttributes, entityAttributes, entityIdAttributes]
     }
-    // 获取压缩后的路径
-    getShrinkedAttribute(entityName:string, attributeName: string):string {
-        // 将路径分割成数组
+    /**
+     * 获取压缩后的路径。
+     *
+     * 把路径中 `attr.&.source` / `attr.&.target` 这种"先进入关系，再回到关系端点"的段压缩掉：
+     * 当端点（source/target）指向的实体与 `attr` 本身指向的实体相同时，`attr.&.<endpoint>` 与 `attr` 等价。
+     * 例如 `owner.&.target.name`（owner 指向关系的 target 实体）压缩为 `owner.name`；
+     * 而 `owner.&.source.name`（回到关系的另一端）无法压缩，原样保留。
+     *
+     * 该函数被 filtered relation 的 rebase（MatchExp.rebase）依赖。
+     */
+    getShrinkedAttribute(entityName: string, attributeName: string): string {
         const pathParts = attributeName.split('.');
         const result: string[] = [];
+        // currentEntity 跟踪 result 尾部对应的实体。空字符串表示已进入无法继续解析的上下文（如 link 的反向端点）。
         let currentEntity = entityName;
-        let previousEntity = entityName; // 保存前一个实体名称
+        // previousEntity 是 result 最后一个属性段所属的实体，用于解析该属性对应的关系信息。
+        let previousEntity = entityName;
         let i = 0;
-        
+
         while (i < pathParts.length) {
             const part = pathParts[i];
-            
-            // 如果当前部分是 & 符号
-            if (part === LINK_SYMBOL && i > 0 && i < pathParts.length - 1) {
+            const isMiddleLinkSymbol = part === LINK_SYMBOL && i > 0 && i < pathParts.length - 1;
+
+            if (isMiddleLinkSymbol) {
                 const previousAttr = result[result.length - 1];
                 const nextPart = pathParts[i + 1];
-                
-                // 如果下一个部分是 source 或 target
+
                 if (nextPart === 'source' || nextPart === 'target') {
-                        // 使用前一个实体来获取关系信息
-                        const relationInfo = this.getInfo(previousEntity, previousAttr);
-                        
-                        if (relationInfo.isRecord) {
-                            // 获取关系的详细信息
-                            const linkInfo = relationInfo.getLinkInfo().data;
-                            
-                            // 确定关系属性指向的实体
-                            let relationPointsTo: string;
-                            if (relationInfo.isRecordSource()) {
-                                // 如果是 source，则指向关系的 target
-                                relationPointsTo = linkInfo.targetRecord;
-                            } else {
-                                // 如果不是 source，则指向关系的 source
-                                relationPointsTo = linkInfo.sourceRecord;
-                            }
-                            
-                            // 确定 source/target 指向的实体
-                            let sourceTargetPointsTo: string;
-                            if (nextPart === 'source') {
-                                sourceTargetPointsTo = linkInfo.sourceRecord;
-                            } else {
-                                sourceTargetPointsTo = linkInfo.targetRecord;
-                            }
-                            
-                            // 如果两者指向相同的实体，可以压缩
-                            if (relationPointsTo === sourceTargetPointsTo) {
-                                // 跳过 & 和 source/target
-                                i += 2;
-                                // currentEntity 保持为 relationPointsTo
-                                // previousEntity 不变，因为我们没有添加新的属性到结果
-                                continue;
-                            } else {
-                                // 如果不能压缩，更新 currentEntity 为 source/target 指向的实体
-                                currentEntity = sourceTargetPointsTo;
-                                previousEntity = currentEntity; // 更新 previousEntity
-                                currentEntity = '';
-                                previousEntity = ''; // 更新 previousEntity
-                                result.push(part);
-                                result.push(nextPart);
-                                i += 2;
-                                continue;
-                            }
+                    // 用前一个属性段判断 link 端点是否与该属性指向同一实体
+                    const relationInfo = this.getInfo(previousEntity, previousAttr);
+                    if (relationInfo.isRecord) {
+                        const linkData = relationInfo.getLinkInfo().data;
+                        // 关系属性指向的实体（站在 previousEntity 的角度看向另一端）
+                        const relationPointsTo = relationInfo.isRecordSource() ? linkData.targetRecord : linkData.sourceRecord;
+                        // source/target 端点指向的实体
+                        const endpointPointsTo = nextPart === 'source' ? linkData.sourceRecord : linkData.targetRecord;
+
+                        if (relationPointsTo === endpointPointsTo) {
+                            // `attr.&.<endpoint>` 与 `attr` 等价：跳过 & 和端点段，实体跟踪保持不变
+                            i += 2;
+                            continue;
                         }
+                        // 端点指向关系的另一端（回到了 previousEntity 一侧）：不能压缩，原样保留。
+                        // 此后路径处于反向端点上下文，无法用 getInfo 继续解析，停止实体跟踪。
+                        currentEntity = '';
+                        previousEntity = '';
+                        result.push(part, nextPart);
+                        i += 2;
+                        continue;
+                    }
+                    // 前一段不是 record 属性，无法判断，保留 & 继续处理后续段
                 } else {
+                    // & 后面不是 source/target（读取 link 自身的属性等）：进入 link 上下文，停止实体跟踪
                     currentEntity = '';
-                    previousEntity = ''; 
+                    previousEntity = '';
                 }
-                
-                // 如果不能压缩，保留 & 符号
+
                 result.push(part);
                 i++;
             } else if (part !== LINK_SYMBOL) {
-                // 保存当前实体作为前一个实体
                 previousEntity = currentEntity;
-                
-                // 更新当前实体
-                if(currentEntity) {
+                // 只在实体跟踪有效时解析。跟踪失效（''）时只做路径拼接。
+                if (currentEntity) {
                     const info = this.getInfo(currentEntity, part);
                     if (info.isRecord) {
                         currentEntity = info.recordName;
                     }
                 }
-                // try {
-                //     const info = this.getInfo(currentEntity, part);
-                //     if (info.isRecord) {
-                //         currentEntity = info.recordName;
-                //     }
-                // } catch (e) {
-                //     // 忽略错误
-                // }
-                
                 result.push(part);
                 i++;
             } else {
-                // 其他情况（比如 & 在开头或结尾）
+                // & 出现在路径开头或结尾：无压缩语义，原样保留
                 result.push(part);
                 i++;
             }
         }
-        
+
         return result.join('.');
     }
 }

--- a/src/storage/erstorage/FilteredEntityManager.ts
+++ b/src/storage/erstorage/FilteredEntityManager.ts
@@ -1,6 +1,6 @@
 import { MatchExpressionData, MatchAtom, MatchExp } from "./MatchExp.js"
 import { BoolExp } from "@core"
-import { EntityToTableMap } from "./EntityToTableMap.js"
+import { EntityToTableMap, MapData } from "./EntityToTableMap.js"
 import { RecordQueryAgent } from "./RecordQueryAgent.js"
 import { RecordQuery } from "./RecordQuery.js"
 import { RecordMutationEvent } from "@runtime"
@@ -16,13 +16,43 @@ export interface FilteredEntityDependency {
     }[]
 }
 
+// CAUTION 依赖分析结果只由不可变的 MapData 决定，按 MapData 缓存。
+//  否则每次 new RecordQueryAgent / EntityQueryHandle（例如 migration 中的临时 handle）都会全量重算。
+const dependenciesByMapData = new WeakMap<MapData, Map<string, FilteredEntityDependency[]>>()
+
 /**
  * 管理 filtered entity 的所有功能，包括依赖分析、跨实体查询和级联事件处理
  */
 export class FilteredEntityManager {
-    private dependencies: Map<string, FilteredEntityDependency[]> = new Map()
-    
-    constructor(private map: EntityToTableMap, private queryAgent: RecordQueryAgent) {}
+    private dependencies: Map<string, FilteredEntityDependency[]>
+
+    constructor(private map: EntityToTableMap, private queryAgent: RecordQueryAgent) {
+        const cached = dependenciesByMapData.get(map.data)
+        if (cached) {
+            this.dependencies = cached
+        } else {
+            this.dependencies = new Map()
+            dependenciesByMapData.set(map.data, this.dependencies)
+            this.initializeDependencies()
+        }
+    }
+
+    /**
+     * 初始化所有 filtered entity 的依赖关系（每个 MapData 只计算一次）
+     */
+    private initializeDependencies() {
+        for (const [recordName, recordData] of Object.entries(this.map.data.records)) {
+            // 统一判断：如果有 matchExpression 且 resolvedBaseRecordName 不指向自己，说明是 filtered entity
+            // 普通 entity 没有 matchExpression 或 resolvedBaseRecordName 指向自己
+            if (recordData.matchExpression && recordData.resolvedBaseRecordName && recordData.resolvedBaseRecordName !== recordName) {
+                this.analyzeDependencies(
+                    recordName,
+                    recordData.resolvedBaseRecordName,
+                    recordData.resolvedMatchExpression || recordData.matchExpression
+                )
+            }
+        }
+    }
     
     // ============ 依赖管理功能 ============
     
@@ -40,20 +70,23 @@ export class FilteredEntityManager {
             dependencies
         }
         
-        // 注册依赖关系
-        for (const dep of dependencies) {
-            if (!this.dependencies.has(dep.entityName)) {
-                this.dependencies.set(dep.entityName, [])
+        // 注册依赖关系。
+        // CAUTION 同一个 dependency 在同一个实体名下只能注册一次。
+        //  谓词包含 base 自身属性时 dependencies 里也会出现 baseEntityName，
+        //  如果这里再无条件注册一次，update 时会对同一条记录做双倍的 membership 查询（结果幂等但白做）。
+        const entityNamesToRegister = new Set<string>(dependencies.map(dep => dep.entityName))
+        // 源实体自身也要注册（即使谓词没有直接引用它的属性）
+        entityNamesToRegister.add(baseEntityName)
+        for (const entityName of entityNamesToRegister) {
+            if (!this.dependencies.has(entityName)) {
+                this.dependencies.set(entityName, [])
             }
-            this.dependencies.get(dep.entityName)!.push(dependency)
+            const registered = this.dependencies.get(entityName)!
+            if (!registered.includes(dependency)) {
+                registered.push(dependency)
+            }
         }
-        
-        // 也注册源实体自身
-        if (!this.dependencies.has(baseEntityName)) {
-            this.dependencies.set(baseEntityName, [])
-        }
-        this.dependencies.get(baseEntityName)!.push(dependency)
-        
+
         return dependency
     }
     
@@ -140,10 +173,11 @@ export class FilteredEntityManager {
     }
     
     /**
-     * 清除所有依赖关系
+     * 清除所有依赖关系（同时失效按 MapData 共享的缓存）
      */
     clear() {
         this.dependencies.clear()
+        dependenciesByMapData.delete(this.map.data)
     }
     
     // ============ 跨实体查询功能 ============
@@ -214,25 +248,38 @@ export class FilteredEntityManager {
         entityName: string,
         matchExpression: MatchExpressionData
     ): Promise<boolean> {
+        const matchedIds = await this.checkRecordsMatchFilter([recordId], entityName, matchExpression)
+        return matchedIds.has(recordId)
+    }
+
+    /**
+     * 批量检查记录是否满足 filtered entity 的条件，返回满足条件的 id 集合。
+     * CAUTION 一次 membership 查询覆盖所有记录，避免每条记录一次查询的 N+1。
+     */
+    async checkRecordsMatchFilter(
+        recordIds: string[],
+        entityName: string,
+        matchExpression: MatchExpressionData
+    ): Promise<Set<string>> {
         if (!this.queryAgent) {
             throw new Error('QueryAgent not set in FilteredEntityManager')
         }
-        
-        
+        if (!recordIds.length) return new Set()
+
         const query = RecordQuery.create(entityName, this.map, {
             matchExpression: matchExpression.and({
                 key: 'id',
-                value: ['=', recordId]
+                value: ['in', recordIds]
             }),
-            modifier: { limit: 1 }
+            attributeQuery: ['id']
         })
-        
+
         const results = await this.queryAgent.findRecords(
             query,
-            `check if record ${recordId} matches filter condition`
+            `check if records [${recordIds.join(',')}] match filter condition`
         )
-        
-        return results.length > 0
+
+        return new Set(results.map(r => r.id))
     }
     
     // ============ 级联事件处理功能 ============
@@ -378,14 +425,12 @@ export class FilteredEntityManager {
                 changedAttributes
             )
             
-            // 更新每个受影响的源记录的 filtered entity 标记
-            for (const sourceRecord of affectedSourceRecords) {
-                await this.updateSingleFilteredEntityFlag(
-                    dependency,
-                    sourceRecord.id,
-                    events
-                )
-            }
+            // 批量更新所有受影响的源记录的 filtered entity 标记
+            await this.updateFilteredEntityFlagsForRecords(
+                dependency,
+                affectedSourceRecords.map(record => record.id),
+                events
+            )
         }
     }
     isFlagEqual(flag1: { [key: string]: boolean }, flag2: { [key: string]: boolean }): boolean {
@@ -396,78 +441,69 @@ export class FilteredEntityManager {
     }
     
     /**
-     * 更新单个依赖关系的 filtered entity 标记
+     * 批量更新单个依赖关系下多条记录的 filtered entity 标记。
+     * CAUTION 批量化：每个依赖只做一次"取当前标记"查询和一次 membership 查询，
+     *  只对标记真正变化的记录逐条 UPDATE（每条记录的 JSON 内容不同，无法合并成一条 UPDATE）。
      */
-    private async updateSingleFilteredEntityFlag(
+    private async updateFilteredEntityFlagsForRecords(
         dependency: FilteredEntityDependency,
-        recordId: string,
+        recordIds: string[],
         events: RecordMutationEvent[]
     ): Promise<void> {
+        if (!recordIds.length) return
+
         const recordInfo = this.map.getRecordInfo(dependency.baseEntityName)
-        // 获取记录当前的 __filtered_entities 状态
-        const currentRecord = await this.queryAgent.findRecords(
+        // 获取所有记录当前的 __filtered_entities 状态
+        const currentRecords = await this.queryAgent.findRecords(
             RecordQuery.create(dependency.baseEntityName, this.map, {
-                matchExpression: MatchExp.atom({ key: 'id', value: ['=', recordId] }),
+                matchExpression: MatchExp.atom({ key: 'id', value: ['in', recordIds] }),
                 attributeQuery: recordInfo.isRelation ? 
                     ['*', ['target', {attributeQuery: ['*']}], ['source', {attributeQuery: ['*']}]] : 
                     ['*']
             }),
-            `get current filtered entity flags for ${dependency.baseEntityName}:${recordId}`
+            `get current filtered entity flags for ${dependency.baseEntityName}`
         )
-        
-        if (currentRecord.length === 0) {
+
+        if (currentRecords.length === 0) {
             return
         }
-        
-        const record = currentRecord[0]
-        const currentFlags: { [key: string]: boolean } = record.__filtered_entities;
-        
-        // 检查记录是否满足 filtered entity 的条件
-        const matchesFilter = await this.checkRecordMatchesFilter(
-            recordId,
+
+        // 批量 membership 查询：一次查出所有仍然满足条件的记录
+        const matchedIds = await this.checkRecordsMatchFilter(
+            currentRecords.map(record => record.id),
             dependency.baseEntityName,
             dependency.matchExpression
         )
-        
-        const previouslyBelonged = currentFlags[dependency.filteredEntityName] === true
-        
-        // 如果状态发生变化，生成相应的事件
-        if (matchesFilter && !previouslyBelonged) {
-            // 记录现在属于这个 filtered entity
+
+        const filteredEntitiesAttribute = recordInfo.data.attributes['__filtered_entities']
+        const flagFieldName = filteredEntitiesAttribute && (filteredEntitiesAttribute as any).field
+
+        for (const record of currentRecords) {
+            // CAUTION __filtered_entities 可能为 NULL（存量数据/手工迁移的行），也可能是未反序列化的字符串。
+            //  这里必须归一化成对象，否则读取属性时会抛 TypeError。
+            const rawFlags = record.__filtered_entities
+            const currentFlags: { [key: string]: boolean } =
+                (typeof rawFlags === 'string' ? JSON.parse(rawFlags) : rawFlags) || {}
+
+            const matchesFilter = matchedIds.has(record.id)
+            const previouslyBelonged = currentFlags[dependency.filteredEntityName] === true
+
+            if (matchesFilter === previouslyBelonged) continue
+
+            // 状态发生变化：生成相应的事件并更新标记
             events.push({
-                type: 'create',
+                type: matchesFilter ? 'create' : 'delete',
                 recordName: dependency.filteredEntityName,
                 record: { ...record }
             })
-            
-            // 更新标记
-            currentFlags[dependency.filteredEntityName] = true
-        } else if (!matchesFilter && previouslyBelonged) {
-            // 记录不再属于这个 filtered entity
-            events.push({
-                type: 'delete',
-                recordName: dependency.filteredEntityName,
-                record: { ...record }
-            })
-            
-            // 更新标记
-            currentFlags[dependency.filteredEntityName] = false
-        }
-        
-        // 更新 __filtered_entities 字段
-        if (previouslyBelonged !== matchesFilter) {
-            // 获取 __filtered_entities 字段的实际数据库字段名
-            const recordInfo = this.map.getRecordInfo(dependency.baseEntityName);
-            const filteredEntitiesAttribute = recordInfo.data.attributes['__filtered_entities'];
-            
-            if (filteredEntitiesAttribute && (filteredEntitiesAttribute as any).field) {
-                const fieldName = (filteredEntitiesAttribute as any).field;
-                
+            currentFlags[dependency.filteredEntityName] = matchesFilter
+
+            if (flagFieldName) {
                 await this.queryAgent.updateRecordDataById(
                     dependency.baseEntityName,
-                    { id: recordId },
+                    { id: record.id },
                     [{
-                        field: fieldName,
+                        field: flagFieldName,
                         value: JSON.stringify(currentFlags)
                     }]
                 )

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -207,7 +207,7 @@ export class MatchExp {
         let fieldParams:unknown[] = []
         const simpleOp = ['=', '>', '<', '<=', '>=', 'like', '!=']
 
-        if (simpleOp.includes(value[0]) || (value[0] === 'not' && value[1] !== null)) {
+        if (simpleOp.includes(value[0])) {
             if (isReferenceValue) {
                 // 当 isReferenceValue 为 true 时，直接将列引用嵌入 SQL，不使用占位符
                 const referenceField = this.getReferenceFieldValue(value[1])
@@ -217,12 +217,28 @@ export class MatchExp {
                 fieldValue = `${value[0]} ${p()}`
                 fieldParams = [value[1]]
             }
-        } else if((value[0] === 'not' && value[1] === null)) {
+        } else if (value[0] === 'not') {
+            // CAUTION 'not' 只支持 null（表示 IS NOT NULL）。
+            //  其他值会生成 `"field" not $1` 这种非法 SQL，必须显式报错。
+            if (value[1] !== null) {
+                throw new Error(`match operator 'not' only supports null (meaning IS NOT NULL). To exclude a value use '!=', got: ${JSON.stringify(value[1])} for key "${key}"`)
+            }
             fieldValue = `IS NOT NULL`
         } else if (value[0].toLowerCase() === 'in') {
             assert(!isReferenceValue, 'reference value cannot use IN to match')
-            fieldValue = `IN (${value[1].map((_x: unknown) => p()).join(',')})`
-            fieldParams = value[1]
+            if (!Array.isArray(value[1])) {
+                throw new Error(`match operator 'in' requires an array value, got: ${JSON.stringify(value[1])} for key "${key}"`)
+            }
+            if (value[1].length === 0) {
+                // 空数组的 IN 语义上恒为 false（任何值都不在空集合中）。
+                // `IN ()` 是非法 SQL，这里生成跨数据库合法且恒为 false 的表达式：
+                // `x IN (NULL)` 求值为 NULL，`NULL AND (1=0)` 为 false，且在外层 NOT 下取反后正确为 true。
+                fieldValue = `IN (NULL) AND 1=0`
+                fieldParams = []
+            } else {
+                fieldValue = `IN (${value[1].map((_x: unknown) => p()).join(',')})`
+                fieldParams = value[1]
+            }
         } else if (value[0].toLowerCase() === 'between') {
             if (isReferenceValue) {
                 // 当 isReferenceValue 为 true 时，直接将列引用嵌入 SQL

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -344,7 +344,7 @@ export class QueryExecutor {
         // 分组需要每条子记录带上父 id。如果用户没有查询反向属性，这里追加 [reverseAttr, {attributeQuery: ['id']}]
         //（1:n 的反向是 x:1，同一次 JOIN 查询即可拿到，无额外往返），组装结果时再删掉。
         const reverseAttrInUserQuery = relatedRecordQuery.attributeQuery.data.some(
-            item => Array.isArray(item) && item[0] === reverseAttributeName
+            item => (typeof item === 'string' ? item : item[0]) === reverseAttributeName
         )
         const attributeQueryData: AttributeQueryData = reverseAttrInUserQuery ?
             relatedRecordQuery.attributeQuery.data :

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -267,20 +267,154 @@ export class QueryExecutor {
         for (let subEntityQuery of entityQuery.attributeQuery.xToManyRecords) {
             // XToMany 的 relationData 是在上面 buildFindQuery 一起查完了的
             if (!subEntityQuery.onlyRelationData) {
-                for (let record of records) {
-                    const nextContext = entityQuery.label ? nextRecursiveContext.concat(record) : nextRecursiveContext
-                    record[subEntityQuery.alias || subEntityQuery.attributeName!] = await this.findXToManyRelatedRecords(
+                // CAUTION 优先按父 id 集合批量查询（IN (...) + 按反向属性分组回填），消掉一层 N+1。
+                //  无法批量的场景（递归 label/goto、per-parent limit/offset、n:n 等）退回逐条查询。
+                if (this.canBatchXToManyQuery(entityQuery, subEntityQuery, records)) {
+                    await this.findXToManyRelatedRecordsBatched(
                         entityQuery.recordName,
                         subEntityQuery.attributeName!,
-                        record.id,
+                        records,
                         subEntityQuery,
                         recordQueryRef,
-                        nextContext
+                        nextRecursiveContext
                     )
+                } else {
+                    for (let record of records) {
+                        const nextContext = entityQuery.label ? nextRecursiveContext.concat(record) : nextRecursiveContext
+                        record[subEntityQuery.alias || subEntityQuery.attributeName!] = await this.findXToManyRelatedRecords(
+                            entityQuery.recordName,
+                            subEntityQuery.attributeName!,
+                            record.id,
+                            subEntityQuery,
+                            recordQueryRef,
+                            nextContext
+                        )
+                    }
                 }
             }
         }
         return records
+    }
+
+    /**
+     * 判断某个 x:n 关联查询能否按父 id 集合批量执行。
+     * 限制条件：
+     * - 至少两条父记录（单条时批量没有收益）。
+     * - 没有递归语义（父查询 label / 子查询 label/goto 需要 per-record 的递归上下文）。
+     * - 子查询没有 limit/offset（它们是 per-parent 语义，合并后无法保证）。
+     * - 关系是 1:n 且非对称：反向是 x:1，可以通过一次 JOIN 拿到父 id 做分组；
+     *   n:n 的反向仍是 x:n，批量会引入 fan-out 与嵌套 N+1，保持逐条查询。
+     */
+    private canBatchXToManyQuery(entityQuery: RecordQuery, subEntityQuery: RecordQuery, records: Record[]): boolean {
+        if (records.length < 2) return false
+        if (entityQuery.label || subEntityQuery.label || subEntityQuery.goto) return false
+        const modifierData = subEntityQuery.modifier?.data
+        if (modifierData?.limit !== undefined || modifierData?.offset !== undefined) return false
+        const info = this.map.getInfo(entityQuery.recordName, subEntityQuery.attributeName!)
+        if (!info.isOneToMany) return false
+        if (info.isLinkManyToManySymmetric()) return false
+        return true
+    }
+
+    /**
+     * 按父 id 集合批量查询 x:n（1:n）关联记录，并按反向属性分组回填到各父记录上。
+     * 与 findXToManyRelatedRecords 的逐条语义保持一致（包括关系数据 & 的处理），
+     * 只是把"每个父记录一次查询"合并为"每批父记录一次查询"。
+     */
+    async findXToManyRelatedRecordsBatched(
+        recordName: string,
+        attributeName: string,
+        parentRecords: Record[],
+        relatedRecordQuery: RecordQuery,
+        recordQueryRef: RecordQueryRef,
+        context: RecursiveContext
+    ): Promise<void> {
+        const BATCH_SIZE = 500
+        const info = this.map.getInfo(recordName, attributeName)
+        const reverseAttributeName = info.getReverseInfo()?.attributeName!
+        const resultKey = relatedRecordQuery.alias || relatedRecordQuery.attributeName!
+
+        // 保证每个父记录都有数组（没有子记录的父记录也一样）
+        const parentById = new Map<string, Record>()
+        for (const parent of parentRecords) {
+            parent[resultKey] = []
+            parentById.set(parent.id, parent)
+        }
+
+        // 分组需要每条子记录带上父 id。如果用户没有查询反向属性，这里追加 [reverseAttr, {attributeQuery: ['id']}]
+        //（1:n 的反向是 x:1，同一次 JOIN 查询即可拿到，无额外往返），组装结果时再删掉。
+        const reverseAttrInUserQuery = relatedRecordQuery.attributeQuery.data.some(
+            item => Array.isArray(item) && item[0] === reverseAttributeName
+        )
+        const attributeQueryData: AttributeQueryData = reverseAttrInUserQuery ?
+            relatedRecordQuery.attributeQuery.data :
+            [...relatedRecordQuery.attributeQuery.data, [reverseAttributeName, { attributeQuery: ['id'] }] as AttributeQueryDataRecordItem]
+
+        const parentLinkRecordQuery = relatedRecordQuery.attributeQuery.parentLinkRecordQuery
+        const shouldQueryParentLink = !!parentLinkRecordQuery
+
+        for (let start = 0; start < parentRecords.length; start += BATCH_SIZE) {
+            const chunk = parentRecords.slice(start, start + BATCH_SIZE)
+            const newMatch = relatedRecordQuery.matchExpression.and({
+                key: `${reverseAttributeName}.id`,
+                value: ['in', chunk.map(r => r.id)]
+            })
+            const newAttributeQuery = new AttributeQuery(
+                relatedRecordQuery.recordName,
+                this.map,
+                attributeQueryData,
+                relatedRecordQuery.parentRecord,
+                relatedRecordQuery.attributeName,
+                shouldQueryParentLink
+            )
+            const newSubQuery = relatedRecordQuery.derive({
+                matchExpression: newMatch,
+                attributeQuery: newAttributeQuery
+            })
+
+            const data = await this.findRecords(
+                newSubQuery,
+                `finding related records in batch: ${relatedRecordQuery.parentRecord}.${relatedRecordQuery.attributeName}`,
+                recordQueryRef,
+                context
+            )
+
+            for (const item of data) {
+                const parentId = item[reverseAttributeName]?.id
+                const parent = parentId !== undefined ? parentById.get(parentId) : undefined
+
+                // 和 findXToManyRelatedRecords 一致：把和父亲的关系数据挂到 & 上，并去掉临时的反向属性
+                if (shouldQueryParentLink) {
+                    item[LINK_SYMBOL] = item[reverseAttributeName]?.[LINK_SYMBOL]
+                    delete item[reverseAttributeName]
+                } else if (!reverseAttrInUserQuery) {
+                    delete item[reverseAttributeName]
+                }
+
+                // 和父亲的关联关系上的 x:n 数据
+                if (parentLinkRecordQuery) {
+                    for (let subEntityQueryOfLink of parentLinkRecordQuery.attributeQuery.xToManyRecords) {
+                        const linkId = item[LINK_SYMBOL].id
+                        setByPath(
+                            item,
+                            [LINK_SYMBOL, subEntityQueryOfLink.attributeName!],
+                            await this.findXToManyRelatedRecords(
+                                subEntityQueryOfLink.parentRecord!,
+                                subEntityQueryOfLink.attributeName!,
+                                linkId,
+                                subEntityQueryOfLink,
+                                recordQueryRef,
+                                context
+                            )
+                        )
+                    }
+                }
+
+                if (parent) {
+                    (parent[resultKey] as Record[]).push(item)
+                }
+            }
+        }
     }
 
     /**

--- a/src/storage/erstorage/RecordQuery.ts
+++ b/src/storage/erstorage/RecordQuery.ts
@@ -31,24 +31,20 @@ export class RecordQuery {
         const recordInfo = map.getRecordInfo(recordName)
         // 统一使用 resolvedBaseRecordName（普通 entity 指向自己，filtered entity 指向 base）
         const baseRecordName = recordInfo.resolvedBaseRecordName!;
-        
+
         // CAUTION 因为合表后可能用关联数据匹配到行。
-        const inputMatch = new MatchExp(baseRecordName, map, data.matchExpression, contextRootEntity)
-        let matchExpression = allowNull ? inputMatch: inputMatch.and({
+        // CAUTION filtered entity 的 resolvedMatchExpression 合并统一由 MatchExp 构造器负责
+        //  （用原始 recordName 构造即可），这里不要再合并一次，否则会产生双重 AND。
+        const inputMatch = new MatchExp(recordName, map, data.matchExpression, contextRootEntity)
+        const matchExpression = allowNull ? inputMatch : inputMatch.and({
             key: 'id',
             value: ['not', null]
         })
 
-        // 如果有 resolvedMatchExpression，说明是 filtered entity，需要合并过滤条件
-        let resolvedMatchExpression = matchExpression;
-        if (recordInfo.resolvedMatchExpression) {
-            resolvedMatchExpression = matchExpression.and(new MatchExp(baseRecordName, map, recordInfo.resolvedMatchExpression));
-        }
-
         return new RecordQuery(
             baseRecordName,
             map,
-            resolvedMatchExpression,
+            matchExpression,
             new AttributeQuery(baseRecordName, map, data.attributeQuery || [], parentRecord, attributeName),
             new Modifier(baseRecordName, map, data.modifier!),
             contextRootEntity,

--- a/src/storage/erstorage/RecordQueryAgent.ts
+++ b/src/storage/erstorage/RecordQueryAgent.ts
@@ -19,7 +19,27 @@ export type Record = EntityIdRef & {
     [k: string]: any
 }
 
-export class RecordQueryAgent {
+/**
+ * executor 之间互相回调所依赖的聚合操作契约。
+ *
+ * CAUTION CreationExecutor/UpdateExecutor/DeletionExecutor 与 RecordQueryAgent 本质上是同一个聚合，
+ *  按文件拆分只是物理组织。这里用显式接口取代原先手工拼装的函数字典（那种写法依赖
+ *  "恰好方法名匹配"的隐式约定），使循环回调成为受类型约束的显式契约。
+ */
+export interface RecordOperationAgent {
+    findRecords(entityQuery: RecordQuery, queryName?: string): Promise<Record[]>
+    createRecord(newEntityData: NewRecordData, queryName?: string, events?: RecordMutationEvent[]): Promise<EntityIdRef>
+    createRecordDependency(newRecordData: NewRecordData, events?: RecordMutationEvent[]): Promise<NewRecordData>
+    updateRecord(entityName: string, matchExpressionData: MatchExpressionData, newEntityData: NewRecordData, events?: RecordMutationEvent[]): Promise<Record[]>
+    unlink(linkName: string, matchExpressionData: MatchExpressionData, moveSource?: boolean, reason?: string, events?: RecordMutationEvent[]): Promise<Record[]>
+    deleteRecordSameRowData(recordName: string, records: EntityIdRef[], events?: RecordMutationEvent[], inSameRowDataOp?: boolean): Promise<Record[]>
+    addLinkFromRecord(entity: string, attribute: string, entityId: string, relatedEntityId: string, attributes?: RawEntityData, events?: RecordMutationEvent[]): Promise<EntityIdRef>
+    preprocessSameRowData(newEntityData: NewRecordData, isUpdate?: boolean, events?: RecordMutationEvent[], oldRecord?: Record): Promise<NewRecordData>
+    flashOutCombinedRecordsAndMergedLinks(newEntityData: NewRecordData, events?: RecordMutationEvent[], reason?: string): Promise<{ [k: string]: RawEntityData }>
+    relocateCombinedRecordDataForLink(linkName: string, matchExpressionData: MatchExpressionData, moveSource?: boolean, events?: RecordMutationEvent[]): Promise<Record[]>
+}
+
+export class RecordQueryAgent implements RecordOperationAgent {
     getPlaceholder: () => PlaceholderGen
     private filteredEntityManager: FilteredEntityManager
     private sqlBuilder: SQLBuilder
@@ -30,32 +50,13 @@ export class RecordQueryAgent {
     
     constructor(public map: EntityToTableMap, public database: Database) {
         this.getPlaceholder = database.getPlaceholder || (() => (name?:string) => `?`)
+        // CAUTION filtered entity 依赖分析由 FilteredEntityManager 按 MapData 缓存，重复 new 不会重算。
         this.filteredEntityManager = new FilteredEntityManager(map, this)
         this.sqlBuilder = new SQLBuilder(map, database)
         this.queryExecutor = new QueryExecutor(map, database, this.sqlBuilder)
         this.creationExecutor = new CreationExecutor(map, database, this.queryExecutor, this.filteredEntityManager, this.sqlBuilder, this)
         this.deletionExecutor = new DeletionExecutor(map, database, this.queryExecutor, this.filteredEntityManager, this.sqlBuilder, this)
         this.updateExecutor = new UpdateExecutor(map, database, this.filteredEntityManager, this.sqlBuilder, this)
-        this.initializeFilteredEntityDependencies()
-    }
-    
-    /**
-     * 初始化所有 filtered entity 的依赖关系
-     */
-    private initializeFilteredEntityDependencies() {
-        const records = this.map.data.records
-        
-        for (const [recordName, recordData] of Object.entries(records)) {
-            // 统一判断：如果有 matchExpression 且 resolvedBaseRecordName 不指向自己，说明是 filtered entity
-            // 普通 entity 没有 matchExpression 或 resolvedBaseRecordName 指向自己
-            if (recordData.matchExpression && recordData.resolvedBaseRecordName && recordData.resolvedBaseRecordName !== recordName) {
-                this.filteredEntityManager.analyzeDependencies(
-                    recordName,
-                    recordData.resolvedBaseRecordName,
-                    recordData.resolvedMatchExpression || recordData.matchExpression
-                )
-            }
-        }
     }
 
     // 查 entity 和 查 relation 都是一样的。具体在 entityQuery 里面区别。
@@ -85,85 +86,11 @@ export class RecordQueryAgent {
         return this.creationExecutor.createRecord(newEntityData, queryName, events)
     }
 
-    // preprocessSameRowData 由于被 update 和 create 共同使用，保留在 RecordQueryAgent
-    // 但在创建场景下会通过 insertSameRowData 间接调用 CreationExecutor 的版本
+    // 委托给 CreationExecutor。
+    // CAUTION 创建/更新两个分支共用同一份实现（CreationExecutor.preprocessSameRowData），
+    //  不要在这里再复制一份，两份实现必然随时间分叉。
     async preprocessSameRowData(newEntityData: NewRecordData, isUpdate = false, events?: RecordMutationEvent[], oldRecord?: Record): Promise<NewRecordData> {
-        if (!isUpdate) {
-            // 创建场景：委托给 CreationExecutor
-            return this.creationExecutor.preprocessSameRowData(newEntityData, isUpdate, events, oldRecord)
-        }
-        
-        // 更新场景：保留原逻辑
-        const newRawDataWithNewIds = newEntityData.getData()
-        if(isUpdate && !newRawDataWithNewIds.id) {
-            newRawDataWithNewIds.id = oldRecord!.id
-        }
-
-        // 可能只是更新关系，所以这里一定要有自身的 value 才算是 update 自己
-        if (newEntityData.valueAttributes.length) {
-            const updatedFieldValues = newEntityData.getSameRowFieldAndValue(oldRecord)
-            const recordInfo = this.map.getRecordInfo(newEntityData.recordName)
-            const valueAttributeNames = new Set(recordInfo.valueAttributes.map(attr => attr.attributeName))
-            const updateRecord = { ...newEntityData.getData() } as Record
-            updatedFieldValues.forEach(field => {
-                if (valueAttributeNames.has(field.name)) {
-                    updateRecord[field.name] = field.value
-                }
-            })
-            events?.push({
-                type: 'update',
-                recordName: newEntityData.recordName,
-                record: { ...updateRecord, id: oldRecord!.id },
-                oldRecord: oldRecord
-            })
-        }
-
-        // 1. 先为三表合一的新数据分配 id
-        for (let record of newEntityData.combinedNewRecords) {
-            newRawDataWithNewIds[record.info!.attributeName] = {
-                ...newRawDataWithNewIds[record.info!.attributeName],
-                id: await this.database.getAutoId(record.info!.recordName!),
-            }
-            events?.push({
-                type: 'create',
-                recordName: record.recordName,
-                record: newRawDataWithNewIds[record.info!.attributeName]
-            })
-        }
-
-        // 2. 为我要新建 三表合一、或者我 mergedLink 的 的 关系 record 分配 id.
-        for (let record of newEntityData.mergedLinkTargetNewRecords.concat(newEntityData.mergedLinkTargetRecordIdRefs, newEntityData.combinedNewRecords)) {
-            if (newRawDataWithNewIds[record.info!.attributeName].id !== oldRecord?.[record.info!.attributeName]?.id) {
-                newRawDataWithNewIds[record.info!.attributeName][LINK_SYMBOL] = {
-                    ...(newRawDataWithNewIds[record.info!.attributeName][LINK_SYMBOL] || {}),
-                    id: await this.database.getAutoId(record.info!.linkName!),
-                }
-
-                const linkRecord = {...newRawDataWithNewIds[record.info!.attributeName][LINK_SYMBOL]}
-                linkRecord[record.info!.isRecordSource() ? 'target' : 'source'] = record.getData()
-                linkRecord[record.info!.isRecordSource() ? 'source' : 'target'] = {...newRawDataWithNewIds}
-                delete linkRecord.target[LINK_SYMBOL]
-                delete linkRecord.source[LINK_SYMBOL]
-
-
-                events?.push({
-                    type: 'create',
-                    recordName: record.info!.linkName,
-                    record: linkRecord
-                })
-            }
-        }
-
-        const newEntityDataWithIds = newEntityData.merge(newRawDataWithNewIds)
-
-        // 2. 处理需要 flashOut 的数据
-        const flashOutRecordRasData: { [k: string]: RawEntityData } = await this.flashOutCombinedRecordsAndMergedLinks(
-            newEntityData,
-            events,
-            `finding combined records for ${newEntityData.recordName} to flash out, for ${isUpdate ? 'updating' : 'creation'} with data ${JSON.stringify(newEntityDataWithIds.getData())}`
-        )
-
-        return newEntityDataWithIds.merge(flashOutRecordRasData)
+        return this.creationExecutor.preprocessSameRowData(newEntityData, isUpdate, events, oldRecord)
     }
 
     /**

--- a/src/storage/erstorage/Setup.ts
+++ b/src/storage/erstorage/Setup.ts
@@ -156,21 +156,6 @@ export class DBSetup {
     }
 
 
-    resolveBaseSourceEntityAndFilter(entity: EntityInstance) {
-        const entityWithProps = entity
-        let baseEntity = (entityWithProps as any).baseEntity
-        let matchExpression = (entityWithProps as any).matchExpression
-        assert((baseEntity && matchExpression) || (!baseEntity && !matchExpression), `matchExpression is required for ${entityWithProps.name}`)
-        if (!(baseEntity && matchExpression)) return
-
-        while(baseEntity.baseEntity) {
-            baseEntity = baseEntity.baseEntity
-            matchExpression = matchExpression.and(baseEntity.filter)
-        }
-
-        return { baseEntity, matchExpression }
-    }
-
     /**
      * 验证 filtered entity 的过滤条件中的路径不包含 x:n 关系
      */
@@ -686,7 +671,36 @@ export class DBSetup {
         return result
     }
 
+    /**
+     * 校验 entity/relation 的 name 满足 nameFormat 约束。
+     * CAUTION name 会被用作表名/字段名/别名直接插值进 SQL（如 CREATE TABLE "${name}"），
+     *  这里是 storage 的入口防线（Entity.create/Relation.create 已经先校验过一次，
+     *  但实例可能绕过 Klass 工厂直接构造，所以这里必须再校验）。
+     */
+    private static readonly VALID_NAME_FORMAT = /^[a-zA-Z0-9_]+$/
+    private validateRecordNames() {
+        this.entities.forEach(entity => {
+            if (typeof entity.name !== 'string' || !DBSetup.VALID_NAME_FORMAT.test(entity.name)) {
+                throw new Error(`Entity name "${entity.name}" is invalid. Entity names must match ${DBSetup.VALID_NAME_FORMAT} (letters, numbers and underscore only).`)
+            }
+        })
+        this.relations.forEach(relation => {
+            if (relation.name !== undefined && !DBSetup.VALID_NAME_FORMAT.test(relation.name)) {
+                throw new Error(`Relation name "${relation.name}" is invalid. Relation names must match ${DBSetup.VALID_NAME_FORMAT} (letters, numbers and underscore only).`)
+            }
+            if (!DBSetup.VALID_NAME_FORMAT.test(relation.sourceProperty)) {
+                throw new Error(`Relation sourceProperty "${relation.sourceProperty}" is invalid. Property names must match ${DBSetup.VALID_NAME_FORMAT} (letters, numbers and underscore only).`)
+            }
+            if (relation.targetProperty !== undefined && !DBSetup.VALID_NAME_FORMAT.test(relation.targetProperty)) {
+                throw new Error(`Relation targetProperty "${relation.targetProperty}" is invalid. Property names must match ${DBSetup.VALID_NAME_FORMAT} (letters, numbers and underscore only).`)
+            }
+        })
+    }
+
     buildMap() {
+        // -1. 校验所有 entity/relation 的 name（name 会直接进入 SQL，必须先于一切处理）
+        this.validateRecordNames();
+
         // 0. 预处理：将 merged entity 和 merged relation 转化为 filtered entity/relation
         this.processMergedItems();
         

--- a/src/storage/erstorage/UpdateExecutor.ts
+++ b/src/storage/erstorage/UpdateExecutor.ts
@@ -6,7 +6,7 @@ import { LINK_SYMBOL, RecordQuery } from "./RecordQuery.js";
 import { NewRecordData, RawEntityData } from "./NewRecordData.js";
 import { SQLBuilder } from "./SQLBuilder.js";
 import { FilteredEntityManager } from "./FilteredEntityManager.js";
-import type { Record } from "./RecordQueryAgent.js";
+import type { Record, RecordOperationAgent } from "./RecordQueryAgent.js";
 
 /**
  * UpdateExecutor - 更新操作执行器
@@ -26,15 +26,8 @@ export class UpdateExecutor {
         private database: Database,
         filteredEntityManager: FilteredEntityManager,
         sqlBuilder: SQLBuilder,
-        private helper: {
-            findRecords: (entityQuery: RecordQuery, queryName: string) => Promise<Record[]>,
-            createRecordDependency: (newRecordData: NewRecordData, events?: RecordMutationEvent[]) => Promise<NewRecordData>,
-            createRecord: (newEntityData: NewRecordData, queryName?: string, events?: RecordMutationEvent[]) => Promise<EntityIdRef>,
-            addLinkFromRecord: (entity: string, attribute: string, entityId: string, relatedEntityId: string, attributes?: RawEntityData, events?: RecordMutationEvent[]) => Promise<EntityIdRef>,
-            unlink: (linkName: string, matchExpression: MatchExpressionData, moveSource: boolean, reason: string, events?: RecordMutationEvent[]) => Promise<Record[]>,
-            deleteRecordSameRowData: (recordName: string, records: EntityIdRef[], events?: RecordMutationEvent[], inSameRowDataOp?: boolean) => Promise<Record[]>,
-            preprocessSameRowData: (newEntityData: NewRecordData, isUpdate: boolean, events?: RecordMutationEvent[], oldRecord?: Record) => Promise<NewRecordData>
-        }
+        // CAUTION executor 之间的互相回调通过 RecordOperationAgent 显式契约进行（见 RecordQueryAgent）。
+        private agent: RecordOperationAgent
     ) {
         this.sqlBuilder = sqlBuilder
         this.filteredEntityManager = filteredEntityManager
@@ -45,19 +38,30 @@ export class UpdateExecutor {
      */
     async updateRecord(entityName: string, matchExpressionData: MatchExpressionData, newEntityData: NewRecordData, events?: RecordMutationEvent[]): Promise<Record[]> {
         // 现在支持在 update 字段的同时，使用 null 来删除关系
-        // FIXME update 的 attributeQuery 应该按需查询，现在查询的记录太多
+        // CAUTION 前置查询按需裁剪：
+        //  - 值属性全部保留：update 事件的 oldRecord、computed 属性重算、增量计算都依赖旧值。
+        //  - 关系记录（reliance/合表/合并 link）只保留本次 update 实际涉及的 attribute：
+        //    unlink 判断和 flash-out 只会用到 newEntityData 里出现的关系，其余的递归 JOIN 纯属浪费。
+        //  - link record 自身的 source/target（managedRecordAttributes）始终保留，它们是同行字段，代价极小。
+        const fullAttributeQuery = AttributeQuery.getAttributeQueryDataForRecord(entityName, this.map, true, true, true, true)
+        const recordInfo = this.map.getRecordInfo(this.map.getRecordInfo(entityName).resolvedBaseRecordName!)
+        const involvedRecordAttributes = new Set(Object.keys(newEntityData.getData() || {}))
+        recordInfo.managedRecordAttributes.forEach(info => involvedRecordAttributes.add(info.attributeName))
+        const trimmedAttributeQuery = fullAttributeQuery.filter(item =>
+            typeof item === 'string' || involvedRecordAttributes.has(item[0])
+        )
 
         const updateRecordQuery = RecordQuery.create(entityName, this.map, {
             matchExpression: matchExpressionData,
-            attributeQuery: AttributeQuery.getAttributeQueryDataForRecord(entityName, this.map, true, true, true, true)
+            attributeQuery: trimmedAttributeQuery
         })
         
-        const matchedEntities = await this.helper.findRecords(updateRecordQuery, `find record for updating ${entityName}`)
+        const matchedEntities = await this.agent.findRecords(updateRecordQuery, `find record for updating ${entityName}`)
         // 注意下面使用的都是 updateRecordQuery 的 recordName，而不是 entityName，因为 RecordQuery 会根据 recordName 来判断是否是 filtered entity。
         const result: Record[] = []
         for (let matchedEntity of matchedEntities) {
             // 1. 创建我依赖的
-            const newEntityDataWithDep = await this.helper.createRecordDependency(newEntityData, events)
+            const newEntityDataWithDep = await this.agent.createRecordDependency(newEntityData, events)
             // 2. 把同表的实体移出去，为新同表 Record 建立 id；可能有要删除的 reliance
             const newEntityDataWithIdsWithFlashOutRecords = await this.updateSameRowData(updateRecordQuery.recordName, matchedEntity, newEntityDataWithDep, events)
             // 3. 更新依赖我的和关系表独立的
@@ -95,7 +99,7 @@ export class UpdateExecutor {
                 continue
             }
 
-            await this.helper.unlink(
+            await this.agent.unlink(
                 linkInfo.name,
                 MatchExp.atom({
                     key: `${updatedEntityLinkAttr}.id`,
@@ -108,7 +112,7 @@ export class UpdateExecutor {
         }
 
         // 2. 分配 id,处理需要 flash out 的数据等，事件也是这里面记录的。这里面会有抢夺关系，所以也可能会有删除事件。
-        const newEntityDataWithIdsWithFlashOutRecords = await this.helper.preprocessSameRowData(newEntityDataWithDep, true, events, matchedEntity)
+        const newEntityDataWithIdsWithFlashOutRecords = await this.agent.preprocessSameRowData(newEntityDataWithDep, true, events, matchedEntity)
         const allSameRowData = newEntityDataWithIdsWithFlashOutRecords.getSameRowFieldAndValue(matchedEntity)
         const columnAndValue = allSameRowData.map(({field, value}: { field: string, value: string }) => (
             {
@@ -148,7 +152,7 @@ export class UpdateExecutor {
 
             removedLinkName.add(linkInfo.name)
             const updatedEntityLinkAttr = linkInfo.isRelationSource(entityName, relatedEntityData.info!.attributeName) ? 'source' : 'target'
-            await this.helper.unlink(
+            await this.agent.unlink(
                 linkInfo.name,
                 MatchExp.atom({
                     key: `${updatedEntityLinkAttr}.id`,
@@ -176,11 +180,11 @@ export class UpdateExecutor {
             if (newRelatedEntityData.isRef()) {
                 finalRelatedEntityRef = newRelatedEntityData.getRef()
             } else {
-                finalRelatedEntityRef = await this.helper.createRecord(newRelatedEntityData, `create new related record for update ${newEntityData.recordName}.${newRelatedEntityData.info?.attributeName}`, events)
+                finalRelatedEntityRef = await this.agent.createRecord(newRelatedEntityData, `create new related record for update ${newEntityData.recordName}.${newRelatedEntityData.info?.attributeName}`, events)
             }
 
             // FIXME 这里没有在更新的时候一次性写入，而是又通过 addLinkFromRecord 建立的关系。需要优化
-            const linkRecord = await this.helper.addLinkFromRecord(entityName, newRelatedEntityData.info?.attributeName!, matchedEntity.id, finalRelatedEntityRef.id, undefined, events)
+            const linkRecord = await this.agent.addLinkFromRecord(entityName, newRelatedEntityData.info?.attributeName!, matchedEntity.id, finalRelatedEntityRef.id, undefined, events)
 
             if (newRelatedEntityData.info!.isXToMany) {
                 if (!result[newRelatedEntityData.info!.attributeName!]) {

--- a/tests/runtime/helpers/postgresConcurrencyFixtures.ts
+++ b/tests/runtime/helpers/postgresConcurrencyFixtures.ts
@@ -1,0 +1,262 @@
+import {
+  Action,
+  Any,
+  Average,
+  Controller,
+  Count,
+  Custom,
+  ComputationResult,
+  Dictionary,
+  Entity,
+  Every,
+  Interaction,
+  InteractionEventEntity,
+  Payload,
+  PayloadItem,
+  Property,
+  Relation,
+  StateMachine,
+  StateNode,
+  StateTransfer,
+  Summation,
+  Transform,
+  WeightedSummation,
+} from 'interaqt';
+
+/**
+ * PostgreSQL 并发测试的共享 fixture。
+ *
+ * CAUTION 这些模型定义必须是 vitest 父进程和 worker 子进程共享的同一个模块。
+ *  migration manifest 会对 computation 回调做 Function.prototype.toString() 哈希，
+ *  而模块转换器（vite SSR）会把回调里引用的 import 重写成 __vite_ssr_import_N__ 这类
+ *  与模块内 import 顺序相关的标识符。如果 spec 和 worker 各自复制一份"相同"的定义，
+ *  两个文件的函数文本会不同 → modelHash 不一致 → setup(false) 正确地报
+ *  "Model manifest mismatch"。共享同一模块（并用同一转换管线执行）才能保证一致。
+ */
+
+export function createGlobalSummationFixture() {
+  const counterEntity = Entity.create({
+    name: 'PgAtomicCounter',
+    properties: [Property.create({ name: 'value', type: 'number' })],
+  });
+
+  const totalDictionary = Dictionary.create({
+    name: 'pgAtomicTotal',
+    type: 'number',
+    collection: false,
+    computation: Summation.create({
+      record: counterEntity,
+      attributeQuery: ['value'],
+    }),
+  });
+
+  return { counterEntity, totalDictionary, entities: [counterEntity], relations: [], dict: [totalDictionary] };
+}
+
+export function createPropertyAggregateFixture() {
+  const User = Entity.create({
+    name: 'PgAggregateUser',
+    properties: [Property.create({ name: 'name', type: 'string' })],
+  });
+  const Order = Entity.create({
+    name: 'PgAggregateOrder',
+    properties: [
+      Property.create({ name: 'amount', type: 'number' }),
+      Property.create({ name: 'weight', type: 'number' }),
+    ],
+  });
+  const UserOrder = Relation.create({
+    name: 'PgAggregateUserOrder',
+    source: User,
+    sourceProperty: 'orders',
+    target: Order,
+    targetProperty: 'buyer',
+    type: '1:n',
+  });
+
+  User.properties.push(
+    Property.create({ name: 'orderCount', type: 'number', computation: Count.create({ property: 'orders' }) }),
+    Property.create({ name: 'orderTotal', type: 'number', computation: Summation.create({ property: 'orders', attributeQuery: ['amount'] }) }),
+    Property.create({ name: 'orderAverage', type: 'number', computation: Average.create({ property: 'orders', attributeQuery: ['amount'] }) }),
+    Property.create({
+      name: 'allPositive',
+      type: 'boolean',
+      computation: Every.create({ property: 'orders', attributeQuery: ['amount'], callback: (order: any) => order.amount > 0 }),
+    }),
+    Property.create({
+      name: 'hasLargeOrder',
+      type: 'boolean',
+      computation: Any.create({ property: 'orders', attributeQuery: ['amount'], callback: (order: any) => order.amount >= 1000 }),
+    }),
+    Property.create({
+      name: 'weightedTotal',
+      type: 'number',
+      computation: WeightedSummation.create({
+        property: 'orders',
+        attributeQuery: ['amount', 'weight'],
+        callback: (order: any) => ({ value: order.amount || 0, weight: order.weight || 0 }),
+      }),
+    })
+  );
+
+  return { User, Order, entities: [User, Order], relations: [UserOrder], dict: [] };
+}
+
+export function createStateMachineFixture() {
+  const Order = Entity.create({
+    name: 'PgStateOrder',
+    properties: [Property.create({ name: 'title', type: 'string' })],
+  });
+  const Approve = Interaction.create({
+    name: 'pgApproveOrder',
+    action: Action.create({ name: 'pgApproveOrder' }),
+    payload: Payload.create({ items: [PayloadItem.create({ name: 'order', type: 'Entity', base: Order, isRef: true })] }),
+  });
+  const Reject = Interaction.create({
+    name: 'pgRejectOrder',
+    action: Action.create({ name: 'pgRejectOrder' }),
+    payload: Payload.create({ items: [PayloadItem.create({ name: 'order', type: 'Entity', base: Order, isRef: true })] }),
+  });
+  const pending = StateNode.create({ name: 'pending' });
+  const approved = StateNode.create({ name: 'approved' });
+  const rejected = StateNode.create({ name: 'rejected' });
+
+  Order.properties.push(Property.create({
+    name: 'status',
+    type: 'string',
+    computation: StateMachine.create({
+      states: [pending, approved, rejected],
+      initialState: pending,
+      transfers: [
+        StateTransfer.create({
+          trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: Approve.name } },
+          current: pending,
+          next: approved,
+          computeTarget: (event: any) => ({ id: event.record.payload.order.id }),
+        }),
+        StateTransfer.create({
+          trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: Reject.name } },
+          current: pending,
+          next: rejected,
+          computeTarget: (event: any) => ({ id: event.record.payload.order.id }),
+        }),
+      ],
+    }),
+  }));
+
+  return { Order, Approve, Reject, entities: [Order], relations: [], eventSources: [Approve, Reject] };
+}
+
+export function createTransformFixture() {
+  const Source = Entity.create({
+    name: 'PgTransformSource',
+    properties: [Property.create({ name: 'items', type: 'number' })],
+  });
+  const Derived = Entity.create({
+    name: 'PgTransformDerived',
+    properties: [Property.create({ name: 'idx', type: 'number' })],
+    computation: Transform.create({
+      record: Source,
+      attributeQuery: ['*'],
+      callback: (source: any) => ({ idx: source.items || 0 }),
+    }),
+  });
+
+  return { Source, Derived, entities: [Source, Derived], relations: [], dict: [] };
+}
+
+export function createAsyncReturnFixture() {
+  const Source = Entity.create({
+    name: 'PgAsyncWorkerSource',
+    properties: [Property.create({ name: 'value', type: 'number' })],
+  });
+  const AddSource = Interaction.create({
+    name: 'pgAddAsyncWorkerSource',
+    action: Action.create({ name: 'pgAddAsyncWorkerSource' }),
+    payload: Payload.create({
+      items: [PayloadItem.create({ name: 'source', type: 'Entity', base: Source })],
+    }),
+  });
+  AddSource.resolve = async function(this: Controller, event: any) {
+    return this.system.storage.create('PgAsyncWorkerSource', event.payload.source);
+  };
+  const total = Dictionary.create({
+    name: 'pgAsyncWorkerTotal',
+    type: 'number',
+    collection: false,
+    computation: Custom.create({
+      name: 'PgAsyncWorkerTotal',
+      dataDeps: {
+        sources: { type: 'records', source: Source, attributeQuery: ['value'] },
+      },
+      compute: async () => ComputationResult.async({ freshnessKey: 'pg-async-worker' }),
+      asyncReturn: async (result: number) => result,
+    }),
+  });
+
+  return { Source, AddSource, total, entities: [Source], relations: [], eventSources: [AddSource], dict: [total] };
+}
+
+export function createFullReplaceFixture() {
+  const Trigger = Entity.create({
+    name: 'PgReplaceTrigger',
+    properties: [Property.create({ name: 'value', type: 'number' })],
+  });
+  const AddTrigger = Interaction.create({
+    name: 'pgAddReplaceTrigger',
+    action: Action.create({ name: 'pgAddReplaceTrigger' }),
+    payload: Payload.create({
+      items: [PayloadItem.create({ name: 'trigger', type: 'Entity', base: Trigger })],
+    }),
+  });
+  AddTrigger.resolve = async function(this: Controller, event: any) {
+    return this.system.storage.create('PgReplaceTrigger', event.payload.trigger);
+  };
+  const Result = Entity.create({
+    name: 'PgReplaceResult',
+    properties: [Property.create({ name: 'value', type: 'number' })],
+    computation: Custom.create({
+      name: 'PgReplaceResultComputation',
+      dataDeps: {
+        triggers: { type: 'records', source: Trigger, attributeQuery: ['value'] },
+      },
+      compute: async (dataDeps: any) => (dataDeps.triggers || []).map((trigger: any) => ({ value: trigger.value })),
+    }),
+  });
+  const Left = Entity.create({
+    name: 'PgReplaceLeft',
+    properties: [Property.create({ name: 'name', type: 'string' })],
+  });
+  const Right = Entity.create({
+    name: 'PgReplaceRight',
+    properties: [Property.create({ name: 'name', type: 'string' })],
+  });
+  const ResultRelation = Relation.create({
+    name: 'PgReplaceRelation',
+    source: Left,
+    sourceProperty: 'replaceLinks',
+    target: Right,
+    targetProperty: 'replaceLinkedBy',
+    type: 'n:n',
+    properties: [Property.create({ name: 'value', type: 'number' })],
+    computation: Custom.create({
+      name: 'PgReplaceRelationComputation',
+      dataDeps: {
+        triggers: { type: 'records', source: Trigger, attributeQuery: ['value'] },
+        lefts: { type: 'records', source: Left, attributeQuery: ['id'] },
+        rights: { type: 'records', source: Right, attributeQuery: ['id'] },
+      },
+      compute: async (dataDeps: any) => {
+        const lefts = dataDeps.lefts || [];
+        const rights = dataDeps.rights || [];
+        return (dataDeps.triggers || []).slice(0, Math.min(lefts.length, rights.length)).map((trigger: any, index: number) => ({
+          source: { id: lefts[index].id },
+          target: { id: rights[index].id },
+          value: trigger.value,
+        }));
+      },
+    }),
+  });
+
+  return { Trigger, AddTrigger, Result, Left, Right, ResultRelation, entities: [Trigger, Result, Left, Right], relations: [ResultRelation], eventSources: [AddTrigger] };
+}

--- a/tests/runtime/helpers/postgresConcurrencyWorker.ts
+++ b/tests/runtime/helpers/postgresConcurrencyWorker.ts
@@ -1,31 +1,20 @@
 import {
-  Action,
-  Any,
-  Average,
   Controller,
-  Count,
-  Custom,
-  ComputationResult,
-  Dictionary,
-  Entity,
-  Every,
-  Interaction,
-  InteractionEventEntity,
   KlassByName,
   MatchExp,
   MonoSystem,
-  Payload,
-  PayloadItem,
-  Property,
-  Relation,
-  StateMachine,
-  StateNode,
-  StateTransfer,
-  Summation,
-  Transform,
-  WeightedSummation,
 } from 'interaqt';
 import { PostgreSQLDB } from '@drivers';
+// CAUTION 模型定义必须与 vitest 父进程共享同一个模块（并通过同一转换管线执行），
+//  否则 migration manifest 的函数文本哈希会不一致，setup(false) 会报 "Model manifest mismatch"。
+import {
+  createAsyncReturnFixture,
+  createFullReplaceFixture,
+  createGlobalSummationFixture,
+  createPropertyAggregateFixture,
+  createStateMachineFixture,
+  createTransformFixture,
+} from './postgresConcurrencyFixtures.js';
 
 const database = process.env.INTERAQT_POSTGRES_DATABASE!;
 const mode = process.env.INTERAQT_POSTGRES_WORKER_MODE || 'global-summation';
@@ -39,257 +28,6 @@ const dbOptions = {
   user: process.env.PGUSER,
   password: process.env.PGPASSWORD,
 };
-
-function createGlobalSummationFixture() {
-  const counterEntity = Entity.create({
-    name: 'PgAtomicCounter',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-  });
-
-  const totalDictionary = Dictionary.create({
-    name: 'pgAtomicTotal',
-    type: 'number',
-    collection: false,
-    computation: Summation.create({
-      record: counterEntity,
-      attributeQuery: ['value'],
-    }),
-  });
-
-  return { entities: [counterEntity], relations: [], dict: [totalDictionary] };
-}
-
-function createPropertyAggregateFixture() {
-  const User = Entity.create({
-    name: 'PgAggregateUser',
-    properties: [Property.create({ name: 'name', type: 'string' })],
-  });
-  const Order = Entity.create({
-    name: 'PgAggregateOrder',
-    properties: [
-      Property.create({ name: 'amount', type: 'number' }),
-      Property.create({ name: 'weight', type: 'number' }),
-    ],
-  });
-
-  User.properties.push(
-    Property.create({
-      name: 'orderCount',
-      type: 'number',
-      computation: Count.create({ property: 'orders' }),
-    }),
-    Property.create({
-      name: 'orderTotal',
-      type: 'number',
-      computation: Summation.create({ property: 'orders', attributeQuery: ['amount'] }),
-    }),
-    Property.create({
-      name: 'orderAverage',
-      type: 'number',
-      computation: Average.create({ property: 'orders', attributeQuery: ['amount'] }),
-    }),
-    Property.create({
-      name: 'allPositive',
-      type: 'boolean',
-      computation: Every.create({
-        property: 'orders',
-        attributeQuery: ['amount'],
-        callback: (order: any) => order.amount > 0,
-      }),
-    }),
-    Property.create({
-      name: 'hasLargeOrder',
-      type: 'boolean',
-      computation: Any.create({
-        property: 'orders',
-        attributeQuery: ['amount'],
-        callback: (order: any) => order.amount >= 1000,
-      }),
-    }),
-    Property.create({
-      name: 'weightedTotal',
-      type: 'number',
-      computation: WeightedSummation.create({
-        property: 'orders',
-        attributeQuery: ['amount', 'weight'],
-        callback: (order: any) => ({ value: order.amount || 0, weight: order.weight || 0 }),
-      }),
-    })
-  );
-
-  const UserOrder = Relation.create({
-    name: 'PgAggregateUserOrder',
-    source: User,
-    sourceProperty: 'orders',
-    target: Order,
-    targetProperty: 'buyer',
-    type: '1:n',
-  });
-
-  return { entities: [User, Order], relations: [UserOrder], dict: [] };
-}
-
-function createStateMachineFixture() {
-  const Order = Entity.create({
-    name: 'PgStateOrder',
-    properties: [Property.create({ name: 'title', type: 'string' })],
-  });
-  const Approve = Interaction.create({
-    name: 'pgApproveOrder',
-    action: Action.create({ name: 'pgApproveOrder' }),
-    payload: Payload.create({
-      items: [PayloadItem.create({ name: 'order', type: 'Entity', base: Order, isRef: true })],
-    }),
-  });
-  const Reject = Interaction.create({
-    name: 'pgRejectOrder',
-    action: Action.create({ name: 'pgRejectOrder' }),
-    payload: Payload.create({
-      items: [PayloadItem.create({ name: 'order', type: 'Entity', base: Order, isRef: true })],
-    }),
-  });
-  const pending = StateNode.create({ name: 'pending' });
-  const approved = StateNode.create({ name: 'approved' });
-  const rejected = StateNode.create({ name: 'rejected' });
-  Order.properties.push(Property.create({
-    name: 'status',
-    type: 'string',
-    computation: StateMachine.create({
-      states: [pending, approved, rejected],
-      initialState: pending,
-      transfers: [
-        StateTransfer.create({
-          trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: Approve.name } },
-          current: pending,
-          next: approved,
-          computeTarget: (event: any) => ({ id: event.record.payload.order.id }),
-        }),
-        StateTransfer.create({
-          trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: Reject.name } },
-          current: pending,
-          next: rejected,
-          computeTarget: (event: any) => ({ id: event.record.payload.order.id }),
-        }),
-      ],
-    }),
-  }));
-
-  return { entities: [Order], relations: [], eventSources: [Approve, Reject], approve: Approve, reject: Reject };
-}
-
-function createTransformFixture() {
-  const Source = Entity.create({
-    name: 'PgTransformSource',
-    properties: [Property.create({ name: 'items', type: 'number' })],
-  });
-  const Derived = Entity.create({
-    name: 'PgTransformDerived',
-    properties: [Property.create({ name: 'idx', type: 'number' })],
-    computation: Transform.create({
-      record: Source,
-      attributeQuery: ['*'],
-      callback: (source: any) => ({ idx: source.items || 0 }),
-    }),
-  });
-
-  return { entities: [Source, Derived], relations: [], dict: [] };
-}
-
-function createAsyncReturnFixture() {
-  const Source = Entity.create({
-    name: 'PgAsyncWorkerSource',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-  });
-  const AddSource = Interaction.create({
-    name: 'pgAddAsyncWorkerSource',
-    action: Action.create({ name: 'pgAddAsyncWorkerSource' }),
-    payload: Payload.create({
-      items: [PayloadItem.create({ name: 'source', type: 'Entity', base: Source })],
-    }),
-  });
-  AddSource.resolve = async function(this: Controller, event: any) {
-    return this.system.storage.create('PgAsyncWorkerSource', event.payload.source);
-  };
-  const total = Dictionary.create({
-    name: 'pgAsyncWorkerTotal',
-    type: 'number',
-    collection: false,
-    computation: Custom.create({
-      name: 'PgAsyncWorkerTotal',
-      dataDeps: {
-        sources: { type: 'records', source: Source, attributeQuery: ['value'] },
-      },
-      compute: async () => ComputationResult.async({ freshnessKey: 'pg-async-worker' }),
-      asyncReturn: async (result: number) => result,
-    }),
-  });
-
-  return { entities: [Source], relations: [], eventSources: [AddSource], dict: [total], addSource: AddSource };
-}
-
-function createFullReplaceFixture() {
-  const Trigger = Entity.create({
-    name: 'PgReplaceTrigger',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-  });
-  const AddTrigger = Interaction.create({
-    name: 'pgAddReplaceTrigger',
-    action: Action.create({ name: 'pgAddReplaceTrigger' }),
-    payload: Payload.create({
-      items: [PayloadItem.create({ name: 'trigger', type: 'Entity', base: Trigger })],
-    }),
-  });
-  AddTrigger.resolve = async function(this: Controller, event: any) {
-    return this.system.storage.create('PgReplaceTrigger', event.payload.trigger);
-  };
-  const Result = Entity.create({
-    name: 'PgReplaceResult',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-    computation: Custom.create({
-      name: 'PgReplaceResultComputation',
-      dataDeps: {
-        triggers: { type: 'records', source: Trigger, attributeQuery: ['value'] },
-      },
-      compute: async (dataDeps: any) => (dataDeps.triggers || []).map((trigger: any) => ({ value: trigger.value })),
-    }),
-  });
-  const Left = Entity.create({
-    name: 'PgReplaceLeft',
-    properties: [Property.create({ name: 'name', type: 'string' })],
-  });
-  const Right = Entity.create({
-    name: 'PgReplaceRight',
-    properties: [Property.create({ name: 'name', type: 'string' })],
-  });
-  const ResultRelation = Relation.create({
-    name: 'PgReplaceRelation',
-    source: Left,
-    sourceProperty: 'replaceLinks',
-    target: Right,
-    targetProperty: 'replaceLinkedBy',
-    type: 'n:n',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-    computation: Custom.create({
-      name: 'PgReplaceRelationComputation',
-      dataDeps: {
-        triggers: { type: 'records', source: Trigger, attributeQuery: ['value'] },
-        lefts: { type: 'records', source: Left, attributeQuery: ['id'] },
-        rights: { type: 'records', source: Right, attributeQuery: ['id'] },
-      },
-      compute: async (dataDeps: any) => {
-        const lefts = dataDeps.lefts || [];
-        const rights = dataDeps.rights || [];
-        return (dataDeps.triggers || []).slice(0, Math.min(lefts.length, rights.length)).map((trigger: any, index: number) => ({
-          source: { id: lefts[index].id },
-          target: { id: rights[index].id },
-          value: trigger.value,
-        }));
-      },
-    }),
-  });
-
-  return { Trigger, AddTrigger, Result, Left, Right, ResultRelation, entities: [Trigger, Result, Left, Right], relations: [ResultRelation], eventSources: [AddTrigger] };
-}
 
 function delay(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -378,7 +116,7 @@ async function runStateMachineWorker() {
   const controller = new Controller({ system, ...fixture });
   await controller.setup(false);
 
-  await controller.dispatch(action === 'approve' ? fixture.approve : fixture.reject, {
+  await controller.dispatch(action === 'approve' ? fixture.Approve : fixture.Reject, {
     user: { id: `pg-state-worker-${workerIndex}` },
     payload: { order: { id: orderId } },
   });

--- a/tests/runtime/migration.spec.ts
+++ b/tests/runtime/migration.spec.ts
@@ -2505,7 +2505,8 @@ describe("Data migration phase 1", () => {
         }
     });
 
-    test("approved changed and unchanged decisions control built-in global aggregate rebuilds", async () => {
+    // 该用例顺序跑 5 个内置聚合的完整 setup+migrate 流程，耗时贴近默认 5s 超时（慢机器上会环境性超时），显式放宽。
+    test("approved changed and unchanged decisions control built-in global aggregate rebuilds", { timeout: 30000 }, async () => {
         const cases = [
             {
                 key: "Average",

--- a/tests/runtime/postgresqlConcurrency.spec.ts
+++ b/tests/runtime/postgresqlConcurrency.spec.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'vitest';
-import { Entity, Property, Dictionary, Summation, Controller, MonoSystem, MatchExp, KlassByName, Relation, Custom, Interaction, Action, Payload, PayloadItem, ComputationResult, Count, Average, Every, Any, WeightedSummation, Transform, StateMachine, StateNode, StateTransfer, InteractionEventEntity, runWithTransactionRetry } from 'interaqt';
+import { Entity, Property, Dictionary, Controller, MonoSystem, MatchExp, KlassByName, Relation, Custom, Interaction, Action, Payload, PayloadItem, ComputationResult, runWithTransactionRetry } from 'interaqt';
 import { PostgreSQLDB } from '@drivers';
 import { execFile } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const execFileAsync = promisify(execFile);
 const describeIfPostgres = process.env.INTERAQT_POSTGRES_DATABASE ? describe : describe.skip;
+// CAUTION 独占的数据库名（带后缀）。postgres 相关的 spec 文件会被 vitest 并行执行，
+//  且各自 setup(true) 会 DROP DATABASE ... WITH (FORCE)，共享库名会互相摧毁数据。
+const database = process.env.INTERAQT_POSTGRES_DATABASE ? `${process.env.INTERAQT_POSTGRES_DATABASE}_concurrency` : '';
 const dbOptions = {
   host: process.env.PGHOST,
   port: process.env.PGPORT ? Number(process.env.PGPORT) : undefined,
@@ -15,212 +19,36 @@ const dbOptions = {
   password: process.env.PGPASSWORD,
 };
 
-function createPropertyAggregateFixture() {
-  const User = Entity.create({
-    name: 'PgAggregateUser',
-    properties: [Property.create({ name: 'name', type: 'string' })],
-  });
-  const Order = Entity.create({
-    name: 'PgAggregateOrder',
-    properties: [
-      Property.create({ name: 'amount', type: 'number' }),
-      Property.create({ name: 'weight', type: 'number' }),
-    ],
-  });
-  const UserOrder = Relation.create({
-    name: 'PgAggregateUserOrder',
-    source: User,
-    sourceProperty: 'orders',
-    target: Order,
-    targetProperty: 'buyer',
-    type: '1:n',
-  });
+// CAUTION 与 worker 子进程共享的模型 fixture（见该模块内注释：manifest 依赖函数文本一致性）。
+import {
+  createAsyncReturnFixture,
+  createFullReplaceFixture,
+  createGlobalSummationFixture,
+  createPropertyAggregateFixture,
+  createStateMachineFixture,
+  createTransformFixture,
+} from './helpers/postgresConcurrencyFixtures.js';
 
-  User.properties.push(
-    Property.create({ name: 'orderCount', type: 'number', computation: Count.create({ property: 'orders' }) }),
-    Property.create({ name: 'orderTotal', type: 'number', computation: Summation.create({ property: 'orders', attributeQuery: ['amount'] }) }),
-    Property.create({ name: 'orderAverage', type: 'number', computation: Average.create({ property: 'orders', attributeQuery: ['amount'] }) }),
-    Property.create({
-      name: 'allPositive',
-      type: 'boolean',
-      computation: Every.create({ property: 'orders', attributeQuery: ['amount'], callback: (order: any) => order.amount > 0 }),
-    }),
-    Property.create({
-      name: 'hasLargeOrder',
-      type: 'boolean',
-      computation: Any.create({ property: 'orders', attributeQuery: ['amount'], callback: (order: any) => order.amount >= 1000 }),
-    }),
-    Property.create({
-      name: 'weightedTotal',
-      type: 'number',
-      computation: WeightedSummation.create({
-        property: 'orders',
-        attributeQuery: ['amount', 'weight'],
-        callback: (order: any) => ({ value: order.amount || 0, weight: order.weight || 0 }),
-      }),
-    })
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const workerPath = path.resolve(specDir, 'helpers/postgresConcurrencyWorker.ts');
+const require = createRequire(import.meta.url);
+const viteNodeEntry = path.resolve(path.dirname(require.resolve('vite-node/package.json')), 'vite-node.mjs');
+const vitestConfigPath = path.resolve(specDir, '../../vitest.config.ts');
+
+// CAUTION worker 子进程必须使用和 vitest 父进程完全相同的模块转换管线（vite-node，同一份配置）。
+//  migration manifest 会对 computation 回调做 Function.prototype.toString() 哈希：
+//  父进程用 vitest(vite/esbuild) 转换、worker 若用其他 loader（如 tsx，会压缩空白），
+//  同一份源码会得到不同的函数文本 → modelHash 不一致 → setup(false) 正确地报
+//  "Model manifest mismatch"。这不是伪造绕过，而是让父子进程真正运行同一份编译产物。
+function execWorker(env: Record<string, string>) {
+  return execFileAsync(
+    process.execPath,
+    [viteNodeEntry, '--config', vitestConfigPath, workerPath],
+    {
+      env: { ...process.env, ...env },
+      maxBuffer: 1024 * 1024,
+    }
   );
-
-  return { User, Order, entities: [User, Order], relations: [UserOrder] };
-}
-
-function createStateMachineFixture() {
-  const Order = Entity.create({
-    name: 'PgStateOrder',
-    properties: [Property.create({ name: 'title', type: 'string' })],
-  });
-  const Approve = Interaction.create({
-    name: 'pgApproveOrder',
-    action: Action.create({ name: 'pgApproveOrder' }),
-    payload: Payload.create({ items: [PayloadItem.create({ name: 'order', type: 'Entity', base: Order, isRef: true })] }),
-  });
-  const Reject = Interaction.create({
-    name: 'pgRejectOrder',
-    action: Action.create({ name: 'pgRejectOrder' }),
-    payload: Payload.create({ items: [PayloadItem.create({ name: 'order', type: 'Entity', base: Order, isRef: true })] }),
-  });
-  const pending = StateNode.create({ name: 'pending' });
-  const approved = StateNode.create({ name: 'approved' });
-  const rejected = StateNode.create({ name: 'rejected' });
-
-  Order.properties.push(Property.create({
-    name: 'status',
-    type: 'string',
-    computation: StateMachine.create({
-      states: [pending, approved, rejected],
-      initialState: pending,
-      transfers: [
-        StateTransfer.create({
-          trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: Approve.name } },
-          current: pending,
-          next: approved,
-          computeTarget: (event: any) => ({ id: event.record.payload.order.id }),
-        }),
-        StateTransfer.create({
-          trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: Reject.name } },
-          current: pending,
-          next: rejected,
-          computeTarget: (event: any) => ({ id: event.record.payload.order.id }),
-        }),
-      ],
-    }),
-  }));
-
-  return { Order, Approve, Reject, entities: [Order], relations: [], eventSources: [Approve, Reject] };
-}
-
-function createTransformFixture() {
-  const Source = Entity.create({
-    name: 'PgTransformSource',
-    properties: [Property.create({ name: 'items', type: 'number' })],
-  });
-  const Derived = Entity.create({
-    name: 'PgTransformDerived',
-    properties: [Property.create({ name: 'idx', type: 'number' })],
-    computation: Transform.create({
-      record: Source,
-      attributeQuery: ['*'],
-      callback: (source: any) => ({ idx: source.items || 0 }),
-    }),
-  });
-
-  return { Source, Derived, entities: [Source, Derived], relations: [] };
-}
-
-function createAsyncReturnWorkerFixture() {
-  const Source = Entity.create({
-    name: 'PgAsyncWorkerSource',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-  });
-  const AddSource = Interaction.create({
-    name: 'pgAddAsyncWorkerSource',
-    action: Action.create({ name: 'pgAddAsyncWorkerSource' }),
-    payload: Payload.create({
-      items: [PayloadItem.create({ name: 'source', type: 'Entity', base: Source })],
-    }),
-  });
-  AddSource.resolve = async function(this: Controller, event: any) {
-    return this.system.storage.create('PgAsyncWorkerSource', event.payload.source);
-  };
-  const total = Dictionary.create({
-    name: 'pgAsyncWorkerTotal',
-    type: 'number',
-    collection: false,
-    computation: Custom.create({
-      name: 'PgAsyncWorkerTotal',
-      dataDeps: {
-        sources: { type: 'records', source: Source, attributeQuery: ['value'] },
-      },
-      compute: async () => ComputationResult.async({ freshnessKey: 'pg-async-worker' }),
-      asyncReturn: async (result: number) => result,
-    }),
-  });
-
-  return { Source, AddSource, total, entities: [Source], relations: [], eventSources: [AddSource], dict: [total] };
-}
-
-function createFullReplaceFixture() {
-  const Trigger = Entity.create({
-    name: 'PgReplaceTrigger',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-  });
-  const AddTrigger = Interaction.create({
-    name: 'pgAddReplaceTrigger',
-    action: Action.create({ name: 'pgAddReplaceTrigger' }),
-    payload: Payload.create({
-      items: [PayloadItem.create({ name: 'trigger', type: 'Entity', base: Trigger })],
-    }),
-  });
-  AddTrigger.resolve = async function(this: Controller, event: any) {
-    return this.system.storage.create('PgReplaceTrigger', event.payload.trigger);
-  };
-  const Result = Entity.create({
-    name: 'PgReplaceResult',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-    computation: Custom.create({
-      name: 'PgReplaceResultComputation',
-      dataDeps: {
-        triggers: { type: 'records', source: Trigger, attributeQuery: ['value'] },
-      },
-      compute: async (dataDeps: any) => (dataDeps.triggers || []).map((trigger: any) => ({ value: trigger.value })),
-    }),
-  });
-  const Left = Entity.create({
-    name: 'PgReplaceLeft',
-    properties: [Property.create({ name: 'name', type: 'string' })],
-  });
-  const Right = Entity.create({
-    name: 'PgReplaceRight',
-    properties: [Property.create({ name: 'name', type: 'string' })],
-  });
-  const ResultRelation = Relation.create({
-    name: 'PgReplaceRelation',
-    source: Left,
-    sourceProperty: 'replaceLinks',
-    target: Right,
-    targetProperty: 'replaceLinkedBy',
-    type: 'n:n',
-    properties: [Property.create({ name: 'value', type: 'number' })],
-    computation: Custom.create({
-      name: 'PgReplaceRelationComputation',
-      dataDeps: {
-        triggers: { type: 'records', source: Trigger, attributeQuery: ['value'] },
-        lefts: { type: 'records', source: Left, attributeQuery: ['id'] },
-        rights: { type: 'records', source: Right, attributeQuery: ['id'] },
-      },
-      compute: async (dataDeps: any) => {
-        const lefts = dataDeps.lefts || [];
-        const rights = dataDeps.rights || [];
-        return (dataDeps.triggers || []).slice(0, Math.min(lefts.length, rights.length)).map((trigger: any, index: number) => ({
-          source: { id: lefts[index].id },
-          target: { id: rights[index].id },
-          value: trigger.value,
-        }));
-      },
-    }),
-  });
-
-  return { Trigger, AddTrigger, Result, Left, Right, ResultRelation, entities: [Trigger, Result, Left, Right], relations: [ResultRelation], eventSources: [AddTrigger] };
 }
 
 function createBarrier(count: number) {
@@ -239,7 +67,6 @@ function createBarrier(count: number) {
 
 describeIfPostgres('PostgreSQL computation concurrency', () => {
   test('allocates unique ids through sequences during concurrent creates', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const sequenceEntity = Entity.create({
       name: 'PgSequenceItem',
       properties: [
@@ -272,7 +99,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('allocates unique ids for relation links through sequences', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const User = Entity.create({
       name: 'PgSequenceUser',
       properties: [Property.create({ name: 'name', type: 'string' })],
@@ -315,7 +141,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('initializes PostgreSQL sequences from legacy ids, table max, missing ids table, and shared physical tables', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const MigrationItem = Entity.create({
       name: 'PgSequenceMigrationItem',
       properties: [Property.create({ name: 'value', type: 'number' })],
@@ -391,7 +216,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('runs 50 concurrent dispatches through Pool without transaction cross-talk', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const EventRecord = Entity.create({
       name: 'PgPoolDispatchEvent',
       properties: [Property.create({ name: 'value', type: 'number' })],
@@ -443,7 +267,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('runs concurrent serializable custom dispatches through retry', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const Counter = Entity.create({
       name: 'PgSerializableDispatchCounter',
       properties: [Property.create({ name: 'value', type: 'number' })],
@@ -475,6 +298,8 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
         dataDeps: {
           counters: { type: 'records', source: Counter, attributeQuery: ['value'] },
         },
+        // 增量计算只依赖 lastValue（每个 mutation +1），不需要额外的增量数据依赖
+        incrementalDataDeps: [],
         incrementalCompute: async (lastValue: number) => (lastValue || 0) + 1,
         getInitialValue: () => 0,
       }),
@@ -509,7 +334,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('handles a PostgreSQL async task only once across repeated workers', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const Source = Entity.create({
       name: 'PgAsyncOnceSource',
       properties: [Property.create({ name: 'value', type: 'number' })],
@@ -567,7 +391,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('keeps property aggregate computations consistent across worker processes', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const fixture = createPropertyAggregateFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
@@ -580,31 +403,18 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
     await controller.setup(true);
     const user = await system.storage.create('PgAggregateUser', { name: 'aggregate-user' });
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     const workerCount = 4;
     const iterations = 12;
 
     await Promise.all(
       Array.from({ length: workerCount }, (_, workerIndex) =>
-        execFileAsync(
-          process.execPath,
-          ['--import', 'tsx', workerPath],
-          {
-            env: {
-              ...process.env,
-              INTERAQT_POSTGRES_DATABASE: database,
-              INTERAQT_POSTGRES_WORKER_MODE: 'property-aggregate',
-              INTERAQT_POSTGRES_USER_ID: String(user.id),
-              INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
-              INTERAQT_POSTGRES_ITERATIONS: String(iterations),
-            },
-            maxBuffer: 1024 * 1024,
-          }
-        )
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_WORKER_MODE: 'property-aggregate',
+          INTERAQT_POSTGRES_USER_ID: String(user.id),
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
+          INTERAQT_POSTGRES_ITERATIONS: String(iterations),
+        })
       )
     );
 
@@ -637,7 +447,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('keeps property aggregate computations consistent during concurrent updates and deletes', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const fixture = createPropertyAggregateFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
@@ -658,37 +467,24 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
       }));
     }
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     const chunks = [orders.slice(0, 8), orders.slice(8, 16), orders.slice(16, 24)];
     await Promise.all(
       chunks.map((chunk, workerIndex) =>
-        execFileAsync(process.execPath, ['--import', 'tsx', workerPath], {
-          env: {
-            ...process.env,
-            INTERAQT_POSTGRES_DATABASE: database,
-            INTERAQT_POSTGRES_WORKER_MODE: 'property-aggregate-update',
-            INTERAQT_POSTGRES_ORDER_IDS: JSON.stringify(chunk.map(order => order.id)),
-            INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
-          },
-          maxBuffer: 1024 * 1024,
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_WORKER_MODE: 'property-aggregate-update',
+          INTERAQT_POSTGRES_ORDER_IDS: JSON.stringify(chunk.map(order => order.id)),
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
         })
       )
     );
     await Promise.all(
       chunks.slice(0, 2).map((chunk, workerIndex) =>
-        execFileAsync(process.execPath, ['--import', 'tsx', workerPath], {
-          env: {
-            ...process.env,
-            INTERAQT_POSTGRES_DATABASE: database,
-            INTERAQT_POSTGRES_WORKER_MODE: 'property-aggregate-delete',
-            INTERAQT_POSTGRES_ORDER_IDS: JSON.stringify(chunk.map(order => order.id)),
-            INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
-          },
-          maxBuffer: 1024 * 1024,
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_WORKER_MODE: 'property-aggregate-delete',
+          INTERAQT_POSTGRES_ORDER_IDS: JSON.stringify(chunk.map(order => order.id)),
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
         })
       )
     );
@@ -722,7 +518,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('serializes concurrent state machine transitions across worker processes', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const fixture = createStateMachineFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
@@ -737,28 +532,15 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
     const order = await system.storage.create('PgStateOrder', { title: 'state-order' });
     await system.destroy();
 
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
-
     await Promise.all(
       ['approve', 'reject'].map((action, workerIndex) =>
-        execFileAsync(
-          process.execPath,
-          ['--import', 'tsx', workerPath],
-          {
-            env: {
-              ...process.env,
-              INTERAQT_POSTGRES_DATABASE: database,
-              INTERAQT_POSTGRES_WORKER_MODE: 'state-machine',
-              INTERAQT_POSTGRES_ORDER_ID: String(order.id),
-              INTERAQT_POSTGRES_STATE_ACTION: action,
-              INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
-            },
-            maxBuffer: 1024 * 1024,
-          }
-        )
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_WORKER_MODE: 'state-machine',
+          INTERAQT_POSTGRES_ORDER_ID: String(order.id),
+          INTERAQT_POSTGRES_STATE_ACTION: action,
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
+        })
       )
     );
 
@@ -783,7 +565,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('keeps transform mapped records aligned during concurrent source updates', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const fixture = createTransformFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
@@ -796,28 +577,15 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
     await controller.setup(true);
     const source = await system.storage.create('PgTransformSource', { items: 2 });
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     await Promise.all(
       Array.from({ length: 4 }, (_, workerIndex) =>
-        execFileAsync(
-          process.execPath,
-          ['--import', 'tsx', workerPath],
-          {
-            env: {
-              ...process.env,
-              INTERAQT_POSTGRES_DATABASE: database,
-              INTERAQT_POSTGRES_WORKER_MODE: 'transform',
-              INTERAQT_POSTGRES_SOURCE_ID: String(source.id),
-              INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
-              INTERAQT_POSTGRES_ITERATIONS: '6',
-            },
-            maxBuffer: 1024 * 1024,
-          }
-        )
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_WORKER_MODE: 'transform',
+          INTERAQT_POSTGRES_SOURCE_ID: String(source.id),
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
+          INTERAQT_POSTGRES_ITERATIONS: '6',
+        })
       )
     );
 
@@ -844,7 +612,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('keeps transform mapped records aligned during concurrent update/delete and installs unique index', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const fixture = createTransformFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
@@ -874,32 +641,19 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
       [transformIndexKey!]: mappedBefore[transformIndexKey!],
     })).rejects.toThrow();
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     await Promise.all([
-      execFileAsync(process.execPath, ['--import', 'tsx', workerPath], {
-        env: {
-          ...process.env,
-          INTERAQT_POSTGRES_DATABASE: database,
-          INTERAQT_POSTGRES_WORKER_MODE: 'transform',
-          INTERAQT_POSTGRES_SOURCE_ID: String(source.id),
-          INTERAQT_POSTGRES_WORKER_INDEX: '10',
-          INTERAQT_POSTGRES_ITERATIONS: '6',
-        },
-        maxBuffer: 1024 * 1024,
+      execWorker({
+        INTERAQT_POSTGRES_DATABASE: database,
+        INTERAQT_POSTGRES_WORKER_MODE: 'transform',
+        INTERAQT_POSTGRES_SOURCE_ID: String(source.id),
+        INTERAQT_POSTGRES_WORKER_INDEX: '10',
+        INTERAQT_POSTGRES_ITERATIONS: '6',
       }),
-      execFileAsync(process.execPath, ['--import', 'tsx', workerPath], {
-        env: {
-          ...process.env,
-          INTERAQT_POSTGRES_DATABASE: database,
-          INTERAQT_POSTGRES_WORKER_MODE: 'transform-delete',
-          INTERAQT_POSTGRES_SOURCE_ID: String(source.id),
-          INTERAQT_POSTGRES_WORKER_DELAY: '20',
-        },
-        maxBuffer: 1024 * 1024,
+      execWorker({
+        INTERAQT_POSTGRES_DATABASE: database,
+        INTERAQT_POSTGRES_WORKER_MODE: 'transform-delete',
+        INTERAQT_POSTGRES_SOURCE_ID: String(source.id),
+        INTERAQT_POSTGRES_WORKER_DELAY: '20',
       }),
     ]);
 
@@ -926,8 +680,7 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('handles the same PostgreSQL async task once across worker processes', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
-    const fixture = createAsyncReturnWorkerFixture();
+    const fixture = createAsyncReturnFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
     const controller = new Controller({
@@ -950,27 +703,14 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
       result: 31,
     });
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     await Promise.all(
       [1, 2].map(workerIndex =>
-        execFileAsync(
-          process.execPath,
-          ['--import', 'tsx', workerPath],
-          {
-            env: {
-              ...process.env,
-              INTERAQT_POSTGRES_DATABASE: database,
-              INTERAQT_POSTGRES_WORKER_MODE: 'async-return',
-              INTERAQT_POSTGRES_TASK_ID: String(task.id),
-              INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex),
-            },
-            maxBuffer: 1024 * 1024,
-          }
-        )
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_WORKER_MODE: 'async-return',
+          INTERAQT_POSTGRES_TASK_ID: String(task.id),
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex),
+        })
       )
     );
 
@@ -992,8 +732,7 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('skips stale async tasks when a newer dispatch wins concurrently', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
-    const fixture = createAsyncReturnWorkerFixture();
+    const fixture = createAsyncReturnFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
     const controller = new Controller({
@@ -1015,20 +754,11 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
       status: 'success',
       result: 11,
     });
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
-    const oldWorker = execFileAsync(process.execPath, ['--import', 'tsx', workerPath], {
-      env: {
-        ...process.env,
-        INTERAQT_POSTGRES_DATABASE: database,
-        INTERAQT_POSTGRES_WORKER_MODE: 'async-return',
-        INTERAQT_POSTGRES_TASK_ID: String(oldTask.id),
-        INTERAQT_POSTGRES_WORKER_DELAY: '30',
-      },
-      maxBuffer: 1024 * 1024,
+    const oldWorker = execWorker({
+      INTERAQT_POSTGRES_DATABASE: database,
+      INTERAQT_POSTGRES_WORKER_MODE: 'async-return',
+      INTERAQT_POSTGRES_TASK_ID: String(oldTask.id),
+      INTERAQT_POSTGRES_WORKER_DELAY: '30',
     });
     const dispatchResult = await controller.dispatch(fixture.AddSource, {
       user: { id: 'pg-async-dispatch-user' },
@@ -1053,7 +783,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('retries real PostgreSQL serialization failures and deadlocks', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const db = new PostgreSQLDB(database, dbOptions);
     await db.open(true);
 
@@ -1101,7 +830,6 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('keeps entity and relation full replace equivalent to a serial order across worker processes', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
     const fixture = createFullReplaceFixture();
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
@@ -1121,20 +849,11 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
       await system.storage.create('PgReplaceRight', { name: 'right-2' }),
     ];
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     await Promise.all([1, 2].map(workerIndex =>
-      execFileAsync(process.execPath, ['--import', 'tsx', workerPath], {
-        env: {
-          ...process.env,
-          INTERAQT_POSTGRES_DATABASE: database,
-          INTERAQT_POSTGRES_WORKER_MODE: 'full-replace-entity',
-          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex),
-        },
-        maxBuffer: 1024 * 1024,
+      execWorker({
+        INTERAQT_POSTGRES_DATABASE: database,
+        INTERAQT_POSTGRES_WORKER_MODE: 'full-replace-entity',
+        INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex),
       })
     ));
 
@@ -1159,31 +878,15 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
   }, 120000);
 
   test('keeps global summation consistent across worker processes', async () => {
-    const database = process.env.INTERAQT_POSTGRES_DATABASE!;
-    const counterEntity = Entity.create({
-      name: 'PgAtomicCounter',
-      properties: [
-        Property.create({ name: 'value', type: 'number' }),
-      ],
-    });
-
-    const totalDictionary = Dictionary.create({
-      name: 'pgAtomicTotal',
-      type: 'number',
-      collection: false,
-      computation: Summation.create({
-        record: counterEntity,
-        attributeQuery: ['value'],
-      }),
-    });
+    const fixture = createGlobalSummationFixture();
 
     const system = new MonoSystem(new PostgreSQLDB(database, dbOptions));
     system.conceptClass = KlassByName;
     const controller = new Controller({
       system,
-      entities: [counterEntity],
-      relations: [],
-      dict: [totalDictionary],
+      entities: fixture.entities,
+      relations: fixture.relations,
+      dict: fixture.dict,
     });
 
     await controller.setup(true);
@@ -1193,30 +896,17 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
       counters.push(await system.storage.create('PgAtomicCounter', { value: 0 }));
     }
     await system.destroy();
-
-    const workerPath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      'helpers/postgresConcurrencyWorker.ts'
-    );
     const workerCount = 4;
     const iterations = 20;
 
     await Promise.all(
       Array.from({ length: workerCount }, (_, workerIndex) =>
-        execFileAsync(
-          process.execPath,
-          ['--import', 'tsx', workerPath],
-          {
-            env: {
-              ...process.env,
-              INTERAQT_POSTGRES_DATABASE: database,
-              INTERAQT_POSTGRES_COUNTER_IDS: JSON.stringify(counters.map(counter => counter.id)),
-              INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
-              INTERAQT_POSTGRES_ITERATIONS: String(iterations),
-            },
-            maxBuffer: 1024 * 1024,
-          }
-        )
+        execWorker({
+          INTERAQT_POSTGRES_DATABASE: database,
+          INTERAQT_POSTGRES_COUNTER_IDS: JSON.stringify(counters.map(counter => counter.id)),
+          INTERAQT_POSTGRES_WORKER_INDEX: String(workerIndex + 1),
+          INTERAQT_POSTGRES_ITERATIONS: String(iterations),
+        })
       )
     );
 
@@ -1224,9 +914,9 @@ describeIfPostgres('PostgreSQL computation concurrency', () => {
     verifySystem.conceptClass = KlassByName;
     const verifyController = new Controller({
       system: verifySystem,
-      entities: [counterEntity],
-      relations: [],
-      dict: [totalDictionary],
+      entities: fixture.entities,
+      relations: fixture.relations,
+      dict: fixture.dict,
     });
     await verifyController.setup(false);
 

--- a/tests/storage/deepAnalysisSection3Fixes.spec.ts
+++ b/tests/storage/deepAnalysisSection3Fixes.spec.ts
@@ -1,0 +1,977 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+    AttributeQuery,
+    DBSetup,
+    EntityQueryHandle,
+    EntityToTableMap,
+    MatchExp,
+    NewRecordData,
+    RecordQuery,
+    RecordQueryAgent
+} from "@storage";
+import { BoolExp, Entity, Property, Relation } from '@core';
+import { RecordMutationEvent } from "@runtime";
+import { PGLiteDB } from '@drivers';
+
+/**
+ * 回归测试：覆盖 agentspace/output/storage-package-deep-analysis.md
+ * 章节《三、其他显著值得改进的地方》中的全部修复。
+ */
+
+// 遍历 BoolExp 树，统计 key 出现的原子个数
+function countAtomsWithKey(expression: any, key: string): number {
+    if (!expression) return 0
+    const boolExp = expression instanceof BoolExp ? expression : BoolExp.fromValue(expression)
+    if (boolExp.isAtom()) {
+        return (boolExp.data as { key: string }).key === key ? 1 : 0
+    }
+    let count = 0
+    if (boolExp.left) count += countAtomsWithKey(boolExp.left, key)
+    if (boolExp.right) count += countAtomsWithKey(boolExp.right, key)
+    return count
+}
+
+// 给 db.query 打补丁，记录所有执行的 (sql, name)
+function recordQueries(db: PGLiteDB): { sql: string, name: string }[] {
+    const recorded: { sql: string, name: string }[] = []
+    const originalQuery = db.query.bind(db);
+    (db as any).query = async (sql: string, params: unknown[] = [], name = '') => {
+        recorded.push({ sql, name })
+        return originalQuery(sql, params, name)
+    }
+    return recorded
+}
+
+describe('3.1.1 dead code removal: Setup.resolveBaseSourceEntityAndFilter', () => {
+    test('method no longer exists on DBSetup', () => {
+        expect((DBSetup.prototype as any).resolveBaseSourceEntityAndFilter).toBeUndefined()
+    })
+})
+
+describe('3.1 fixes that need a live database', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let handle: EntityQueryHandle
+
+    const createSchema = () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'age', type: 'number' }),
+                Property.create({ name: 'isActive', type: 'boolean' })
+            ]
+        })
+        const teamEntity = Entity.create({
+            name: 'Team',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'type', type: 'string' })
+            ]
+        })
+        const profileEntity = Entity.create({
+            name: 'Profile',
+            properties: [
+                Property.create({ name: 'title', type: 'string' })
+            ]
+        })
+        const userTeamRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'team',
+            target: teamEntity,
+            targetProperty: 'members',
+            type: 'n:1'
+        })
+        const userProfileRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'profile',
+            target: profileEntity,
+            targetProperty: 'owner',
+            type: '1:1',
+            isTargetReliance: true
+        })
+        // 谓词同时包含 base 自身属性和跨实体属性
+        const activeTechUserEntity = Entity.create({
+            name: 'ActiveTechUser',
+            baseEntity: userEntity,
+            matchExpression: MatchExp.atom({
+                key: 'isActive',
+                value: ['=', true]
+            }).and({
+                key: 'team.type',
+                value: ['=', 'tech']
+            })
+        })
+        return {
+            entities: [userEntity, teamEntity, profileEntity, activeTechUserEntity],
+            relations: [userTeamRelation, userProfileRelation]
+        }
+    }
+
+    beforeEach(async () => {
+        const { entities, relations } = createSchema()
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup(entities, relations, db)
+        await setup.createTables()
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('3.1.2 dependency is registered exactly once under the base entity name', () => {
+        const filteredEntityManager = (handle.agent as any).filteredEntityManager
+        const userDependencies = filteredEntityManager.getAffectedFilteredEntities('User')
+            .filter((dep: any) => dep.filteredEntityName === 'ActiveTechUser')
+        // 修复前：谓词包含 base 自身属性时，同一个 dependency 会在 'User' 名下注册两次，
+        // 导致每次 update 做双倍的 membership 查询。
+        expect(userDependencies.length).toBe(1)
+
+        // 跨实体依赖（Team）也只注册一次
+        const teamDependencies = filteredEntityManager.getAffectedFilteredEntities('Team')
+            .filter((dep: any) => dep.filteredEntityName === 'ActiveTechUser')
+        expect(teamDependencies.length).toBe(1)
+    })
+
+    test('3.1.2 duplicate registration removal does not duplicate membership events', async () => {
+        const team = await handle.create('Team', { name: 'Engineering', type: 'tech' })
+        const user = await handle.create('User', { name: 'Alice', age: 30, isActive: false, team })
+
+        const events: RecordMutationEvent[] = []
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), { isActive: true }, events)
+
+        const filteredCreateEvents = events.filter(e => e.type === 'create' && e.recordName === 'ActiveTechUser')
+        expect(filteredCreateEvents.length).toBe(1)
+    })
+
+    test('3.1.3 merged preprocessSameRowData: update path still produces correct update event', async () => {
+        const user = await handle.create('User', { name: 'Bob', age: 20, isActive: true })
+
+        const events: RecordMutationEvent[] = []
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), { age: 21 }, events)
+
+        const updateEvents = events.filter(e => e.type === 'update' && e.recordName === 'User')
+        expect(updateEvents.length).toBe(1)
+        expect(updateEvents[0].record!.age).toBe(21)
+        expect(updateEvents[0].record!.id).toBe(user.id)
+        // oldRecord 携带更新前的值属性
+        expect(updateEvents[0].oldRecord!.age).toBe(20)
+        expect(updateEvents[0].oldRecord!.name).toBe('Bob')
+    })
+
+    test('3.1.3 merged preprocessSameRowData: agent delegation handles update branch (id assignment + update event)', async () => {
+        const user = await handle.create('User', { name: 'Carl', age: 40, isActive: true })
+        const oldRecord = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), {}, ['*'])
+
+        const events: RecordMutationEvent[] = []
+        // 直接调用 agent 上的方法（历史上这里是第二份复制的实现）
+        const newData = new NewRecordData(handle.map, 'User', { age: 41 })
+        const processed = await handle.agent.preprocessSameRowData(newData, true, events, oldRecord)
+
+        // update 分支必须从 oldRecord 补上 id
+        expect(processed.getData().id).toBe(user.id)
+        const updateEvents = events.filter(e => e.type === 'update' && e.recordName === 'User')
+        expect(updateEvents.length).toBe(1)
+        expect(updateEvents[0].record!.id).toBe(user.id)
+        expect(updateEvents[0].oldRecord!.age).toBe(40)
+    })
+
+    test('3.1.4 deletion events are grouped structurally: record delete events always come last', async () => {
+        const team = await handle.create('Team', { name: 'T1', type: 'tech' })
+        await handle.create('User', { name: 'D1', age: 1, isActive: true, team, profile: { title: 'p1' } })
+        await handle.create('User', { name: 'D2', age: 2, isActive: true, team, profile: { title: 'p2' } })
+
+        const events: RecordMutationEvent[] = []
+        await handle.delete('User', MatchExp.atom({ key: 'age', value: ['<', 10] }), events)
+
+        const userDeleteIndexes = events
+            .map((e, i) => (e.type === 'delete' && e.recordName === 'User') ? i : -1)
+            .filter(i => i >= 0)
+        expect(userDeleteIndexes.length).toBe(2)
+
+        // 所有非 User 的事件（link 删除、reliance 级联删除、filtered entity 删除）都在 User 删除事件之前
+        const firstUserDeleteIndex = Math.min(...userDeleteIndexes)
+        const nonUserEventsAfter = events
+            .slice(firstUserDeleteIndex)
+            .filter(e => e.recordName !== 'User')
+        expect(nonUserEventsAfter.length).toBe(0)
+
+        // reliance（Profile）的级联删除事件在 User 删除事件之前
+        const profileDeleteIndexes = events
+            .map((e, i) => (e.type === 'delete' && e.recordName === 'Profile') ? i : -1)
+            .filter(i => i >= 0)
+        expect(profileDeleteIndexes.length).toBe(2)
+        expect(Math.max(...profileDeleteIndexes)).toBeLessThan(firstUserDeleteIndex)
+
+        // 关系删除事件也在 User 删除事件之前
+        const linkDeleteEvents = events.filter(e => e.type === 'delete' && e.recordName.includes('_team_'))
+        expect(linkDeleteEvents.length).toBe(2)
+        events.forEach((e, i) => {
+            if (e.type === 'delete' && e.recordName.includes('_team_')) {
+                expect(i).toBeLessThan(firstUserDeleteIndex)
+            }
+        })
+    })
+
+    test('3.1.6 in with empty array is always false instead of invalid SQL', async () => {
+        await handle.create('User', { name: 'E1', age: 1, isActive: true })
+        await handle.create('User', { name: 'E2', age: 2, isActive: true })
+
+        // 空数组 ⇒ 恒 false，不产生 `IN ()` 非法 SQL
+        const noneMatched = await handle.find('User', MatchExp.atom({ key: 'name', value: ['in', []] }), {}, ['name'])
+        expect(noneMatched.length).toBe(0)
+
+        // 外层 NOT 下语义正确：NOT(恒 false) = 恒 true
+        const allMatched = await handle.find('User', MatchExp.atom({ key: 'name', value: ['in', []] }).not(), {}, ['name'])
+        expect(allMatched.length).toBe(2)
+
+        // 非空数组行为不变
+        const oneMatched = await handle.find('User', MatchExp.atom({ key: 'name', value: ['in', ['E1']] }), {}, ['name'])
+        expect(oneMatched.length).toBe(1)
+        expect(oneMatched[0].name).toBe('E1')
+    })
+
+    test('3.1.6 in with non-array value throws a clear error', async () => {
+        await expect(
+            handle.find('User', MatchExp.atom({ key: 'name', value: ['in', 'notAnArray'] }), {}, ['name'])
+        ).rejects.toThrow(/'in' requires an array value/)
+    })
+
+    test("3.1.6 'not' with non-null value throws instead of generating invalid SQL", async () => {
+        await handle.create('User', { name: 'N1', age: 1, isActive: true })
+        await expect(
+            handle.find('User', MatchExp.atom({ key: 'name', value: ['not', 'N1'] }), {}, ['name'])
+        ).rejects.toThrow(/'not' only supports null/)
+
+        // ['not', null]（IS NOT NULL）行为不变
+        const found = await handle.find('User', MatchExp.atom({ key: 'name', value: ['not', null] }), {}, ['name'])
+        expect(found.length).toBe(1)
+    })
+
+    test('3.1.7 NULL __filtered_entities does not crash flag update', async () => {
+        const team = await handle.create('Team', { name: 'T2', type: 'tech' })
+        const user = await handle.create('User', { name: 'F1', age: 5, isActive: false, team })
+
+        // 模拟存量数据/手工迁移：把 __filtered_entities 置为 NULL
+        const flagsField = (setup.map.records['User'].attributes['__filtered_entities'] as any).field
+        const table = setup.map.records['User'].table
+        await db.query(`UPDATE "${table}" SET "${flagsField}" = NULL`, [])
+
+        const events: RecordMutationEvent[] = []
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), { isActive: true }, events)
+
+        const filteredCreateEvents = events.filter(e => e.type === 'create' && e.recordName === 'ActiveTechUser')
+        expect(filteredCreateEvents.length).toBe(1)
+
+        // 标记被正确重建
+        const updated = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), {}, ['*'])
+        expect(updated.__filtered_entities['ActiveTechUser']).toBe(true)
+    })
+})
+
+describe('3.1.5 name format enforcement', () => {
+    test('Entity.create rejects invalid names', () => {
+        expect(() => Entity.create({ name: 'Bad Name', properties: [] })).toThrow(/invalid/)
+        expect(() => Entity.create({ name: 'Bad"; DROP TABLE users;--', properties: [] })).toThrow(/invalid/)
+        expect(() => Entity.create({ name: 'Bad-Name', properties: [] })).toThrow(/invalid/)
+        expect(() => Entity.create({ name: '', properties: [] })).toThrow(/invalid/)
+        // 合法名字不受影响
+        expect(() => Entity.create({ name: 'Good_Name_1', properties: [] })).not.toThrow()
+    })
+
+    test('Relation.create rejects invalid explicit names and property names', () => {
+        const a = Entity.create({ name: 'RelNameCheckA', properties: [] })
+        const b = Entity.create({ name: 'RelNameCheckB', properties: [] })
+        expect(() => Relation.create({
+            name: 'bad relation name',
+            source: a, sourceProperty: 'b', target: b, targetProperty: 'a', type: 'n:1'
+        })).toThrow(/invalid/)
+        expect(() => Relation.create({
+            source: a, sourceProperty: 'bad prop', target: b, targetProperty: 'a', type: 'n:1'
+        })).toThrow(/invalid/)
+        expect(() => Relation.create({
+            source: a, sourceProperty: 'b', target: b, targetProperty: 'bad prop', type: 'n:1'
+        })).toThrow(/invalid/)
+        expect(() => Relation.create({
+            source: a, sourceProperty: 'b', target: b, targetProperty: 'a', type: 'n:1'
+        })).not.toThrow()
+    })
+
+    test('DBSetup boundary rejects invalid names even when Klass factory is bypassed', () => {
+        // 绕过 Entity.create 直接构造实例
+        const bad = new (Entity as any)({ name: 'Bad Name', properties: [] })
+        expect(() => new DBSetup([bad], [])).toThrow(/invalid/)
+    })
+})
+
+describe('3.2.1 update pre-query trimming', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let handle: EntityQueryHandle
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'age', type: 'number' })
+            ]
+        })
+        const profileEntity = Entity.create({
+            name: 'Profile',
+            properties: [
+                Property.create({ name: 'title', type: 'string' })
+            ]
+        })
+        const itemEntity = Entity.create({
+            name: 'Item',
+            properties: [
+                Property.create({ name: 'itemName', type: 'string' })
+            ]
+        })
+        // profile：普通 1:1（可以在 update 中替换）；item：1:1 reliance（三表合一，字段在同一行）
+        const userProfileRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'profile',
+            target: profileEntity,
+            targetProperty: 'owner',
+            type: '1:1'
+        })
+        const userItemRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'item',
+            target: itemEntity,
+            targetProperty: 'owner',
+            type: '1:1',
+            isTargetReliance: true
+        })
+
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup([userEntity, profileEntity, itemEntity], [userProfileRelation, userItemRelation], db)
+        await setup.createTables()
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    const getProfileLinkField = () => {
+        const linkName = handle.getRelationName('User', 'profile')
+        return (setup.map.records[linkName].attributes['target'] as any).field as string
+    }
+
+    test('updating only value attributes does not fetch unrelated relation/reliance data', async () => {
+        const user = await handle.create('User', {
+            name: 'U1', age: 10,
+            profile: { title: 'p' },
+            item: { itemName: 'i' }
+        })
+
+        const recorded = recordQueries(db)
+        const events: RecordMutationEvent[] = []
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), { age: 11 }, events)
+
+        const preQuery = recorded.find(q => q.name.includes('find record for updating User'))
+        expect(preQuery).toBeDefined()
+
+        // 未涉及的 reliance（Item，三表合一）字段不应出现在前置查询中
+        const itemNameField = (setup.map.records['Item'].attributes['itemName'] as any).field
+        expect(preQuery!.sql).not.toContain(itemNameField)
+        // 未涉及的合并关系（profile）的 link 字段也不应出现
+        expect(preQuery!.sql).not.toContain(getProfileLinkField())
+
+        // 值属性仍然全部保留（update 事件的 oldRecord 需要）
+        const userNameField = (setup.map.records['User'].attributes['name'] as any).field
+        expect(preQuery!.sql).toContain(userNameField)
+        const updateEvent = events.find(e => e.type === 'update' && e.recordName === 'User')!
+        expect(updateEvent.oldRecord!.name).toBe('U1')
+        expect(updateEvent.oldRecord!.age).toBe(10)
+    })
+
+    test('updating a relation attribute still fetches that relation and replaces it correctly', async () => {
+        const user = await handle.create('User', {
+            name: 'U2', age: 20,
+            profile: { title: 'old' },
+            item: { itemName: 'keep' }
+        })
+        const newProfile = await handle.create('Profile', { title: 'new' })
+
+        const recorded = recordQueries(db)
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), {
+            profile: { id: newProfile.id }
+        })
+
+        const preQuery = recorded.find(q => q.name.includes('find record for updating User'))!
+        // 涉及的 profile 关系字段必须在前置查询中（unlink 判断需要）
+        expect(preQuery.sql).toContain(getProfileLinkField())
+        // 未涉及的 item 字段不在
+        const itemNameField = (setup.map.records['Item'].attributes['itemName'] as any).field
+        expect(preQuery.sql).not.toContain(itemNameField)
+
+        const updated = await handle.findOne(
+            'User',
+            MatchExp.atom({ key: 'id', value: ['=', user.id] }),
+            {},
+            ['name', ['profile', { attributeQuery: ['title'] }], ['item', { attributeQuery: ['itemName'] }]]
+        )
+        expect(updated.profile.title).toBe('new')
+        // 未涉及的关系不受影响
+        expect(updated.item.itemName).toBe('keep')
+    })
+})
+
+describe('3.2.2 batched x:n related record queries', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let handle: EntityQueryHandle
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' })
+            ]
+        })
+        const postEntity = Entity.create({
+            name: 'Post',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'seq', type: 'number' })
+            ]
+        })
+        const tagEntity = Entity.create({
+            name: 'Tag',
+            properties: [
+                Property.create({ name: 'tagName', type: 'string' })
+            ]
+        })
+        const userPostRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'posts',
+            target: postEntity,
+            targetProperty: 'author',
+            type: '1:n',
+            properties: [
+                Property.create({ name: 'pinned', type: 'boolean' })
+            ]
+        })
+        const userTagRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'tags',
+            target: tagEntity,
+            targetProperty: 'users',
+            type: 'n:n'
+        })
+
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup([userEntity, postEntity, tagEntity], [userPostRelation, userTagRelation], db)
+        await setup.createTables()
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('1:n related records are fetched with one query per batch and correctly grouped', async () => {
+        const u1 = await handle.create('User', { name: 'A' })
+        const u2 = await handle.create('User', { name: 'B' })
+        const u3 = await handle.create('User', { name: 'C' })
+        await handle.create('Post', { title: 'a1', seq: 1, author: u1 })
+        await handle.create('Post', { title: 'a2', seq: 2, author: u1 })
+        await handle.create('Post', { title: 'b1', seq: 3, author: u2 })
+        // u3 没有 post
+
+        const recorded = recordQueries(db)
+        const users = await handle.find('User', undefined, { orderBy: { name: 'ASC' } }, [
+            'name',
+            ['posts', { attributeQuery: ['title', 'seq'], modifier: { orderBy: { seq: 'ASC' } } }]
+        ])
+
+        // 1 次根查询 + 1 次批量子查询（修复前是 1 + 每个父记录 1 次 = 4 次）
+        expect(recorded.length).toBe(2)
+
+        expect(users.length).toBe(3)
+        expect(users[0].posts.map((p: any) => p.title)).toEqual(['a1', 'a2'])
+        expect(users[1].posts.map((p: any) => p.title)).toEqual(['b1'])
+        // 没有子记录的父记录必须得到空数组
+        expect(users[2].posts).toEqual([])
+    })
+
+    test('batched 1:n query keeps relation (&) data semantics', async () => {
+        const u1 = await handle.create('User', { name: 'A' })
+        const u2 = await handle.create('User', { name: 'B' })
+        await handle.create('Post', { title: 'a1', seq: 1, author: u1 })
+        await handle.addRelationById('User', 'posts', u2.id, (await handle.create('Post', { title: 'b1', seq: 2 })).id, { pinned: true })
+
+        const users = await handle.find('User', undefined, { orderBy: { name: 'ASC' } }, [
+            'name',
+            ['posts', { attributeQuery: ['title', ['&', { attributeQuery: ['pinned'] }]] }]
+        ])
+
+        expect(users[0].posts.length).toBe(1)
+        expect(users[0].posts[0]['&']).toBeDefined()
+        expect(users[1].posts.length).toBe(1)
+        expect(users[1].posts[0]['&'].pinned).toBe(true)
+        // 临时用于分组的反向属性不应泄漏到结果里
+        expect(users[0].posts[0].author).toBeUndefined()
+        expect(users[1].posts[0].author).toBeUndefined()
+    })
+
+    test('per-parent limit falls back to per-record queries with correct semantics', async () => {
+        const u1 = await handle.create('User', { name: 'A' })
+        const u2 = await handle.create('User', { name: 'B' })
+        await handle.create('Post', { title: 'a1', seq: 1, author: u1 })
+        await handle.create('Post', { title: 'a2', seq: 2, author: u1 })
+        await handle.create('Post', { title: 'b1', seq: 3, author: u2 })
+        await handle.create('Post', { title: 'b2', seq: 4, author: u2 })
+
+        const users = await handle.find('User', undefined, { orderBy: { name: 'ASC' } }, [
+            'name',
+            ['posts', { attributeQuery: ['title'], modifier: { limit: 1, orderBy: { seq: 'ASC' } } }]
+        ])
+
+        // limit 是 per-parent 语义，每个父记录都限制 1 条
+        expect(users[0].posts.map((p: any) => p.title)).toEqual(['a1'])
+        expect(users[1].posts.map((p: any) => p.title)).toEqual(['b1'])
+    })
+
+    test('n:n related records keep per-record query path and stay correct', async () => {
+        const u1 = await handle.create('User', { name: 'A' })
+        const u2 = await handle.create('User', { name: 'B' })
+        const t1 = await handle.create('Tag', { tagName: 't1' })
+        const t2 = await handle.create('Tag', { tagName: 't2' })
+        await handle.addRelationById('User', 'tags', u1.id, t1.id)
+        await handle.addRelationById('User', 'tags', u1.id, t2.id)
+        await handle.addRelationById('User', 'tags', u2.id, t2.id)
+
+        const users = await handle.find('User', undefined, { orderBy: { name: 'ASC' } }, [
+            'name',
+            ['tags', { attributeQuery: ['tagName'] }]
+        ])
+
+        expect(users[0].tags.map((t: any) => t.tagName).sort()).toEqual(['t1', 't2'])
+        expect(users[1].tags.map((t: any) => t.tagName)).toEqual(['t2'])
+    })
+
+    test('user-requested reverse attribute in subquery is preserved when batching', async () => {
+        const u1 = await handle.create('User', { name: 'A' })
+        const u2 = await handle.create('User', { name: 'B' })
+        await handle.create('Post', { title: 'a1', seq: 1, author: u1 })
+        await handle.create('Post', { title: 'b1', seq: 2, author: u2 })
+
+        const users = await handle.find('User', undefined, { orderBy: { name: 'ASC' } }, [
+            'name',
+            ['posts', { attributeQuery: ['title', ['author', { attributeQuery: ['name'] }]] }]
+        ])
+
+        expect(users[0].posts[0].author.name).toBe('A')
+        expect(users[1].posts[0].author.name).toBe('B')
+    })
+})
+
+describe('3.2.3 batched filtered entity flag maintenance', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let handle: EntityQueryHandle
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' })
+            ]
+        })
+        const teamEntity = Entity.create({
+            name: 'Team',
+            properties: [
+                Property.create({ name: 'type', type: 'string' })
+            ]
+        })
+        const userTeamRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'team',
+            target: teamEntity,
+            targetProperty: 'members',
+            type: 'n:1'
+        })
+        const techTeamUserEntity = Entity.create({
+            name: 'TechTeamUser',
+            baseEntity: userEntity,
+            matchExpression: MatchExp.atom({
+                key: 'team.type',
+                value: ['=', 'tech']
+            })
+        })
+
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup([userEntity, teamEntity, techTeamUserEntity], [userTeamRelation], db)
+        await setup.createTables()
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('one flags query + one membership query per dependency when many records are affected', async () => {
+        const team = await handle.create('Team', { type: 'sales' })
+        const users = []
+        for (let i = 0; i < 3; i++) {
+            users.push(await handle.create('User', { name: `U${i}`, team }))
+        }
+
+        const recorded = recordQueries(db)
+        const events: RecordMutationEvent[] = []
+        await handle.update('Team', MatchExp.atom({ key: 'id', value: ['=', team.id] }), { type: 'tech' }, events)
+
+        // 所有受影响的 user 都产生 filtered entity create 事件
+        const filteredCreateEvents = events.filter(e => e.type === 'create' && e.recordName === 'TechTeamUser')
+        expect(filteredCreateEvents.length).toBe(3)
+        expect(new Set(filteredCreateEvents.map(e => e.record!.id))).toEqual(new Set(users.map(u => u.id)))
+
+        // 批量化：取当前标记 1 次查询（修复前是每条受影响记录 1 次）
+        const flagQueries = recorded.filter(q => q.name.includes('get current filtered entity flags'))
+        expect(flagQueries.length).toBe(1)
+        // membership 检查 1 次查询（修复前是每条受影响记录 1 次）
+        const membershipQueries = recorded.filter(q => q.name.includes('match filter condition'))
+        expect(membershipQueries.length).toBe(1)
+
+        // 标记全部正确持久化
+        const techUsers = await handle.find('TechTeamUser', undefined, {}, ['name'])
+        expect(techUsers.length).toBe(3)
+    })
+
+    test('membership leave events are generated for all affected records', async () => {
+        const team = await handle.create('Team', { type: 'tech' })
+        for (let i = 0; i < 3; i++) {
+            await handle.create('User', { name: `U${i}`, team })
+        }
+
+        const events: RecordMutationEvent[] = []
+        await handle.update('Team', MatchExp.atom({ key: 'id', value: ['=', team.id] }), { type: 'sales' }, events)
+
+        const filteredDeleteEvents = events.filter(e => e.type === 'delete' && e.recordName === 'TechTeamUser')
+        expect(filteredDeleteEvents.length).toBe(3)
+
+        const techUsers = await handle.find('TechTeamUser', undefined, {}, ['name'])
+        expect(techUsers.length).toBe(0)
+    })
+})
+
+describe('3.2.4 runtime table alias fallback beyond pregenerated depth', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let handle: EntityQueryHandle
+    let map: EntityToTableMap
+    // 两个仅在超过 63 字节截断点之后才不同的长属性名（PG 截断后会碰撞）
+    const longAttrA = 'branch_' + 'x'.repeat(56) + '_a'
+    const longAttrB = 'branch_' + 'x'.repeat(56) + '_b'
+
+    beforeEach(async () => {
+        // 链：C0 -l1-> C1 -l2-> C2 -l3-> C3 -l4-> C4 -l5-> C5，然后 C5 上有两个长名分支
+        const entities = []
+        for (let i = 0; i <= 5; i++) {
+            entities.push(Entity.create({
+                name: `Chain${i}`,
+                properties: [Property.create({ name: 'name', type: 'string' })]
+            }))
+        }
+        const branchA = Entity.create({ name: 'BranchA', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const branchB = Entity.create({ name: 'BranchB', properties: [Property.create({ name: 'name', type: 'string' })] })
+
+        const relations = []
+        for (let i = 0; i < 5; i++) {
+            relations.push(Relation.create({
+                source: entities[i],
+                sourceProperty: `l${i + 1}`,
+                target: entities[i + 1],
+                targetProperty: `r${i + 1}`,
+                type: 'n:1'
+            }))
+        }
+        relations.push(Relation.create({
+            source: entities[5],
+            sourceProperty: longAttrA,
+            target: branchA,
+            targetProperty: 'back',
+            type: 'n:1'
+        }))
+        relations.push(Relation.create({
+            source: entities[5],
+            sourceProperty: longAttrB,
+            target: branchB,
+            targetProperty: 'back',
+            type: 'n:1'
+        }))
+
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup([...entities, branchA, branchB], relations, db)
+        await setup.createTables()
+        map = new EntityToTableMap(setup.map, setup.aliasManager)
+        handle = new EntityQueryHandle(map, db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('deep paths beyond depth 5 get runtime-registered aliases within the 63-char limit', () => {
+        const deepPathA = ['Chain0', 'l1', 'l2', 'l3', 'l4', 'l5', longAttrA]
+        const deepPathB = ['Chain0', 'l1', 'l2', 'l3', 'l4', 'l5', longAttrB]
+
+        const aliasA = map.getTableAndAliasStack(deepPathA).at(-1)!.alias
+        const aliasB = map.getTableAndAliasStack(deepPathB).at(-1)!.alias
+
+        // 别名必须在 PG 的 63 字节限制内（修复前落回原始长名，PG 会静默截断）
+        expect(aliasA.length).toBeLessThanOrEqual(63)
+        expect(aliasB.length).toBeLessThanOrEqual(63)
+        // 两条长路径截断后不能碰撞
+        expect(aliasA).not.toBe(aliasB)
+        // 别名可以解析回原始路径
+        if (aliasA.startsWith('T')) {
+            expect(setup.aliasManager.getTablePath(aliasA)).toBeDefined()
+        }
+    })
+
+    test('deep query across both long branches executes correctly end to end', async () => {
+        const bA = await handle.create('BranchA', { name: 'goalA' })
+        const bB = await handle.create('BranchB', { name: 'goalB' })
+        const c5 = await handle.create('Chain5', { name: 'c5', [longAttrA]: bA, [longAttrB]: bB })
+        const c4 = await handle.create('Chain4', { name: 'c4', l5: c5 })
+        const c3 = await handle.create('Chain3', { name: 'c3', l4: c4 })
+        const c2 = await handle.create('Chain2', { name: 'c2', l3: c3 })
+        const c1 = await handle.create('Chain1', { name: 'c1', l2: c2 })
+        await handle.create('Chain0', { name: 'c0', l1: c1 })
+        // 干扰数据
+        await handle.create('Chain0', { name: 'other' })
+
+        // 同一查询里同时通过两条深度为 6 的长名路径做 match（修复前两个超长别名截断后同名，PG 会报错或产生错误 JOIN）
+        const found = await handle.find(
+            'Chain0',
+            MatchExp.atom({ key: ['l1', 'l2', 'l3', 'l4', 'l5', longAttrA, 'name'].join('.'), value: ['=', 'goalA'] })
+                .and({ key: ['l1', 'l2', 'l3', 'l4', 'l5', longAttrB, 'name'].join('.'), value: ['=', 'goalB'] }),
+            {},
+            ['name']
+        )
+        expect(found.length).toBe(1)
+        expect(found[0].name).toBe('c0')
+    })
+})
+
+describe('3.2.5 / 3.3.1 metadata and dependency analysis caching', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let map: EntityToTableMap
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' })
+            ]
+        })
+        const teamEntity = Entity.create({
+            name: 'Team',
+            properties: [Property.create({ name: 'type', type: 'string' })]
+        })
+        const userTeamRelation = Relation.create({
+            source: userEntity,
+            sourceProperty: 'team',
+            target: teamEntity,
+            targetProperty: 'members',
+            type: 'n:1'
+        })
+        const activeUserEntity = Entity.create({
+            name: 'ActiveUser',
+            baseEntity: userEntity,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] })
+        })
+
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup(
+            [userEntity, teamEntity, activeUserEntity],
+            [userTeamRelation],
+            db
+        )
+        await setup.createTables()
+        map = new EntityToTableMap(setup.map, setup.aliasManager)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('3.2.5 getRecordInfo and getInfoByPath return cached objects on immutable map', () => {
+        expect(map.getRecordInfo('User')).toBe(map.getRecordInfo('User'))
+        expect(map.getInfoByPath(['User', 'team'])).toBe(map.getInfoByPath(['User', 'team']))
+        expect(map.getInfoByPath(['User', 'team', 'type'])).toBe(map.getInfoByPath(['User', 'team', 'type']))
+        // 不同路径仍然是不同对象
+        expect(map.getInfoByPath(['User', 'name'])).not.toBe(map.getInfoByPath(['User', 'team']))
+        // 缓存不改变行为
+        expect(map.getInfoByPath(['User', 'team'])!.isRecord).toBe(true)
+        expect(map.getInfoByPath(['User', 'name'])!.isValue).toBe(true)
+    })
+
+    test('3.3.1 filtered entity dependency analysis is shared across agents on the same map data', () => {
+        const agent1 = new RecordQueryAgent(map, db)
+        const agent2 = new RecordQueryAgent(map, db)
+        // 同一 MapData 的依赖分析结果是共享的（WeakMap 缓存），不会重复计算
+        const deps1 = (agent1 as any).filteredEntityManager.getAffectedFilteredEntities('User')
+        const deps2 = (agent2 as any).filteredEntityManager.getAffectedFilteredEntities('User')
+        expect(deps1.length).toBeGreaterThan(0)
+        expect(deps1).toBe(deps2)
+
+        // 相同 map data 的另一个 EntityToTableMap 实例也共享（缓存 key 是 MapData）
+        const map2 = new EntityToTableMap(setup.map, setup.aliasManager)
+        const agent3 = new RecordQueryAgent(map2, db)
+        const deps3 = (agent3 as any).filteredEntityManager.getAffectedFilteredEntities('User')
+        expect(deps3).toBe(deps1)
+
+        // 依然没有重复注册
+        expect(deps1.filter((d: any) => d.filteredEntityName === 'ActiveUser').length).toBe(1)
+    })
+})
+
+describe('3.3.3 / 3.3.5 AttributeQuery and MatchExp cleanups', () => {
+    let db: PGLiteDB
+    let setup: DBSetup
+    let map: EntityToTableMap
+    let handle: EntityQueryHandle
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' })
+            ]
+        })
+        const activeUserEntity = Entity.create({
+            name: 'ActiveUser',
+            baseEntity: userEntity,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] })
+        })
+
+        db = new PGLiteDB()
+        await db.open()
+        setup = new DBSetup([userEntity, activeUserEntity], [], db)
+        await setup.createTables()
+        map = new EntityToTableMap(setup.map, setup.aliasManager)
+        handle = new EntityQueryHandle(map, db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('3.3.3 AttributeQuery no longer carries a random debug id', () => {
+        const attributeQuery = new AttributeQuery('User', map, ['name'])
+        expect((attributeQuery as any).id).toBeUndefined()
+    })
+
+    test('3.3.5 filtered entity match merging happens exactly once', () => {
+        // 通过 RecordQuery.create 构造：filter 条件只出现一次（由 MatchExp 构造器统一合并）
+        const query = RecordQuery.create('ActiveUser', map, {
+            matchExpression: MatchExp.atom({ key: 'name', value: ['=', 'x'] }),
+            attributeQuery: ['name']
+        })
+        expect(countAtomsWithKey(query.matchExpression.data, 'isActive')).toBe(1)
+        expect(countAtomsWithKey(query.matchExpression.data, 'name')).toBe(1)
+
+        // 直接构造 MatchExp 也一样
+        const matchExp = new MatchExp('ActiveUser', map, MatchExp.atom({ key: 'name', value: ['=', 'x'] }))
+        expect(countAtomsWithKey(matchExp.data, 'isActive')).toBe(1)
+    })
+
+    test('3.3.5 filtered entity queries stay correct end to end', async () => {
+        await handle.create('User', { name: 'a', isActive: true })
+        await handle.create('User', { name: 'a', isActive: false })
+        await handle.create('User', { name: 'b', isActive: true })
+
+        const activeA = await handle.find('ActiveUser', MatchExp.atom({ key: 'name', value: ['=', 'a'] }), {}, ['name', 'isActive'])
+        expect(activeA.length).toBe(1)
+        expect(activeA[0].isActive).toBe(true)
+
+        const allActive = await handle.find('ActiveUser', undefined, {}, ['name'])
+        expect(allActive.length).toBe(2)
+    })
+})
+
+describe('3.3.2 explicit RecordOperationAgent contract between executors', () => {
+    let db: PGLiteDB
+    let handle: EntityQueryHandle
+
+    beforeEach(async () => {
+        const userEntity = Entity.create({
+            name: 'User',
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        })
+        const profileEntity = Entity.create({
+            name: 'Profile',
+            properties: [Property.create({ name: 'title', type: 'string' })]
+        })
+        const groupEntity = Entity.create({
+            name: 'Group',
+            properties: [Property.create({ name: 'groupName', type: 'string' })]
+        })
+        const relations = [
+            Relation.create({
+                source: userEntity,
+                sourceProperty: 'profile',
+                target: profileEntity,
+                targetProperty: 'owner',
+                type: '1:1',
+                isTargetReliance: true
+            }),
+            Relation.create({
+                source: userEntity,
+                sourceProperty: 'group',
+                target: groupEntity,
+                targetProperty: 'members',
+                type: 'n:1'
+            })
+        ]
+
+        db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([userEntity, profileEntity, groupEntity], relations, db)
+        await setup.createTables()
+        handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+    })
+
+    afterEach(async () => {
+        await db.close()
+    })
+
+    test('cross-executor callbacks (create→update→unlink→delete) work through the typed contract', async () => {
+        // create：CreationExecutor 回调 agent.updateRecord / agent.flashOutCombinedRecordsAndMergedLinks
+        const g1 = await handle.create('Group', { groupName: 'g1' })
+        const g2 = await handle.create('Group', { groupName: 'g2' })
+        const user = await handle.create('User', { name: 'u', profile: { title: 't' }, group: g1 })
+
+        // update 替换关系：UpdateExecutor 回调 agent.unlink / agent.addLinkFromRecord / agent.preprocessSameRowData
+        const events: RecordMutationEvent[] = []
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), { group: g2 }, events)
+        const updated = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), {},
+            ['name', ['group', { attributeQuery: ['groupName'] }]])
+        expect(updated.group.groupName).toBe('g2')
+
+        // delete：DeletionExecutor 回调 agent.findRecords，级联删除 reliance
+        const deleteEvents: RecordMutationEvent[] = []
+        await handle.delete('User', MatchExp.atom({ key: 'id', value: ['=', user.id] }), deleteEvents)
+        expect(deleteEvents.some(e => e.type === 'delete' && e.recordName === 'User')).toBe(true)
+        expect(deleteEvents.some(e => e.type === 'delete' && e.recordName === 'Profile')).toBe(true)
+        const remainingProfiles = await handle.find('Profile', undefined, {}, ['title'])
+        expect(remainingProfiles.length).toBe(0)
+    })
+})

--- a/tests/storage/getShrinkedAttribute.spec.ts
+++ b/tests/storage/getShrinkedAttribute.spec.ts
@@ -66,4 +66,34 @@ describe("getShrinkedAttribute test", () => {
         const result = entityToTableMap.getShrinkedAttribute('User', 'leader.&.target.name');
         expect(result).toBe('leader.name');
     });
-}); 
+
+    // 以下为 3.3.4 重写后补充的边界用例（重写不改变语义，这里把语义固定下来）
+
+    test("should keep & at the beginning of a path unchanged", () => {
+        const result = entityToTableMap.getShrinkedAttribute('User', '&.profile.title');
+        expect(result).toBe('&.profile.title');
+    });
+
+    test("should keep & followed by a non source/target segment and stop entity tracking", () => {
+        // & 后面不是 source/target（读取关系自身属性），无压缩语义，原样保留
+        const result = entityToTableMap.getShrinkedAttribute('User', 'profile.&.viewed');
+        expect(result).toBe('profile.&.viewed');
+    });
+
+    test("should keep segments after a non-shrinkable endpoint unchanged", () => {
+        // owner.&.source 回到关系另一端（File），不能压缩，且后续段不再解析实体
+        const result = entityToTableMap.getShrinkedAttribute('File', 'owner.&.source.fileName');
+        expect(result).toBe('owner.&.source.fileName');
+    });
+
+    test("should shrink first segment then keep the second non-shrinkable one", () => {
+        // owner.&.target 可压缩（都指向 User）；随后的 profile.&.viewed 保留
+        const result = entityToTableMap.getShrinkedAttribute('File', 'owner.&.target.profile.&.viewed');
+        expect(result).toBe('owner.profile.&.viewed');
+    });
+
+    test("should keep plain single attribute unchanged", () => {
+        const result = entityToTableMap.getShrinkedAttribute('User', 'name');
+        expect(result).toBe('name');
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes every issue listed in `agentspace/output/storage-package-deep-analysis.md` § 三《其他显著值得改进的地方》. Each change is covered by new regression tests (`tests/storage/deepAnalysisSection3Fixes.spec.ts`, 30 tests + 5 new `getShrinkedAttribute` cases), and the full suite passes (123 files, 1647 tests, 0 failures — including the PostgreSQL suites).

## 3.1 Correctness / robustness

1. **Dead code**: removed `Setup.resolveBaseSourceEntityAndFilter` (never called, read the non-existent `baseEntity.filter`).
2. **Duplicate dependency registration**: `FilteredEntityManager.analyzeDependencies` now registers each dependency at most once per entity name, eliminating doubled membership queries when a predicate references base-local properties.
3. **`preprocessSameRowData` dual implementation**: the copied update-branch in `RecordQueryAgent` is gone; both create and update paths delegate to the single implementation in `CreationExecutor`. The drifted comment ("does not persist `__filtered_entities`") is corrected.
4. **Positional event slicing**: `DeletionExecutor` now collects deletion events structurally (`deleteRecordSameRowDataGrouped` returns `linkAndCascadeEvents` / `recordDeleteEvents`) instead of guessing record events via `slice(length - records.length)`. Emitted order is unchanged.
5. **`nameFormat` enforcement**: `Entity.create` / `Relation.create` validate names (and relation property names) against `/^[a-zA-Z0-9_]+$/`; `DBSetup.buildMap` re-validates at the storage boundary since names are interpolated into SQL.
6. **Invalid SQL from `MatchExp`**: `['in', []]` now produces a cross-driver valid, always-false expression (correct under outer `NOT`); `['in', nonArray]` and `['not', nonNull]` throw clear errors instead of emitting broken SQL.
7. **NULL `__filtered_entities`**: flag maintenance normalizes NULL / string values instead of throwing `TypeError` on legacy rows.

## 3.2 Performance

1. **Update pre-query trimming**: `UpdateExecutor.updateRecord` keeps all value attributes (needed for `oldRecord` in events and computed recomputation) but only fetches relation/reliance sub-records actually involved in the update payload (resolves the in-code FIXME).
2. **x:n N+1**: 1:n related records are now fetched in one query per batch (`IN (parentIds)` + grouping by the reverse attribute), with identical semantics including `&` link data. Non-batchable cases (recursion labels/goto, per-parent `limit`/`offset`, n:n, symmetric) keep the per-record path.
3. **Filtered flag maintenance batching**: per dependency, one "current flags" query + one membership query for all affected records; UPDATEs only for records whose membership actually changed (previously 3 queries × N records).
4. **Alias depth limit**: paths beyond the pre-generated depth 5 now get runtime-registered aliases via `AliasManager.registerTablePath` instead of falling back to raw long names that PostgreSQL silently truncates (two long paths could collide into wrong JOINs). Covered by an end-to-end test with two 6-level paths that collide after truncation.
5. **Metadata caching**: `EntityToTableMap` caches `RecordInfo` and `getInfoByPath` results (MapData is immutable after setup).

## 3.3 API / code quality

1. **Dependency analysis caching**: filtered-entity dependency analysis is computed once per `MapData` (WeakMap) and shared across `RecordQueryAgent` / `EntityQueryHandle` instances (e.g. temporary handles in `migration.ts`).
2. **Explicit executor contract**: the hand-assembled `helper` function dictionaries are replaced by the typed `RecordOperationAgent` interface which `RecordQueryAgent` implements — the aggregate relationship is now an explicit, type-checked contract.
3. Removed the debug leftover `AttributeQuery.id = Math.random()`.
4. Rewrote `EntityToTableMap.getShrinkedAttribute` (same semantics, no commented-out code / no-op assignments) and pinned its behavior with additional unit tests.
5. Filtered-entity match merging now lives only in the `MatchExp` constructor; `RecordQuery.create` no longer duplicates it (a test asserts the filter atom appears exactly once).
6. Synced `src/storage/IMPLEMENTATION_DETAILS.md` / `USAGE_GUIDE.md` with the current APIs.

## CI fix (PostgreSQL Concurrency workflow)

The workflow had **never been green** (every historical run failed). This PR makes it pass by fixing the actual root causes — no tests were weakened or skipped:

1. **`npm ci` could never run**: `package-lock.json` was gitignored and never committed, and a plain `npm install` failed on a peer conflict (`@release-it/conventional-changelog@^8` wants `release-it@^17`, repo has `^19`). Upgraded the plugin to `^10` (peer `^18||^19`; changelog generation verified) and committed the lockfile.
2. **"Model manifest mismatch" in all multi-process tests**: the migration manifest hashes computation callbacks via `Function.prototype.toString()`. The vitest parent (vite/esbuild) and the `tsx`-launched worker processes produced different function text for identical source. Workers now run through **vite-node with the vitest config** (same transform pipeline), and the model fixtures were extracted into one shared module (`postgresConcurrencyFixtures.ts`) imported by both spec and worker.
3. **Outdated Custom API in one test**: `incrementalCompute` now requires `planIncremental`/`incrementalDataDeps`; the test declares `incrementalDataDeps: []`.

Once the tests actually ran, they uncovered real framework bugs, also fixed here:

4. **Sequence rollback corruption** (`PostgreSQLDB.setupRecordSequences`): attaching a new process via `setup(false)` unconditionally `setval`-ed sequences back to the committed `MAX(id)`, while concurrent writers had already consumed higher values — producing duplicate ids and corrupted incremental aggregates (reproduced deterministically with 4 worker processes). `setval` is now guarded to only advance, never rewind.
5. **Pool leak / unhandled 'error' events** (`PostgreSQLDB.open`): `open()` orphaned the pool created by `openForSchemaRead()` on the `setup(false)` path; orphaned idle connections later killed by `DROP DATABASE … WITH (FORCE)` crashed the process with uncaught `'error'` events (vitest exit 1 despite passing tests). `open()` now reuses the existing pool, and pools carry the standard `'error'` listener node-postgres requires.
6. **`number` → INT mapping**: PostgreSQL/PGLite/MySQL mapped `type: 'number'` to integer columns, so legitimately fractional values (e.g. built-in `Average` = sum/count) failed with `invalid input syntax for type integer`. JS numbers are double-precision floats; they now map to `DOUBLE PRECISION` / `DOUBLE`.
7. **Cross-spec database clobbering**: the concurrency spec shared its database with `postgresqlDataConstraints.spec.ts`; parallel vitest files `DROP … WITH (FORCE)` each other mid-test. It now uses a dedicated `${INTERAQT_POSTGRES_DATABASE}_concurrency` database, like the other postgres specs.

## Testing

- `npm run check:all` — clean.
- Exact CI steps locally against PostgreSQL 16: `npm ci`, `npm run check`, `test:postgres-concurrency` (16/16, three consecutive runs, exit 0, zero unhandled errors), `test:postgres-scoped-sequence` (2/2).
- Full suite twice with PostgreSQL enabled: 123 files / 1647 tests, all green.
- The `postgres-concurrency` CI check on this PR is now **passing**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9886f87f-a463-46dc-b79c-a6d2885150ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9886f87f-a463-46dc-b79c-a6d2885150ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

