### PR TITLE
Fix fatal issues F1–F7 from core/runtime/builtins deep review

### DIFF
--- a/agentspace/output/core-runtime-builtins-review.md
+++ b/agentspace/output/core-runtime-builtins-review.md
@@ -3,7 +3,7 @@
 - 日期:2026-07-04
 - 基线 commit:`f6eb89d`(main,detached at `df1a9eb`)
 - 范围:`src/core`、`src/runtime`、`src/builtins` 三个包(约 20,000 行),`src/storage` 仅在追溯问题根因时交叉阅读
-- 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ **对每个致命判定编写最小复现测试实际运行验证**
+- 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ **对致命判定编写最小复现测试实际运行验证**(验证覆盖范围与例外见第二节开头)
 - 测试基线:当前全量测试 **1636 passed / 26 skipped,全绿**。下述致命问题均不在现有断言覆盖范围内
 - 复现测试:本次 review 为 F1/F2/F3/F5/F6/F7/F8(a) 编写的复现测试已提交为 `tests/runtime/review-repro-{guards,activity,computations}.spec.ts`(以 `test.fails` 标注,详见第五节)
 
@@ -31,7 +31,7 @@ Controller.dispatch(EventSource, args)
 
 ## 二、致命问题(Fatal)
 
-除 F8(需要真实 PostgreSQL 并发,见该条说明)外,**所有 F 级问题均已由可运行的复现测试实际确认**。复现测试已提交进仓库(`tests/runtime/review-repro-*.spec.ts`),全部用 `test.fails` 标注"断言正确行为、当前必然失败":今天套件保持全绿,任何一个 bug 被修复后对应测试会自动转红提醒移除 `.fails`。
+**每个 F 级条目都至少有一个可运行的复现测试实际确认**,例外与保留精确说明如下:F8(b)(并发 read-modify-write)在真实 PostgreSQL 上未能稳定触发,按观察到的实际行为如实记录于该条;F6 的 5 个子项中,子项 2、5 仅有源码级确认(未编写测试),子项 1、3、4 有测试确认。复现测试已提交进仓库(`tests/runtime/review-repro-*.spec.ts`),全部用 `test.fails` 标注"断言正确行为、当前必然失败":今天套件保持全绿,任何一个 bug 被修复后对应测试会自动转红提醒移除 `.fails`。
 
 > **勘误**:初版报告中的 F4(PropertyCount + callback 双重计数 / computed 属性不触发 / HardDeletion 崩溃)**已在 main 上修复**(commits `0875658`、`06375f0`),`count-callback.spec.ts` 中的 BUG 注释是过期残留——测试断言的是正确值且全部通过。初版报告误读了"测试通过"的含义,该条已撤销,详见第 2.5 节。
 
@@ -63,7 +63,7 @@ storage 的 update 事件 `record` 只包含本次变更的值字段(`src/storag
 - `src/runtime/computations/Count.ts` L86–89(GlobalCount update 分支)
 - `src/runtime/computations/Every.ts` L84–87(GlobalEvery update 分支)
 
-直接把 `mutationEvent.record` 传给用户 callback。callback 若依赖任何**未在本次 update 中出现**的字段,读到 `undefined`,增量 delta 计算错误,且结果被写入 `isItemMatch` bound state,**错误会持久化并污染后续增量**。
+直接把 `mutationEvent.record` 传给用户 callback。callback 若依赖任何**未在本次 update 中出现**的字段,读到 `undefined`,增量 delta 计算错误。错误的 match 结果同时被写入 `isItemMatch` bound state(state 与错误判定自洽),**聚合值将保持错误,直到该记录下一次恰好携带全部相关字段的 update 或一次全量重算才会被纠正**。
 
 **复现已确认(两例)**:callback 为 `t.status === 'active' && t.score > 50`,只 update `status` 字段 → Count 应为 1 实际为 0;Every 应为 true 实际为 false。复现测试:`tests/runtime/review-repro-computations.spec.ts`。
 
@@ -99,7 +99,7 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 
 - **图构建**(L230–240):`Gateway.is(sourceNode)` 检查的是 `_type === 'Gateway'`,但 `sourceNode` 是图节点包装 `{ content, next: [], prev: [], uuid }`,没有 `_type`,恒为 false。于是 GatewayNode 的 `next: []` 数组被 `sourceNode.next = targetNode` 直接覆盖成单节点,**并行分支拓扑丢失**。已核实 `Gateway.is` 实现(`Gateway.ts` L69–70)确认此判断不可能为真。
 - **状态推进**(L96–105):`transferToNext` 会把 GatewayNode 当作普通状态节点写入 `current`,而 `isInteractionAvailable` 只匹配 Interaction/Group 的 uuid,Gateway 的 uuid 永远无法被 dispatch 命中 → **Activity 永久卡死在 Gateway 上**。
-- 另有 L225–226 的 `rawGatewayToNode` map 声明后从未写入(gateway 实际存进了 `rawToNode`,查找侥幸成立),属于同一块代码质量问题的佐证。
+- 另有 `rawGatewayToNode` map(L193 声明,L225–226 读取)从未被写入——gateway 节点实际存进了 `rawToNode`,查找靠第一个 `||` 分支侥幸成立,属于同一块代码质量问题的佐证。
 
 **复现已确认(两例)**,见 `tests/runtime/review-repro-activity.spec.ts`:
 - F5a(状态卡死):`step1 → gateway → step2` 的线性 Activity,完成 step1 后 dispatch step2 → `Error: interaction ... not available`,Activity 永久卡死。
@@ -153,7 +153,7 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 | S3 | **global dict 变更触发依赖它的 property 计算时全表扫描 `['*']`** | `Scheduler.ts` L451–464 | 对每个依赖该 dict 的 property computation 做 host entity 全表 find 且在事务内,大表下是延迟与锁放大的隐患 |
 | S4 | **`computeOldRecord` 对关联路径返回 `{...newRecord}` 占位** | `Scheduler.ts` L440–446(带 FIXME) | 关联实体变更时 oldRecord 是当前记录副本,依赖 old/new diff 的下游判断(如 membership 变化)可能误判 |
 | S5 | **Property 级聚合在 relation delete 时不复位 per-item bound state** | `Summation.ts` L235–238、`WeightedSummation.ts` L204–207、`Count.ts` L232–242 | Global 路径在 `dd5feef` 中已修复并加了 CAUTION 注释,property 路径行为不对称;filtered relation 成员资格退出后再进入会读到陈旧 state |
-| S6 | **`Controller.addEventListener`/`callbacks` 是死代码** | `Controller.ts` L568、L734–739 | 从未被读取;`agentspace/knowledge/filtered-entity-usage-guide.md` 还在描述该 API。删除或接入 |
+| S6 | **`Controller.addEventListener`/`callbacks` 是死代码** | `Controller.ts` L568、L734–739 | `callbacks` 只写不读;另外 `agentspace/knowledge/filtered-entity-usage-guide.md` L252/256 示例的 `system.addEventListener(recordName, type, cb)` 在 System/MonoSystem 上**根本不存在**(签名也与 Controller 版不同),文档描述的是虚构 API。删除或接入,并修文档 |
 | S7 | **GlobalAverage 对 null 字段的语义**:null 计 0 且计入分母 | `Average.ts` L63–77 | 与 SQL `AVG`(忽略 null)不同,应文档化或改为不计 count |
 | S8 | **manifest/migration log 写入用字符串拼接 SQL** | `MonoSystem.ts` L1323–1331 等 | 目前 value 是框架生成的 hash/JSON,风险低,但属于埋雷,应统一参数化 |
 

--- a/agentspace/output/core-runtime-builtins-review.md
+++ b/agentspace/output/core-runtime-builtins-review.md
@@ -4,7 +4,8 @@
 - 基线 commit:`f6eb89d`(main,detached at `df1a9eb`)
 - 范围:`src/core`、`src/runtime`、`src/builtins` 三个包(约 20,000 行),`src/storage` 仅在追溯问题根因时交叉阅读
 - 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ **对每个致命判定编写最小复现测试实际运行验证**
-- 测试基线:当前全量测试 **1636 passed / 26 skipped,全绿**。下述致命问题均不在现有断言覆盖范围内(部分测试甚至以"验证 bug 存在"的方式把错误行为断言为通过)
+- 测试基线:当前全量测试 **1636 passed / 26 skipped,全绿**。下述致命问题均不在现有断言覆盖范围内
+- 复现测试:本次 review 为 F1/F2/F3/F5/F6/F7/F8(a) 编写的复现测试已提交为 `tests/runtime/review-repro-{guards,activity,computations}.spec.ts`(以 `test.fails` 标注,详见第五节)
 
 ---
 
@@ -24,13 +25,15 @@ Controller.dispatch(EventSource, args)
 
 分层 `builtins → runtime → storage → core` 基本被遵守(见 M-1 例外)。事务边界、post-commit 副作用隔离、`RequireSerializableRetry` 升级、filtered entity 成员资格 delete 时复位 bound state(`dd5feef` 修复)等近期工作质量较高。
 
-**总体结论:架构和事务模型是健康的;致命问题集中在两处 —— (1) 增量计算在"update 事件只携带变更字段"这一事实下的多处错误,(2) builtins 的 guard/校验链存在多个 fail-open 和一个提前 return 的硬 bug。Activity 的 Gateway 支持实际上是坏的。**
+**总体结论:架构和事务模型是健康的;致命问题集中在三处 —— (1) 增量计算在"update 事件只携带变更字段"这一事实下的多处错误,(2) builtins 的 guard/校验链存在多个 fail-open 和一个提前 return 的硬 bug,(3) Activity 运行时:Gateway 支持实际上是坏的,`any` 组的互斥剪枝失效可确定性双花。**
 
 ---
 
 ## 二、致命问题(Fatal)
 
-以下 F1–F4 均由本次 review 编写的最小复现测试**实际运行确认**;F5–F8 由源码逻辑链路确认。
+除 F8(需要真实 PostgreSQL 并发,见该条说明)外,**所有 F 级问题均已由可运行的复现测试实际确认**。复现测试已提交进仓库(`tests/runtime/review-repro-*.spec.ts`),全部用 `test.fails` 标注"断言正确行为、当前必然失败":今天套件保持全绿,任何一个 bug 被修复后对应测试会自动转红提醒移除 `.fails`。
+
+> **勘误**:初版报告中的 F4(PropertyCount + callback 双重计数 / computed 属性不触发 / HardDeletion 崩溃)**已在 main 上修复**(commits `0875658`、`06375f0`),`count-callback.spec.ts` 中的 BUG 注释是过期残留——测试断言的是正确值且全部通过。初版报告误读了"测试通过"的含义,该条已撤销,详见第 2.5 节。
 
 ### F1. `checkPayload` 遇到"缺失的可选字段"时提前 `return`,跳过其后所有校验(含 required)
 
@@ -62,7 +65,7 @@ storage 的 update 事件 `record` 只包含本次变更的值字段(`src/storag
 
 直接把 `mutationEvent.record` 传给用户 callback。callback 若依赖任何**未在本次 update 中出现**的字段,读到 `undefined`,增量 delta 计算错误,且结果被写入 `isItemMatch` bound state,**错误会持久化并污染后续增量**。
 
-**复现已确认(两例)**:callback 为 `t.status === 'active' && t.score > 50`,只 update `status` 字段 → Count 应为 1 实际为 0;Every 应为 true 实际为 false。
+**复现已确认(两例)**:callback 为 `t.status === 'active' && t.score > 50`,只 update `status` 字段 → Count 应为 1 实际为 0;Every 应为 true 实际为 false。复现测试:`tests/runtime/review-repro-computations.spec.ts`。
 
 对比:`Any.ts` L81–90 和 `Summation`/`Average`/`WeightedSummation` 的同路径都已改为先 `findOne` 拉全量(Any 中有明确注释"拉取全量的 new record 数据"),**Count/Every 是被遗漏的两个**。修复方式与 Any 完全一致。
 
@@ -76,19 +79,19 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 
 当 `relatedAttribute` 为 `['students']`(关联实体自身字段更新的常见形态)时,`slice(2)` 得空数组,match key 变成 `'id'` —— 用**学生实体的 id 去匹配关系记录的 id**。两类 id 一旦不一致,`findOne` 返回 `undefined`,下一行 `newRelationWithEntity[this.isSource ? 'target' : 'source']` 抛 `Cannot read properties of undefined (reading 'target')`,**整个 dispatch 事务被 abort**。
 
-**复现已确认**:先创建 3 个学生再建立关系(让关系 id ≠ 实体 id),update 学生 score → `ComputationError: ... Cannot read properties of undefined (reading 'target')`。
+**复现已确认**:先创建 3 个学生再建立关系(让关系 id ≠ 实体 id),update 学生 score → `ComputationError: ... Cannot read properties of undefined (reading 'target')`。复现测试:`tests/runtime/review-repro-computations.spec.ts`。
 
 现有测试 `averageUpdatePath.spec.ts` 恰好在关系 id 与实体 id 巧合相等的场景下通过(每张表各自从 1 开始自增,测试里第一个学生配第一条关系)。`Summation.ts` L242–247 和 `Count.ts` L248–253 有正确的三分支 key 构造逻辑,Average 应复用同一实现(建议抽取共享的 `buildRelationMatchKey`)。
 
-### F4. PropertyCount + callback 生态存在系统性错误(双重计数 / computed 属性不触发 / HardDeletion 崩溃)
+### F4.(已撤销)PropertyCount + callback 双重计数 / computed 属性不触发 / HardDeletion 崩溃 —— **已在 main 上修复**
 
-仓库中 `tests/runtime/count-callback.spec.ts` 与 `count-hard-deletion.spec.ts` 以"断言错误行为"的方式记录了三个 bug,本次运行确认它们**仍然全部存在**:
+初版报告将此列为致命现存问题,**经重新核实予以撤销**:
 
-1. **双重计数**:创建带 StateMachine 属性的子实体时,先产生 relation create 事件(+1),随后 StateMachine 初始值写入产生 update 事件再次匹配(+1),1 个 child 计成 2、3 个计成 6(`Count.ts` L212–268,create 与 update 两个分支对同一逻辑事件各计一次 delta,`isItemMatchCount.replace` 的去重在 create 用 `relationRecord`、update 用 `newRelationWithEntity` 作为 key,行为不对齐)。
-2. **computed 属性变化不触发重算**:callback 依赖 `isActive`(由 `_status` 派生的 computed 属性)时,mutation event 只含 `_status`,`ComputationSourceMap.shouldTriggerUpdateComputation`(L205–209)按声明的 attributes 过滤后不触发,Count 永久失真。source map 需要把 computed 属性反解为其源字段注册监听,或在文档中明确禁止 callback 依赖 computed 属性并在 setup 时校验报错。
-3. **HardDeletionProperty 与 Count callback 组合**在 relation delete 路径读取 bound state 失败(`count-hard-deletion.spec.ts` 记录的 `TypeError: Cannot read properties of undefined`),且 delete 分支(`Count.ts` L232–242)不像 GlobalCount(L85)那样复位 `isItemMatchCount`,membership 退出后再进入会读到陈旧值。
+- `tests/runtime/count-callback.spec.ts` 与 `count-hard-deletion.spec.ts` 断言的是**正确值**(`toBe(0)`/`toBe(1)`/`toBe(3)`),且当前**全部通过**——即框架行为已正确。
+- 修复对应 commits:`0875658 fix: propagate computed updates to count callbacks`、`06375f0 fix: use record instead of oldRecord in Count delete event handling`,均已在 HEAD 祖先链上。
+- 这两个测试文件头部的大段 "BUG ... This assertion FAILS" 注释是修复前的过期残留,极具误导性(本次 review 的初版判读即被其误导)。**建议清理这些注释**,并把文件更名为常规回归测试。
 
-这三个问题共同指向:**PropertyCount 的 callback 增量路径需要整体重写**,与 Summation/Average 的 per-item bound state 模式对齐,并对"一次 dispatch 内同一 relation 的多个事件"做幂等处理。
+保留的关注点:PropertyCount 的 relation delete 分支(`Count.ts` L232–242)仍不像 GlobalCount(L85)那样在减 delta 后复位 `isItemMatchCount`,filtered relation 成员资格"退出→再进入"场景下有陈旧 state 风险(归入 S5)。
 
 ### F5. Activity Gateway 全链路损坏(图构建 + 状态推进)
 
@@ -97,6 +100,10 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 - **图构建**(L230–240):`Gateway.is(sourceNode)` 检查的是 `_type === 'Gateway'`,但 `sourceNode` 是图节点包装 `{ content, next: [], prev: [], uuid }`,没有 `_type`,恒为 false。于是 GatewayNode 的 `next: []` 数组被 `sourceNode.next = targetNode` 直接覆盖成单节点,**并行分支拓扑丢失**。已核实 `Gateway.is` 实现(`Gateway.ts` L69–70)确认此判断不可能为真。
 - **状态推进**(L96–105):`transferToNext` 会把 GatewayNode 当作普通状态节点写入 `current`,而 `isInteractionAvailable` 只匹配 Interaction/Group 的 uuid,Gateway 的 uuid 永远无法被 dispatch 命中 → **Activity 永久卡死在 Gateway 上**。
 - 另有 L225–226 的 `rawGatewayToNode` map 声明后从未写入(gateway 实际存进了 `rawToNode`,查找侥幸成立),属于同一块代码质量问题的佐证。
+
+**复现已确认(两例)**,见 `tests/runtime/review-repro-activity.spec.ts`:
+- F5a(状态卡死):`step1 → gateway → step2` 的线性 Activity,完成 step1 后 dispatch step2 → `Error: interaction ... not available`,Activity 永久卡死。
+- F5b(拓扑丢失):gateway 两条出边,构图后 `gatewayNode.next` 不是含 2 条边的数组,而是被覆盖成单个节点。
 
 现状:tests 中没有任何"执行经过 Gateway 的 Activity"的运行时测试(仅 core 层的结构测试)。**建议:要么完整实现(gateway 自动跳过 + 并行边),要么在 `Activity.create` 中对含 transfers 指向 Gateway 的定义直接抛"not supported",不要让用户静默得到坏状态机。**
 
@@ -110,15 +117,28 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 4. **回调返回 `undefined` 视为通过**(L277–278、L301–302,`ActivityCall.ts` L408 同):Condition/Attributive 回调若忘写 `return`,静默放行。异常是 fail-closed(catch → false),但 `undefined` 是 fail-open,与之不一致。
 5. **`DerivedConcept.attributive` 分支为死代码**(L401–407):if/else 两个分支完全相同,derived attributive 从不执行。
 
+**复现已确认(1/3/4 三例)**,见 `tests/runtime/review-repro-guards.spec.ts`:
+- F6-1:payload base 为 content 恒返回 `false` 的 Attributive,dispatch 依然成功(attributive 从未执行)。
+- F6-3:`isRef` payload 传不存在的 id `'no-such-id-999'`,guard 放行,dispatch 无错误。
+- F6-4:attributive 回调忘写 `return`(返回 `undefined`),权限检查静默通过。
+
 按项目"explicit control"原则,guard 链应统一 fail-closed:`undefined`、未知类型、无 content 的 attributive 出现在权限位上都应显式报错而非放行。
 
 ### F7. `isRef` Attributive 在独立 Interaction 中语义静默降级
 
 Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attributive.isRef` 走 `checkUserRef`(对比 activity refs 中记录的用户 id);而独立 Interaction 的 `checkUser`(`Interaction.ts` L307–316)**没有 isRef 分支**,`createUserRoleAttributive({ name: 'B', isRef: true })` 会被当成 `user.roles.includes('B')` 的角色检查执行。开发者以为在做"必须是流程中绑定的那个人"的身份校验,实际执行的是完全不同的检查。无 `activityId` 场景下遇到 isRef attributive 应显式抛错(fail-closed)。
 
-### F8. Activity 状态推进无并发控制,可双花
+**复现已确认**,见 `tests/runtime/review-repro-guards.spec.ts`:userAttributives 为 `isRef: true` 的 'Approver',一个恰好持有名为 `'Approver'` 的**角色**的无关用户 dispatch 成功——身份绑定检查被静默降级为角色检查。
 
-`ActivityCall.ts` `checkActivityState`(L318–323)与 `completeInteractionState`(L362–368)是经典 read-modify-write:两个并发 dispatch 可同时通过可用性检查、各自推进并末写胜出。对 `any` 组(如 approve/reject 二选一)意味着**互斥分支可以都被执行**,由 Transform 等下游计算造成的业务副作用无法回收。dispatch 事务默认 READ COMMITTED,不足以阻止这种丢失更新。修复:state 增加版本号做条件 update(CAS),失败抛 `RequireSerializableRetry` 或业务错误。
+### F8. Activity `any` 组互斥性失效:剪枝丢失(确定性复现)+ 并发 read-modify-write(设计缺陷)
+
+本条在复现过程中拆成两个层次:
+
+**(a) 确定性复现 —— `any` 组剪枝结果被丢弃(即 S18 的升级)。** `AnyActivityStateNode.onChange`(`ActivityCall.ts` L416–426)返回 `{ children: <过滤后的分支> }`,但**没有任何调用方消费这个返回值**(基类 `onChange` 返回 void,`transferToNext` L104 不接收)。只要 `any` 组的分支是多步序列,一条分支推进后兄弟分支依然可用——**互斥分支可以被顺序地全部执行完,不需要任何并发**。
+
+**复现已确认**,见 `tests/runtime/review-repro-activity.spec.ts`:`any` 组含 approve1→approve2 与 reject1→reject2 两条两步分支,完成 approve1 后 dispatch reject1、reject2 全部成功,XOR 语义完全失效。这把原 S18 从 significant 升级为 fatal 级别的确定性双花。
+
+**(b) 并发 read-modify-write。** `checkActivityState`(L318–323)与 `completeInteractionState`(L362–368)是经典 read-modify-write,无版本号/CAS。对单步分支的 `any` 组(如 friend-request 的 approve/reject),双花需要两个事务在对方 commit 前完成同一状态快照的读取。**本次在真实 PostgreSQL 16 上用 `Promise.all` 并发 dispatch 未能稳定触发**:观察到的行为是后到者在 `completeInteractionState` 重读时拿到已推进的状态,`findStateNode(uuid)!` 返回 `undefined` 后抛 `TypeError: Cannot read properties of undefined (reading 'complete')`——即当前实现"侥幸"以一个**未处理的 TypeError**(而非清晰的 `ActivityStateError`)挡住了这条竞争路径,且窗口是否可穿越取决于 guard 读与状态写的时序,属于时序运气而非设计保证。结论:(a) 已是确定性 bug 必须修;(b) 的修复(state 版本号条件 update,失败给出明确业务错误)应与 (a) 一起做,顺带消除这个 TypeError。
 
 ---
 
@@ -155,7 +175,7 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 | # | 问题 | 位置 | 说明 |
 |---|------|------|------|
 | S17 | **`saveUserRefs` 对 `isCollection` payload 取 `.id` 得 undefined** | `ActivityCall.ts` L379–385 | collection 时 `payloadItem` 是数组,`(payloadItem as {id}).id` 为 undefined,refs 被污染;且 `checkUserRef`(L392–396)对数组 refs 用 `===` 比较恒 false。collection itemRef 从未真正工作过 |
-| S18 | **`AnyActivityStateNode.onChange` 返回值被丢弃** | `ActivityCall.ts` L416–426 | `return { children: filter(...) }` 无人消费(基类 `onChange` 返回 void,`transferToNext` 不接收),多步 `any` 分支中一条路径前进后兄弟分支仍可用,违反 XOR 语义 |
+| S18 | **`AnyActivityStateNode.onChange` 返回值被丢弃** | `ActivityCall.ts` L416–426 | 已升级并入 F8(a):确定性双花,见 `review-repro-activity.spec.ts` 复现 |
 | S19 | **`findStateNode` 嵌套 Group 时多取一层 `.current`** | `ActivityCall.ts` L90–95 | `find(child => child.findStateNode(uuid))?.current` 返回的是 seq 的 current 而非命中的 state node,嵌套 group 下 `completeInteraction` 会拿错节点 |
 | S20 | **`PayloadItem.type` 声明了但从不校验** | `checkPayload` 全函数 | runtime 类型检查缺失,`type: 'string'` 传对象也通过 |
 | S21 | **`DataAttributive`/`DataAttributives` 定义并导出但零接入** | `Data.ts` | `retrieveData` 只使用 `dataPolicy.match`,DataAttributive 是悬空 API,要么接入 `GetAction` 的 resolve 链,要么移除 |
@@ -171,32 +191,36 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 ## 四、修复优先级建议
 
 **P0(安全/正确性,改动小、收益大,建议立即修):**
-1. F1 `checkPayload` 的 `return` → `continue`(一行)+ 补字段顺序回归测试。
+1. F1 `checkPayload` 的 `return` → `continue`(一行)。
 2. F2 GlobalCount/GlobalEvery update 路径改为 findOne 拉全量(照抄 Any 的实现,各约 5 行)。
 3. F3 PropertyAverage 复用 Summation 的 relationMatchKey 三分支逻辑(建议抽公共函数,一并消除三处重复)。
 4. F6 中的 1/2/5(checkConcept 的三处 fail-open,均为局部小改)。
+5. F8(a) `any` 组剪枝:让 `transferToNext` 消费 `onChange` 的返回值或改为 `onChange` 内直接修改 `this.children`。
 
 **P1(需要设计,但属于框架可信度基石):**
-5. F4 PropertyCount callback 增量路径重写(以仓库中现成的 bug 断言测试翻转为验收标准)。
 6. F7 isRef 语义统一 + F6-4 `undefined` fail-closed(可能破坏依赖隐式放行的现有用户,需要 changelog)。
-7. F8 Activity state 乐观锁。
+7. F8(b) Activity state 版本号 CAS,顺带把并发落败路径的 `TypeError` 换成明确错误。
 8. S9 Relation `isTargetReliance` 覆盖修复。
 
 **P2(债务清理):**
 9. F5 Gateway:短期在 create 时禁用并报错,长期决定是否完整实现。
 10. S10/S11/S12 序列化与 registry 一致性(或正式废弃这条管道)。
-11. S1 计算拓扑排序、S3 global-dep 全表扫描、S17–S19 Activity 细节、M-1 分层违规。
-
-**流程建议**:`count-callback.spec.ts` 这类"断言 bug 行为使测试通过"的做法会让全绿的 CI 掩盖已知致命缺陷,建议改用 `test.fails`(vitest 原生支持"预期失败"),修复后测试会自动报红提醒翻转断言。
+11. S1 计算拓扑排序、S3 global-dep 全表扫描、S17/S19 Activity 细节、M-1 分层违规。
+12. 清理 `count-callback.spec.ts` / `count-hard-deletion.spec.ts` 中过期的 BUG 注释(见 F4 勘误)。
 
 ---
 
-## 五、复现测试(核实记录)
+## 五、复现测试
 
-以下测试在本次 review 中编写并实际运行(未提交进仓库),可直接用作修复的验收用例:
+**已提交进仓库**(全部 `test.fails` 标注:断言正确行为、当前必然失败,套件保持全绿;bug 修复后对应测试转红提醒移除 `.fails`):
 
-1. **F1**:payload 定义 `[note(optional), title(required)]`,空 payload dispatch → `error === undefined`(应报 title missing)。
-2. **F2-Count**:callback `status==='active' && score>50`,只 update `status` → count 为 0(应为 1)。
-3. **F2-Every**:同构造 → every 为 false(应为 true)。
-4. **F3**:关系 id 与实体 id 错开后 update 关联实体字段 → `ComputationError ... Cannot read properties of undefined (reading 'target')`。
-5. **F4**:直接运行仓库自带 `tests/runtime/count-callback.spec.ts` 与 `count-hard-deletion.spec.ts`,5+1 个"bug 验证"断言全部通过,确认三个 bug 现存。
+| 文件 | 覆盖 | 内容 |
+|------|------|------|
+| `tests/runtime/review-repro-guards.spec.ts` | F1、F6-1/3/4、F7 | 可选字段提前 return 绕过必填;Attributive base 不执行;isRef 不存在 id 放行;`undefined` fail-open;isRef 降级为角色检查 |
+| `tests/runtime/review-repro-activity.spec.ts` | F5a、F5b、F8(a) | Gateway 卡死;Gateway 出边被覆盖;`any` 组剪枝失效顺序双花 |
+| `tests/runtime/review-repro-computations.spec.ts` | F2×2、F3 | GlobalCount/GlobalEvery partial record;PropertyAverage match key 崩溃 |
+
+**未提交的核实记录**:
+
+- **F8(b) 并发路径**:在本机安装 PostgreSQL 16,用 `Promise.all` 并发 dispatch `any` 组两个互斥分支(附带拉长 guard 与 afterDispatch 窗口的延时),未能稳定穿越竞争窗口:后到者在 `completeInteractionState` 重读时状态已推进,`findStateNode(uuid)!` 为 `undefined`,抛 `TypeError: Cannot read properties of undefined (reading 'complete')` 使 dispatch 回滚。即互斥性目前由一个未处理的 TypeError"侥幸"守住,不是设计保证;确定性的双花走 F8(a) 已复现。
+- **F4 勘误核实**:重跑 `count-callback.spec.ts`(5 个测试)与 `count-hard-deletion.spec.ts`(1 个测试),断言均为正确值且全部通过;`git merge-base --is-ancestor` 确认修复 commits `0875658`、`06375f0` 在 HEAD 祖先链上。

--- a/agentspace/output/core-runtime-builtins-review.md
+++ b/agentspace/output/core-runtime-builtins-review.md
@@ -5,7 +5,7 @@
 - 范围:`src/core`、`src/runtime`、`src/builtins` 三个包(约 20,000 行),`src/storage` 仅在追溯问题根因时交叉阅读
 - 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ **对致命判定编写最小复现测试实际运行验证**(验证覆盖范围与例外见第二节开头)
 - 测试基线:当前全量测试 **1636 passed / 26 skipped,全绿**。下述致命问题均不在现有断言覆盖范围内
-- 复现测试:本次 review 为 F1/F2/F3/F5/F6/F7/F8(a) 编写的复现测试已提交为 `tests/runtime/review-repro-{guards,activity,computations}.spec.ts`(以 `test.fails` 标注,详见第五节)
+- 复现测试:本次 review 为 F1–F6 及 F7(a) 编写的复现测试已提交为 `tests/runtime/review-repro-{guards,activity,computations}.spec.ts`(以 `test.fails` 标注,详见第五节)
 
 ---
 
@@ -31,9 +31,7 @@ Controller.dispatch(EventSource, args)
 
 ## 二、致命问题(Fatal)
 
-**每个 F 级条目都至少有一个可运行的复现测试实际确认**,例外与保留精确说明如下:F8(b)(并发 read-modify-write)在真实 PostgreSQL 上未能稳定触发,按观察到的实际行为如实记录于该条;F6 的 5 个子项中,子项 2、5 仅有源码级确认(未编写测试),子项 1、3、4 有测试确认。复现测试已提交进仓库(`tests/runtime/review-repro-*.spec.ts`),全部用 `test.fails` 标注"断言正确行为、当前必然失败":今天套件保持全绿,任何一个 bug 被修复后对应测试会自动转红提醒移除 `.fails`。
-
-> **勘误**:初版报告中的 F4(PropertyCount + callback 双重计数 / computed 属性不触发 / HardDeletion 崩溃)**已在 main 上修复**(commits `0875658`、`06375f0`),`count-callback.spec.ts` 中的 BUG 注释是过期残留——测试断言的是正确值且全部通过。初版报告误读了"测试通过"的含义,该条已撤销,详见第 2.5 节。
+**每个 F 级条目都至少有一个可运行的复现测试实际确认**,例外与保留精确说明如下:F7(b)(并发 read-modify-write)在真实 PostgreSQL 上未能稳定触发,按观察到的实际行为如实记录于该条;F5 的 5 个子项中,子项 2、5 仅有源码级确认(未编写测试),子项 1、3、4 有测试确认。复现测试已提交进仓库(`tests/runtime/review-repro-*.spec.ts`),全部用 `test.fails` 标注"断言正确行为、当前必然失败":今天套件保持全绿,任何一个 bug 被修复后对应测试会自动转红提醒移除 `.fails`。
 
 ### F1. `checkPayload` 遇到"缺失的可选字段"时提前 `return`,跳过其后所有校验(含 required)
 
@@ -83,17 +81,7 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 
 现有测试 `averageUpdatePath.spec.ts` 恰好在关系 id 与实体 id 巧合相等的场景下通过(每张表各自从 1 开始自增,测试里第一个学生配第一条关系)。`Summation.ts` L242–247 和 `Count.ts` L248–253 有正确的三分支 key 构造逻辑,Average 应复用同一实现(建议抽取共享的 `buildRelationMatchKey`)。
 
-### F4.(已撤销)PropertyCount + callback 双重计数 / computed 属性不触发 / HardDeletion 崩溃 —— **已在 main 上修复**
-
-初版报告将此列为致命现存问题,**经重新核实予以撤销**:
-
-- `tests/runtime/count-callback.spec.ts` 与 `count-hard-deletion.spec.ts` 断言的是**正确值**(`toBe(0)`/`toBe(1)`/`toBe(3)`),且当前**全部通过**——即框架行为已正确。
-- 修复对应 commits:`0875658 fix: propagate computed updates to count callbacks`、`06375f0 fix: use record instead of oldRecord in Count delete event handling`,均已在 HEAD 祖先链上。
-- 这两个测试文件头部的大段 "BUG ... This assertion FAILS" 注释是修复前的过期残留,极具误导性(本次 review 的初版判读即被其误导)。**建议清理这些注释**,并把文件更名为常规回归测试。
-
-保留的关注点:PropertyCount 的 relation delete 分支(`Count.ts` L232–242)仍不像 GlobalCount(L85)那样在减 delta 后复位 `isItemMatchCount`,filtered relation 成员资格"退出→再进入"场景下有陈旧 state 风险(归入 S5)。
-
-### F5. Activity Gateway 全链路损坏(图构建 + 状态推进)
+### F4. Activity Gateway 全链路损坏(图构建 + 状态推进)
 
 `src/builtins/interaction/activity/ActivityCall.ts`:
 
@@ -102,12 +90,12 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 - 另有 `rawGatewayToNode` map(L193 声明,L225–226 读取)从未被写入——gateway 节点实际存进了 `rawToNode`,查找靠第一个 `||` 分支侥幸成立,属于同一块代码质量问题的佐证。
 
 **复现已确认(两例)**,见 `tests/runtime/review-repro-activity.spec.ts`:
-- F5a(状态卡死):`step1 → gateway → step2` 的线性 Activity,完成 step1 后 dispatch step2 → `Error: interaction ... not available`,Activity 永久卡死。
-- F5b(拓扑丢失):gateway 两条出边,构图后 `gatewayNode.next` 不是含 2 条边的数组,而是被覆盖成单个节点。
+- F4a(状态卡死):`step1 → gateway → step2` 的线性 Activity,完成 step1 后 dispatch step2 → `Error: interaction ... not available`,Activity 永久卡死。
+- F4b(拓扑丢失):gateway 两条出边,构图后 `gatewayNode.next` 不是含 2 条边的数组,而是被覆盖成单个节点。
 
 现状:tests 中没有任何"执行经过 Gateway 的 Activity"的运行时测试(仅 core 层的结构测试)。**建议:要么完整实现(gateway 自动跳过 + 并行边),要么在 `Activity.create` 中对含 transfers 指向 Gateway 的定义直接抛"not supported",不要让用户静默得到坏状态机。**
 
-### F6. 权限链多处 fail-open
+### F5. 权限链多处 fail-open
 
 `src/builtins/interaction/Interaction.ts`:
 
@@ -118,19 +106,19 @@ MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.
 5. **`DerivedConcept.attributive` 分支为死代码**(L401–407):if/else 两个分支完全相同,derived attributive 从不执行。
 
 **复现已确认(1/3/4 三例)**,见 `tests/runtime/review-repro-guards.spec.ts`:
-- F6-1:payload base 为 content 恒返回 `false` 的 Attributive,dispatch 依然成功(attributive 从未执行)。
-- F6-3:`isRef` payload 传不存在的 id `'no-such-id-999'`,guard 放行,dispatch 无错误。
-- F6-4:attributive 回调忘写 `return`(返回 `undefined`),权限检查静默通过。
+- F5-1:payload base 为 content 恒返回 `false` 的 Attributive,dispatch 依然成功(attributive 从未执行)。
+- F5-3:`isRef` payload 传不存在的 id `'no-such-id-999'`,guard 放行,dispatch 无错误。
+- F5-4:attributive 回调忘写 `return`(返回 `undefined`),权限检查静默通过。
 
 按项目"explicit control"原则,guard 链应统一 fail-closed:`undefined`、未知类型、无 content 的 attributive 出现在权限位上都应显式报错而非放行。
 
-### F7. `isRef` Attributive 在独立 Interaction 中语义静默降级
+### F6. `isRef` Attributive 在独立 Interaction 中语义静默降级
 
 Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attributive.isRef` 走 `checkUserRef`(对比 activity refs 中记录的用户 id);而独立 Interaction 的 `checkUser`(`Interaction.ts` L307–316)**没有 isRef 分支**,`createUserRoleAttributive({ name: 'B', isRef: true })` 会被当成 `user.roles.includes('B')` 的角色检查执行。开发者以为在做"必须是流程中绑定的那个人"的身份校验,实际执行的是完全不同的检查。无 `activityId` 场景下遇到 isRef attributive 应显式抛错(fail-closed)。
 
 **复现已确认**,见 `tests/runtime/review-repro-guards.spec.ts`:userAttributives 为 `isRef: true` 的 'Approver',一个恰好持有名为 `'Approver'` 的**角色**的无关用户 dispatch 成功——身份绑定检查被静默降级为角色检查。
 
-### F8. Activity `any` 组互斥性失效:剪枝丢失(确定性复现)+ 并发 read-modify-write(设计缺陷)
+### F7. Activity `any` 组互斥性失效:剪枝丢失(确定性复现)+ 并发 read-modify-write(设计缺陷)
 
 本条在复现过程中拆成两个层次:
 
@@ -175,7 +163,7 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 | # | 问题 | 位置 | 说明 |
 |---|------|------|------|
 | S17 | **`saveUserRefs` 对 `isCollection` payload 取 `.id` 得 undefined** | `ActivityCall.ts` L379–385 | collection 时 `payloadItem` 是数组,`(payloadItem as {id}).id` 为 undefined,refs 被污染;且 `checkUserRef`(L392–396)对数组 refs 用 `===` 比较恒 false。collection itemRef 从未真正工作过 |
-| S18 | **`AnyActivityStateNode.onChange` 返回值被丢弃** | `ActivityCall.ts` L416–426 | 已升级并入 F8(a):确定性双花,见 `review-repro-activity.spec.ts` 复现 |
+| S18 | **`AnyActivityStateNode.onChange` 返回值被丢弃** | `ActivityCall.ts` L416–426 | 已升级并入 F7(a):确定性双花,见 `review-repro-activity.spec.ts` 复现 |
 | S19 | **`findStateNode` 嵌套 Group 时多取一层 `.current`** | `ActivityCall.ts` L90–95 | `find(child => child.findStateNode(uuid))?.current` 返回的是 seq 的 current 而非命中的 state node,嵌套 group 下 `completeInteraction` 会拿错节点 |
 | S20 | **`PayloadItem.type` 声明了但从不校验** | `checkPayload` 全函数 | runtime 类型检查缺失,`type: 'string'` 传对象也通过 |
 | S21 | **`DataAttributive`/`DataAttributives` 定义并导出但零接入** | `Data.ts` | `retrieveData` 只使用 `dataPolicy.match`,DataAttributive 是悬空 API,要么接入 `GetAction` 的 resolve 链,要么移除 |
@@ -194,19 +182,19 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 1. F1 `checkPayload` 的 `return` → `continue`(一行)。
 2. F2 GlobalCount/GlobalEvery update 路径改为 findOne 拉全量(照抄 Any 的实现,各约 5 行)。
 3. F3 PropertyAverage 复用 Summation 的 relationMatchKey 三分支逻辑(建议抽公共函数,一并消除三处重复)。
-4. F6 中的 1/2/5(checkConcept 的三处 fail-open,均为局部小改)。
-5. F8(a) `any` 组剪枝:让 `transferToNext` 消费 `onChange` 的返回值或改为 `onChange` 内直接修改 `this.children`。
+4. F5 中的 1/2/5(checkConcept 的三处 fail-open,均为局部小改)。
+5. F7(a) `any` 组剪枝:让 `transferToNext` 消费 `onChange` 的返回值或改为 `onChange` 内直接修改 `this.children`。
 
 **P1(需要设计,但属于框架可信度基石):**
-6. F7 isRef 语义统一 + F6-4 `undefined` fail-closed(可能破坏依赖隐式放行的现有用户,需要 changelog)。
-7. F8(b) Activity state 版本号 CAS,顺带把并发落败路径的 `TypeError` 换成明确错误。
+6. F6 isRef 语义统一 + F5-4 `undefined` fail-closed(可能破坏依赖隐式放行的现有用户,需要 changelog)。
+7. F7(b) Activity state 版本号 CAS,顺带把并发落败路径的 `TypeError` 换成明确错误。
 8. S9 Relation `isTargetReliance` 覆盖修复。
 
 **P2(债务清理):**
-9. F5 Gateway:短期在 create 时禁用并报错,长期决定是否完整实现。
+9. F4 Gateway:短期在 create 时禁用并报错,长期决定是否完整实现。
 10. S10/S11/S12 序列化与 registry 一致性(或正式废弃这条管道)。
 11. S1 计算拓扑排序、S3 global-dep 全表扫描、S17/S19 Activity 细节、M-1 分层违规。
-12. 清理 `count-callback.spec.ts` / `count-hard-deletion.spec.ts` 中过期的 BUG 注释(见 F4 勘误)。
+12. 清理 `count-callback.spec.ts` / `count-hard-deletion.spec.ts` 头部过期的 "BUG ... This assertion FAILS" 注释:这些 bug 已由 `0875658`/`06375f0` 修复,测试断言正确值并通过,但注释仍宣称断言会失败,会严重误导读者(包括自动化 agent)对现状的判断。
 
 ---
 
@@ -216,11 +204,10 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 
 | 文件 | 覆盖 | 内容 |
 |------|------|------|
-| `tests/runtime/review-repro-guards.spec.ts` | F1、F6-1/3/4、F7 | 可选字段提前 return 绕过必填;Attributive base 不执行;isRef 不存在 id 放行;`undefined` fail-open;isRef 降级为角色检查 |
-| `tests/runtime/review-repro-activity.spec.ts` | F5a、F5b、F8(a) | Gateway 卡死;Gateway 出边被覆盖;`any` 组剪枝失效顺序双花 |
+| `tests/runtime/review-repro-guards.spec.ts` | F1、F5-1/3/4、F6 | 可选字段提前 return 绕过必填;Attributive base 不执行;isRef 不存在 id 放行;`undefined` fail-open;isRef 降级为角色检查 |
+| `tests/runtime/review-repro-activity.spec.ts` | F4a、F4b、F7(a) | Gateway 卡死;Gateway 出边被覆盖;`any` 组剪枝失效顺序双花 |
 | `tests/runtime/review-repro-computations.spec.ts` | F2×2、F3 | GlobalCount/GlobalEvery partial record;PropertyAverage match key 崩溃 |
 
 **未提交的核实记录**:
 
-- **F8(b) 并发路径**:在本机安装 PostgreSQL 16,用 `Promise.all` 并发 dispatch `any` 组两个互斥分支(附带拉长 guard 与 afterDispatch 窗口的延时),未能稳定穿越竞争窗口:后到者在 `completeInteractionState` 重读时状态已推进,`findStateNode(uuid)!` 为 `undefined`,抛 `TypeError: Cannot read properties of undefined (reading 'complete')` 使 dispatch 回滚。即互斥性目前由一个未处理的 TypeError"侥幸"守住,不是设计保证;确定性的双花走 F8(a) 已复现。
-- **F4 勘误核实**:重跑 `count-callback.spec.ts`(5 个测试)与 `count-hard-deletion.spec.ts`(1 个测试),断言均为正确值且全部通过;`git merge-base --is-ancestor` 确认修复 commits `0875658`、`06375f0` 在 HEAD 祖先链上。
+- **F7(b) 并发路径**:在本机安装 PostgreSQL 16,用 `Promise.all` 并发 dispatch `any` 组两个互斥分支(附带拉长 guard 与 afterDispatch 窗口的延时),未能稳定穿越竞争窗口:后到者在 `completeInteractionState` 重读时状态已推进,`findStateNode(uuid)!` 为 `undefined`,抛 `TypeError: Cannot read properties of undefined (reading 'complete')` 使 dispatch 回滚。即互斥性目前由一个未处理的 TypeError"侥幸"守住,不是设计保证;确定性的双花走 F7(a) 已复现。

--- a/agentspace/output/core-runtime-builtins-review.md
+++ b/agentspace/output/core-runtime-builtins-review.md
@@ -1,0 +1,202 @@
+# core / runtime / builtins 深度 Review 报告
+
+- 日期:2026-07-04
+- 基线 commit:`f6eb89d`(main,detached at `df1a9eb`)
+- 范围:`src/core`、`src/runtime`、`src/builtins` 三个包(约 20,000 行),`src/storage` 仅在追溯问题根因时交叉阅读
+- 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ **对每个致命判定编写最小复现测试实际运行验证**
+- 测试基线:当前全量测试 **1636 passed / 26 skipped,全绿**。下述致命问题均不在现有断言覆盖范围内(部分测试甚至以"验证 bug 存在"的方式把错误行为断言为通过)
+
+---
+
+## 一、项目理解(目标与原理)
+
+interaqt 是一个**声明式响应式后端框架**:用户声明"数据是什么"(Entity/Relation/Property + Count/Summation/Transform/StateMachine 等 Computation),而不是写"如何更新数据"。数据流严格单向:
+
+```
+Controller.dispatch(EventSource, args)
+  └─ runWithTransactionRetry(默认 READ COMMITTED,可升级 SERIALIZABLE 重试)
+      └─ storage.runInTransaction
+          guard → mapEventData → 创建事件记录 → resolve → [级联同步计算] → afterDispatch → commit
+  └─ commit 后:postCommit、RecordMutationSideEffect(失败只记入 sideEffects,不回滚)
+```
+
+同步计算的触发机制:每个 Computation 声明 `dataDeps`,`ComputationSourceMapManager` 把它们编译成「(recordName, 事件类型) → computation」的 source map;storage 的每次 mutation 产生 `RecordMutationEvent`,`Scheduler` 在**同一事务内**同步匹配 source map、计算脏记录、执行增量(`incrementalCompute`)或全量(`compute`,强制 SERIALIZABLE)计算并写回,写回又产生新的 mutation 形成级联。异步计算通过 task 记录 + `handleAsyncReturn` 独立事务应用。
+
+分层 `builtins → runtime → storage → core` 基本被遵守(见 M-1 例外)。事务边界、post-commit 副作用隔离、`RequireSerializableRetry` 升级、filtered entity 成员资格 delete 时复位 bound state(`dd5feef` 修复)等近期工作质量较高。
+
+**总体结论:架构和事务模型是健康的;致命问题集中在两处 —— (1) 增量计算在"update 事件只携带变更字段"这一事实下的多处错误,(2) builtins 的 guard/校验链存在多个 fail-open 和一个提前 return 的硬 bug。Activity 的 Gateway 支持实际上是坏的。**
+
+---
+
+## 二、致命问题(Fatal)
+
+以下 F1–F4 均由本次 review 编写的最小复现测试**实际运行确认**;F5–F8 由源码逻辑链路确认。
+
+### F1. `checkPayload` 遇到"缺失的可选字段"时提前 `return`,跳过其后所有校验(含 required)
+
+`src/builtins/interaction/Interaction.ts` L350–351:
+
+```342:351:src/builtins/interaction/Interaction.ts
+  for (const payloadDef of payloadDefs) {
+    if (payloadDef.required && !(payloadDef.name! in payload)) {
+      throw new InteractionGuardError(
+        `Payload validation failed for field '${payloadDef.name}': missing`,
+        { type: `${payloadDef.name} missing`, checkType: 'payload' }
+      );
+    }
+
+    const payloadItem = payload[payloadDef.name!];
+    if (payloadItem === undefined) return;
+```
+
+`return` 应为 `continue`。payload 定义顺序中只要有一个可选字段未传,**其后所有字段的 required / isCollection / isRef / concept 校验全部被跳过**。
+
+**复现已确认**:定义 `[note(可选), title(必填)]`,dispatch 空 payload,`result.error` 为 `undefined`,必填校验被完全绕过。这是一行修复(`return` → `continue`),但影响面是所有多字段 Interaction 的输入校验与权限语义,属于安全边界失效。
+
+### F2. GlobalCount / GlobalEvery 的 update 增量路径使用"只含变更字段"的 partial record 调用 callback
+
+storage 的 update 事件 `record` 只包含本次变更的值字段(`src/storage/erstorage/CreationExecutor.ts` L191–202 构造 `updateRecord` 时仅放入 `newEntityData` 中出现的字段)。而:
+
+- `src/runtime/computations/Count.ts` L86–89(GlobalCount update 分支)
+- `src/runtime/computations/Every.ts` L84–87(GlobalEvery update 分支)
+
+直接把 `mutationEvent.record` 传给用户 callback。callback 若依赖任何**未在本次 update 中出现**的字段,读到 `undefined`,增量 delta 计算错误,且结果被写入 `isItemMatch` bound state,**错误会持久化并污染后续增量**。
+
+**复现已确认(两例)**:callback 为 `t.status === 'active' && t.score > 50`,只 update `status` 字段 → Count 应为 1 实际为 0;Every 应为 true 实际为 false。
+
+对比:`Any.ts` L81–90 和 `Summation`/`Average`/`WeightedSummation` 的同路径都已改为先 `findOne` 拉全量(Any 中有明确注释"拉取全量的 new record 数据"),**Count/Every 是被遗漏的两个**。修复方式与 Any 完全一致。
+
+### F3. PropertyAverage 的 update 增量路径 relationMatchKey 构造错误,直接抛 TypeError
+
+`src/runtime/computations/Average.ts` L286–296:update 分支固定使用
+
+```typescript
+MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.'), value: ['=', relatedMutationEvent.oldRecord!.id]})
+```
+
+当 `relatedAttribute` 为 `['students']`(关联实体自身字段更新的常见形态)时,`slice(2)` 得空数组,match key 变成 `'id'` —— 用**学生实体的 id 去匹配关系记录的 id**。两类 id 一旦不一致,`findOne` 返回 `undefined`,下一行 `newRelationWithEntity[this.isSource ? 'target' : 'source']` 抛 `Cannot read properties of undefined (reading 'target')`,**整个 dispatch 事务被 abort**。
+
+**复现已确认**:先创建 3 个学生再建立关系(让关系 id ≠ 实体 id),update 学生 score → `ComputationError: ... Cannot read properties of undefined (reading 'target')`。
+
+现有测试 `averageUpdatePath.spec.ts` 恰好在关系 id 与实体 id 巧合相等的场景下通过(每张表各自从 1 开始自增,测试里第一个学生配第一条关系)。`Summation.ts` L242–247 和 `Count.ts` L248–253 有正确的三分支 key 构造逻辑,Average 应复用同一实现(建议抽取共享的 `buildRelationMatchKey`)。
+
+### F4. PropertyCount + callback 生态存在系统性错误(双重计数 / computed 属性不触发 / HardDeletion 崩溃)
+
+仓库中 `tests/runtime/count-callback.spec.ts` 与 `count-hard-deletion.spec.ts` 以"断言错误行为"的方式记录了三个 bug,本次运行确认它们**仍然全部存在**:
+
+1. **双重计数**:创建带 StateMachine 属性的子实体时,先产生 relation create 事件(+1),随后 StateMachine 初始值写入产生 update 事件再次匹配(+1),1 个 child 计成 2、3 个计成 6(`Count.ts` L212–268,create 与 update 两个分支对同一逻辑事件各计一次 delta,`isItemMatchCount.replace` 的去重在 create 用 `relationRecord`、update 用 `newRelationWithEntity` 作为 key,行为不对齐)。
+2. **computed 属性变化不触发重算**:callback 依赖 `isActive`(由 `_status` 派生的 computed 属性)时,mutation event 只含 `_status`,`ComputationSourceMap.shouldTriggerUpdateComputation`(L205–209)按声明的 attributes 过滤后不触发,Count 永久失真。source map 需要把 computed 属性反解为其源字段注册监听,或在文档中明确禁止 callback 依赖 computed 属性并在 setup 时校验报错。
+3. **HardDeletionProperty 与 Count callback 组合**在 relation delete 路径读取 bound state 失败(`count-hard-deletion.spec.ts` 记录的 `TypeError: Cannot read properties of undefined`),且 delete 分支(`Count.ts` L232–242)不像 GlobalCount(L85)那样复位 `isItemMatchCount`,membership 退出后再进入会读到陈旧值。
+
+这三个问题共同指向:**PropertyCount 的 callback 增量路径需要整体重写**,与 Summation/Average 的 per-item bound state 模式对齐,并对"一次 dispatch 内同一 relation 的多个事件"做幂等处理。
+
+### F5. Activity Gateway 全链路损坏(图构建 + 状态推进)
+
+`src/builtins/interaction/activity/ActivityCall.ts`:
+
+- **图构建**(L230–240):`Gateway.is(sourceNode)` 检查的是 `_type === 'Gateway'`,但 `sourceNode` 是图节点包装 `{ content, next: [], prev: [], uuid }`,没有 `_type`,恒为 false。于是 GatewayNode 的 `next: []` 数组被 `sourceNode.next = targetNode` 直接覆盖成单节点,**并行分支拓扑丢失**。已核实 `Gateway.is` 实现(`Gateway.ts` L69–70)确认此判断不可能为真。
+- **状态推进**(L96–105):`transferToNext` 会把 GatewayNode 当作普通状态节点写入 `current`,而 `isInteractionAvailable` 只匹配 Interaction/Group 的 uuid,Gateway 的 uuid 永远无法被 dispatch 命中 → **Activity 永久卡死在 Gateway 上**。
+- 另有 L225–226 的 `rawGatewayToNode` map 声明后从未写入(gateway 实际存进了 `rawToNode`,查找侥幸成立),属于同一块代码质量问题的佐证。
+
+现状:tests 中没有任何"执行经过 Gateway 的 Activity"的运行时测试(仅 core 层的结构测试)。**建议:要么完整实现(gateway 自动跳过 + 并行边),要么在 `Activity.create` 中对含 transfers 指向 Gateway 的定义直接抛"not supported",不要让用户静默得到坏状态机。**
+
+### F6. 权限链多处 fail-open
+
+`src/builtins/interaction/Interaction.ts`:
+
+1. **`checkConcept` 对 Attributive base 直接放行**(L417–419):payload 字段以 Attributive 为 base 时 `return true`,attributive 的 content 从不执行 —— payload 级权限校验为空实现。
+2. **`checkConcept` 末行无条件 `return true`**(L426–427):未知 concept 类型一律通过。
+3. **Entity base 不验证存在性/所属实体**(L421–424):`isRef` 只检查形状 `{id}`,不查库确认该 id 存在、更不确认属于声明的 Entity。跨实体 id 注入、伪造引用均可通过 guard(后续 storage 操作可能失败,但那时事件记录语义已错,且错误信息完全不指向权限问题)。
+4. **回调返回 `undefined` 视为通过**(L277–278、L301–302,`ActivityCall.ts` L408 同):Condition/Attributive 回调若忘写 `return`,静默放行。异常是 fail-closed(catch → false),但 `undefined` 是 fail-open,与之不一致。
+5. **`DerivedConcept.attributive` 分支为死代码**(L401–407):if/else 两个分支完全相同,derived attributive 从不执行。
+
+按项目"explicit control"原则,guard 链应统一 fail-closed:`undefined`、未知类型、无 content 的 attributive 出现在权限位上都应显式报错而非放行。
+
+### F7. `isRef` Attributive 在独立 Interaction 中语义静默降级
+
+Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attributive.isRef` 走 `checkUserRef`(对比 activity refs 中记录的用户 id);而独立 Interaction 的 `checkUser`(`Interaction.ts` L307–316)**没有 isRef 分支**,`createUserRoleAttributive({ name: 'B', isRef: true })` 会被当成 `user.roles.includes('B')` 的角色检查执行。开发者以为在做"必须是流程中绑定的那个人"的身份校验,实际执行的是完全不同的检查。无 `activityId` 场景下遇到 isRef attributive 应显式抛错(fail-closed)。
+
+### F8. Activity 状态推进无并发控制,可双花
+
+`ActivityCall.ts` `checkActivityState`(L318–323)与 `completeInteractionState`(L362–368)是经典 read-modify-write:两个并发 dispatch 可同时通过可用性检查、各自推进并末写胜出。对 `any` 组(如 approve/reject 二选一)意味着**互斥分支可以都被执行**,由 Transform 等下游计算造成的业务副作用无法回收。dispatch 事务默认 READ COMMITTED,不足以阻止这种丢失更新。修复:state 增加版本号做条件 update(CAS),失败抛 `RequireSerializableRetry` 或业务错误。
+
+---
+
+## 三、显著问题(Significant)
+
+### runtime
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| S1 | **同一 mutation 触发的多个 computation 无拓扑排序** | `Scheduler.ts` L367–387 | 按 source map 注册顺序串行执行,若计算 A 的输出是 B 的输入且同批触发,B 可能基于陈旧值计算,依赖后续级联事件二次修正才收敛(收敛性依赖偶然而非设计)。migration 路径有 topo sort(`migration.ts`),runtime 主路径没有。建议 manifest 级构建依赖图排序,或至少检测环并文档化顺序契约 |
+| S2 | **guard / mapEventData / afterDispatch 在 retry 边界内会被重放** | `Controller.ts` L608–638 | `RequireSerializableRetry` 与 40001 冲突都会整段重跑。`postCommit` 已正确隔离,但用户在 `afterDispatch`/`guard` 里做的非幂等外部 IO 会重复执行。README 有提示,但框架层面可考虑在 attemptArgs 上暴露 `attempt` 编号,并在错误信息中强化约束 |
+| S3 | **global dict 变更触发依赖它的 property 计算时全表扫描 `['*']`** | `Scheduler.ts` L451–464 | 对每个依赖该 dict 的 property computation 做 host entity 全表 find 且在事务内,大表下是延迟与锁放大的隐患 |
+| S4 | **`computeOldRecord` 对关联路径返回 `{...newRecord}` 占位** | `Scheduler.ts` L440–446(带 FIXME) | 关联实体变更时 oldRecord 是当前记录副本,依赖 old/new diff 的下游判断(如 membership 变化)可能误判 |
+| S5 | **Property 级聚合在 relation delete 时不复位 per-item bound state** | `Summation.ts` L235–238、`WeightedSummation.ts` L204–207、`Count.ts` L232–242 | Global 路径在 `dd5feef` 中已修复并加了 CAUTION 注释,property 路径行为不对称;filtered relation 成员资格退出后再进入会读到陈旧 state |
+| S6 | **`Controller.addEventListener`/`callbacks` 是死代码** | `Controller.ts` L568、L734–739 | 从未被读取;`agentspace/knowledge/filtered-entity-usage-guide.md` 还在描述该 API。删除或接入 |
+| S7 | **GlobalAverage 对 null 字段的语义**:null 计 0 且计入分母 | `Average.ts` L63–77 | 与 SQL `AVG`(忽略 null)不同,应文档化或改为不计 count |
+| S8 | **manifest/migration log 写入用字符串拼接 SQL** | `MonoSystem.ts` L1323–1331 等 | 目前 value 是框架生成的 hash/JSON,风险低,但属于埋雷,应统一参数化 |
+
+### core
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| S9 | **Relation 的 `isTargetReliance` 继承被覆盖** | `Relation.ts` L114/131 vs L150 | merged/filtered 分支从 inputRelations/baseRelation 继承该值,但 L150 无条件 `args.isTargetReliance ?? false` 覆盖,用户未显式传参时继承值恒被抹成 false。storage 用它决定 reliance 删除语义(`Setup.ts` L388/591、`DeletionExecutor.ts` L299)。目前 filtered/merged relation + reliance 的组合无测试覆盖,一旦使用即错。L114/131 是死代码 —— 要么删掉,要么修 L150 只对普通 relation 生效 |
+| S10 | **序列化 round-trip 系统性不完整** | 多文件 | ① `Entity/Relation.stringify` 不用 `stringifyAttribute`,嵌套的 properties/baseEntity 序列化为 plain object,parse 后不是 Instance;② `Property.stringify` 丢 `computation`,`computed` 是裸 Function 被 `JSON.stringify` 丢弃;③ `Transform.stringify` 丢 `eventDeps`;④ `StateNode.stringify` 丢 `computeValue`;⑤ `Summation/Average/Every/Dictionary` 各丢 `property`/`direction`/`notEmpty`/`defaultValue`;⑥ `createInstances` 没有第二遍 `uuid::` 引用解析,与 `stringifyAttribute` 的输出格式不配套。**当前运行时主流程不依赖这条序列化管道所以未爆雷,但它是 public API(`stringifyAllInstances`/`createInstancesFromString`),现状是"看起来能用、实际不可 round-trip"** —— 要么修完整,要么明确废弃 |
+| S11 | **`init.ts` 未注册 `NonNullConstraint`、`Custom`** | `init.ts` L22–43 | 反序列化遇到这些类型仅 `console.warn` 跳过(`utils.ts` L120–122),静默丢数据。未知 type 应 throw |
+| S12 | **clone 语义不一致且污染全局 registry** | `Entity.ts` L171–184 vs `Relation.ts` L349 | `Entity.clone` 走 `create()` 把 clone 注册进 `Entity.instances`(RefContainer 每次初始化都触发),`Relation.clone` 用 `new Relation()` 绕过 registry 与校验。两者应统一(建议都不注册),否则 `stringifyAllInstances` 输出重复、跨测试污染 |
+| S13 | **`BoolExp.and/or` 用 truthy 过滤参数** | `BoolExp.ts` L232/241 | `filter(v => !!v)` 会丢弃 `0`/`false`/`''` 等合法 atom。当前调用点(如 `retrieveData` 合并 match)传的都是对象,未触雷,但作为通用 public API 应改为 `v != null` |
+| S14 | **同步 `evaluate` 会把 Promise 当 truthy** | `BoolExp.ts` L384–395 | `AtomHandle` 类型允许返回 Promise,同步 evaluate 不检测,async handler 误用同步入口会静默恒真。应检测 `instanceof Promise` 并抛错 |
+| S15 | **`Property/UniqueConstraint/NonNullConstraint.create` 不执行 name 格式校验** | `Property.ts` L87–98、`Constraint.ts` | `static.public.name.constraints.format` 声明了却不执行;property 名直接进入 SQL 列名,Entity/Relation 已在 create 强校验,此处不一致 |
+| S16 | **`types.ts` 对 `CustomInstance` 值导入形成循环依赖** | `types.ts` L19 | `types → Custom → Computation → types`,当前靠 ESM 部分初始化侥幸工作,应改 `import type` |
+
+### builtins(除 F 级外)
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| S17 | **`saveUserRefs` 对 `isCollection` payload 取 `.id` 得 undefined** | `ActivityCall.ts` L379–385 | collection 时 `payloadItem` 是数组,`(payloadItem as {id}).id` 为 undefined,refs 被污染;且 `checkUserRef`(L392–396)对数组 refs 用 `===` 比较恒 false。collection itemRef 从未真正工作过 |
+| S18 | **`AnyActivityStateNode.onChange` 返回值被丢弃** | `ActivityCall.ts` L416–426 | `return { children: filter(...) }` 无人消费(基类 `onChange` 返回 void,`transferToNext` 不接收),多步 `any` 分支中一条路径前进后兄弟分支仍可用,违反 XOR 语义 |
+| S19 | **`findStateNode` 嵌套 Group 时多取一层 `.current`** | `ActivityCall.ts` L90–95 | `find(child => child.findStateNode(uuid))?.current` 返回的是 seq 的 current 而非命中的 state node,嵌套 group 下 `completeInteraction` 会拿错节点 |
+| S20 | **`PayloadItem.type` 声明了但从不校验** | `checkPayload` 全函数 | runtime 类型检查缺失,`type: 'string'` 传对象也通过 |
+| S21 | **`DataAttributive`/`DataAttributives` 定义并导出但零接入** | `Data.ts` | `retrieveData` 只使用 `dataPolicy.match`,DataAttributive 是悬空 API,要么接入 `GetAction` 的 resolve 链,要么移除 |
+| S22 | **未知 ActivityGroup type 直接 `new undefined()`** | `ActivityCall.ts` L132 | `GroupStateNodeType.get(type)!` 无校验,应在 Activity.create 时报清晰错误 |
+| S23 | **头/非头 Interaction 的 guard 路径不一致** | `ActivityManager.ts` L98–117 | 头节点走 `interaction.guard`(无 isRef 支持),非头节点走 `fullGuardWithUserRef`(不含 `interaction.guard` 中的完整逻辑),两套代码漂移。应提取统一的 guard runner |
+
+### 分层违规
+
+- **M-1**:`src/builtins/interaction/activity/ActivityCall.ts` L6 直接 `import { MatchExp } from "@storage"`,违反 `builtins → runtime → storage → core` 的单向依赖(builtins 不应直接触达 storage)。core 与 runtime 未发现违规。建议 runtime re-export MatchExp 或提供查询封装。
+
+---
+
+## 四、修复优先级建议
+
+**P0(安全/正确性,改动小、收益大,建议立即修):**
+1. F1 `checkPayload` 的 `return` → `continue`(一行)+ 补字段顺序回归测试。
+2. F2 GlobalCount/GlobalEvery update 路径改为 findOne 拉全量(照抄 Any 的实现,各约 5 行)。
+3. F3 PropertyAverage 复用 Summation 的 relationMatchKey 三分支逻辑(建议抽公共函数,一并消除三处重复)。
+4. F6 中的 1/2/5(checkConcept 的三处 fail-open,均为局部小改)。
+
+**P1(需要设计,但属于框架可信度基石):**
+5. F4 PropertyCount callback 增量路径重写(以仓库中现成的 bug 断言测试翻转为验收标准)。
+6. F7 isRef 语义统一 + F6-4 `undefined` fail-closed(可能破坏依赖隐式放行的现有用户,需要 changelog)。
+7. F8 Activity state 乐观锁。
+8. S9 Relation `isTargetReliance` 覆盖修复。
+
+**P2(债务清理):**
+9. F5 Gateway:短期在 create 时禁用并报错,长期决定是否完整实现。
+10. S10/S11/S12 序列化与 registry 一致性(或正式废弃这条管道)。
+11. S1 计算拓扑排序、S3 global-dep 全表扫描、S17–S19 Activity 细节、M-1 分层违规。
+
+**流程建议**:`count-callback.spec.ts` 这类"断言 bug 行为使测试通过"的做法会让全绿的 CI 掩盖已知致命缺陷,建议改用 `test.fails`(vitest 原生支持"预期失败"),修复后测试会自动报红提醒翻转断言。
+
+---
+
+## 五、复现测试(核实记录)
+
+以下测试在本次 review 中编写并实际运行(未提交进仓库),可直接用作修复的验收用例:
+
+1. **F1**:payload 定义 `[note(optional), title(required)]`,空 payload dispatch → `error === undefined`(应报 title missing)。
+2. **F2-Count**:callback `status==='active' && score>50`,只 update `status` → count 为 0(应为 1)。
+3. **F2-Every**:同构造 → every 为 false(应为 true)。
+4. **F3**:关系 id 与实体 id 错开后 update 关联实体字段 → `ComputationError ... Cannot read properties of undefined (reading 'target')`。
+5. **F4**:直接运行仓库自带 `tests/runtime/count-callback.spec.ts` 与 `count-hard-deletion.spec.ts`,5+1 个"bug 验证"断言全部通过,确认三个 bug 现存。

--- a/agentspace/output/core-runtime-builtins-review.md
+++ b/agentspace/output/core-runtime-builtins-review.md
@@ -3,9 +3,9 @@
 - 日期:2026-07-04
 - 基线 commit:`f6eb89d`(main,detached at `df1a9eb`)
 - 范围:`src/core`、`src/runtime`、`src/builtins` 三个包(约 20,000 行),`src/storage` 仅在追溯问题根因时交叉阅读
-- 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ **对致命判定编写最小复现测试实际运行验证**(验证覆盖范围与例外见第二节开头)
-- 测试基线:当前全量测试 **1636 passed / 26 skipped,全绿**。下述致命问题均不在现有断言覆盖范围内
-- 复现测试:本次 review 为 F1–F6 及 F7(a) 编写的复现测试已提交为 `tests/runtime/review-repro-{guards,activity,computations}.spec.ts`(以 `test.fails` 标注,详见第五节)
+- 方法:三个包并行深度探查 + 人工精读关键执行路径(Controller.dispatch、Scheduler、transaction、ComputationSourceMap、各 computation handle、InteractionCall/ActivityCall)+ 对致命判定编写最小复现测试实际运行验证
+
+> **维护说明**:本报告最初记录的 7 个致命问题(F1–F7,含并入 F7(a) 的原 S18)已全部修复并有回归测试覆盖(分支 `cursor/fix-fatal-review-issues-9cda`,回归测试见 `tests/runtime/review-repro-{guards,activity,computations}.spec.ts`),相关条目已从本文档删除以免误导后续工作。下文仅保留**尚未修复**的显著问题与债务项。
 
 ---
 
@@ -25,112 +25,11 @@ Controller.dispatch(EventSource, args)
 
 分层 `builtins → runtime → storage → core` 基本被遵守(见 M-1 例外)。事务边界、post-commit 副作用隔离、`RequireSerializableRetry` 升级、filtered entity 成员资格 delete 时复位 bound state(`dd5feef` 修复)等近期工作质量较高。
 
-**总体结论:架构和事务模型是健康的;致命问题集中在三处 —— (1) 增量计算在"update 事件只携带变更字段"这一事实下的多处错误,(2) builtins 的 guard/校验链存在多个 fail-open 和一个提前 return 的硬 bug,(3) Activity 运行时:Gateway 支持实际上是坏的,`any` 组的互斥剪枝失效可确定性双花。**
+**总体结论:架构和事务模型是健康的。**review 发现的致命问题(增量计算的 partial-record 错误、guard 链 fail-open、Activity 的 Gateway/`any` 组运行时缺陷)均已修复(见文首维护说明);遗留的是下述显著问题与债务清理项。
 
 ---
 
-## 二、致命问题(Fatal)
-
-**每个 F 级条目都至少有一个可运行的复现测试实际确认**,例外与保留精确说明如下:F7(b)(并发 read-modify-write)在真实 PostgreSQL 上未能稳定触发,按观察到的实际行为如实记录于该条;F5 的 5 个子项中,子项 2、5 仅有源码级确认(未编写测试),子项 1、3、4 有测试确认。复现测试已提交进仓库(`tests/runtime/review-repro-*.spec.ts`),全部用 `test.fails` 标注"断言正确行为、当前必然失败":今天套件保持全绿,任何一个 bug 被修复后对应测试会自动转红提醒移除 `.fails`。
-
-### F1. `checkPayload` 遇到"缺失的可选字段"时提前 `return`,跳过其后所有校验(含 required)
-
-`src/builtins/interaction/Interaction.ts` L350–351:
-
-```342:351:src/builtins/interaction/Interaction.ts
-  for (const payloadDef of payloadDefs) {
-    if (payloadDef.required && !(payloadDef.name! in payload)) {
-      throw new InteractionGuardError(
-        `Payload validation failed for field '${payloadDef.name}': missing`,
-        { type: `${payloadDef.name} missing`, checkType: 'payload' }
-      );
-    }
-
-    const payloadItem = payload[payloadDef.name!];
-    if (payloadItem === undefined) return;
-```
-
-`return` 应为 `continue`。payload 定义顺序中只要有一个可选字段未传,**其后所有字段的 required / isCollection / isRef / concept 校验全部被跳过**。
-
-**复现已确认**:定义 `[note(可选), title(必填)]`,dispatch 空 payload,`result.error` 为 `undefined`,必填校验被完全绕过。这是一行修复(`return` → `continue`),但影响面是所有多字段 Interaction 的输入校验与权限语义,属于安全边界失效。
-
-### F2. GlobalCount / GlobalEvery 的 update 增量路径使用"只含变更字段"的 partial record 调用 callback
-
-storage 的 update 事件 `record` 只包含本次变更的值字段(`src/storage/erstorage/CreationExecutor.ts` L191–202 构造 `updateRecord` 时仅放入 `newEntityData` 中出现的字段)。而:
-
-- `src/runtime/computations/Count.ts` L86–89(GlobalCount update 分支)
-- `src/runtime/computations/Every.ts` L84–87(GlobalEvery update 分支)
-
-直接把 `mutationEvent.record` 传给用户 callback。callback 若依赖任何**未在本次 update 中出现**的字段,读到 `undefined`,增量 delta 计算错误。错误的 match 结果同时被写入 `isItemMatch` bound state(state 与错误判定自洽),**聚合值将保持错误,直到该记录下一次恰好携带全部相关字段的 update 或一次全量重算才会被纠正**。
-
-**复现已确认(两例)**:callback 为 `t.status === 'active' && t.score > 50`,只 update `status` 字段 → Count 应为 1 实际为 0;Every 应为 true 实际为 false。复现测试:`tests/runtime/review-repro-computations.spec.ts`。
-
-对比:`Any.ts` L81–90 和 `Summation`/`Average`/`WeightedSummation` 的同路径都已改为先 `findOne` 拉全量(Any 中有明确注释"拉取全量的 new record 数据"),**Count/Every 是被遗漏的两个**。修复方式与 Any 完全一致。
-
-### F3. PropertyAverage 的 update 增量路径 relationMatchKey 构造错误,直接抛 TypeError
-
-`src/runtime/computations/Average.ts` L286–296:update 分支固定使用
-
-```typescript
-MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.'), value: ['=', relatedMutationEvent.oldRecord!.id]})
-```
-
-当 `relatedAttribute` 为 `['students']`(关联实体自身字段更新的常见形态)时,`slice(2)` 得空数组,match key 变成 `'id'` —— 用**学生实体的 id 去匹配关系记录的 id**。两类 id 一旦不一致,`findOne` 返回 `undefined`,下一行 `newRelationWithEntity[this.isSource ? 'target' : 'source']` 抛 `Cannot read properties of undefined (reading 'target')`,**整个 dispatch 事务被 abort**。
-
-**复现已确认**:先创建 3 个学生再建立关系(让关系 id ≠ 实体 id),update 学生 score → `ComputationError: ... Cannot read properties of undefined (reading 'target')`。复现测试:`tests/runtime/review-repro-computations.spec.ts`。
-
-现有测试 `averageUpdatePath.spec.ts` 恰好在关系 id 与实体 id 巧合相等的场景下通过(每张表各自从 1 开始自增,测试里第一个学生配第一条关系)。`Summation.ts` L242–247 和 `Count.ts` L248–253 有正确的三分支 key 构造逻辑,Average 应复用同一实现(建议抽取共享的 `buildRelationMatchKey`)。
-
-### F4. Activity Gateway 全链路损坏(图构建 + 状态推进)
-
-`src/builtins/interaction/activity/ActivityCall.ts`:
-
-- **图构建**(L230–240):`Gateway.is(sourceNode)` 检查的是 `_type === 'Gateway'`,但 `sourceNode` 是图节点包装 `{ content, next: [], prev: [], uuid }`,没有 `_type`,恒为 false。于是 GatewayNode 的 `next: []` 数组被 `sourceNode.next = targetNode` 直接覆盖成单节点,**并行分支拓扑丢失**。已核实 `Gateway.is` 实现(`Gateway.ts` L69–70)确认此判断不可能为真。
-- **状态推进**(L96–105):`transferToNext` 会把 GatewayNode 当作普通状态节点写入 `current`,而 `isInteractionAvailable` 只匹配 Interaction/Group 的 uuid,Gateway 的 uuid 永远无法被 dispatch 命中 → **Activity 永久卡死在 Gateway 上**。
-- 另有 `rawGatewayToNode` map(L193 声明,L225–226 读取)从未被写入——gateway 节点实际存进了 `rawToNode`,查找靠第一个 `||` 分支侥幸成立,属于同一块代码质量问题的佐证。
-
-**复现已确认(两例)**,见 `tests/runtime/review-repro-activity.spec.ts`:
-- F4a(状态卡死):`step1 → gateway → step2` 的线性 Activity,完成 step1 后 dispatch step2 → `Error: interaction ... not available`,Activity 永久卡死。
-- F4b(拓扑丢失):gateway 两条出边,构图后 `gatewayNode.next` 不是含 2 条边的数组,而是被覆盖成单个节点。
-
-现状:tests 中没有任何"执行经过 Gateway 的 Activity"的运行时测试(仅 core 层的结构测试)。**建议:要么完整实现(gateway 自动跳过 + 并行边),要么在 `Activity.create` 中对含 transfers 指向 Gateway 的定义直接抛"not supported",不要让用户静默得到坏状态机。**
-
-### F5. 权限链多处 fail-open
-
-`src/builtins/interaction/Interaction.ts`:
-
-1. **`checkConcept` 对 Attributive base 直接放行**(L417–419):payload 字段以 Attributive 为 base 时 `return true`,attributive 的 content 从不执行 —— payload 级权限校验为空实现。
-2. **`checkConcept` 末行无条件 `return true`**(L426–427):未知 concept 类型一律通过。
-3. **Entity base 不验证存在性/所属实体**(L421–424):`isRef` 只检查形状 `{id}`,不查库确认该 id 存在、更不确认属于声明的 Entity。跨实体 id 注入、伪造引用均可通过 guard(后续 storage 操作可能失败,但那时事件记录语义已错,且错误信息完全不指向权限问题)。
-4. **回调返回 `undefined` 视为通过**(L277–278、L301–302,`ActivityCall.ts` L408 同):Condition/Attributive 回调若忘写 `return`,静默放行。异常是 fail-closed(catch → false),但 `undefined` 是 fail-open,与之不一致。
-5. **`DerivedConcept.attributive` 分支为死代码**(L401–407):if/else 两个分支完全相同,derived attributive 从不执行。
-
-**复现已确认(1/3/4 三例)**,见 `tests/runtime/review-repro-guards.spec.ts`:
-- F5-1:payload base 为 content 恒返回 `false` 的 Attributive,dispatch 依然成功(attributive 从未执行)。
-- F5-3:`isRef` payload 传不存在的 id `'no-such-id-999'`,guard 放行,dispatch 无错误。
-- F5-4:attributive 回调忘写 `return`(返回 `undefined`),权限检查静默通过。
-
-按项目"explicit control"原则,guard 链应统一 fail-closed:`undefined`、未知类型、无 content 的 attributive 出现在权限位上都应显式报错而非放行。
-
-### F6. `isRef` Attributive 在独立 Interaction 中语义静默降级
-
-Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attributive.isRef` 走 `checkUserRef`(对比 activity refs 中记录的用户 id);而独立 Interaction 的 `checkUser`(`Interaction.ts` L307–316)**没有 isRef 分支**,`createUserRoleAttributive({ name: 'B', isRef: true })` 会被当成 `user.roles.includes('B')` 的角色检查执行。开发者以为在做"必须是流程中绑定的那个人"的身份校验,实际执行的是完全不同的检查。无 `activityId` 场景下遇到 isRef attributive 应显式抛错(fail-closed)。
-
-**复现已确认**,见 `tests/runtime/review-repro-guards.spec.ts`:userAttributives 为 `isRef: true` 的 'Approver',一个恰好持有名为 `'Approver'` 的**角色**的无关用户 dispatch 成功——身份绑定检查被静默降级为角色检查。
-
-### F7. Activity `any` 组互斥性失效:剪枝丢失(确定性复现)+ 并发 read-modify-write(设计缺陷)
-
-本条在复现过程中拆成两个层次:
-
-**(a) 确定性复现 —— `any` 组剪枝结果被丢弃(即 S18 的升级)。** `AnyActivityStateNode.onChange`(`ActivityCall.ts` L416–426)返回 `{ children: <过滤后的分支> }`,但**没有任何调用方消费这个返回值**(基类 `onChange` 返回 void,`transferToNext` L104 不接收)。只要 `any` 组的分支是多步序列,一条分支推进后兄弟分支依然可用——**互斥分支可以被顺序地全部执行完,不需要任何并发**。
-
-**复现已确认**,见 `tests/runtime/review-repro-activity.spec.ts`:`any` 组含 approve1→approve2 与 reject1→reject2 两条两步分支,完成 approve1 后 dispatch reject1、reject2 全部成功,XOR 语义完全失效。这把原 S18 从 significant 升级为 fatal 级别的确定性双花。
-
-**(b) 并发 read-modify-write。** `checkActivityState`(L318–323)与 `completeInteractionState`(L362–368)是经典 read-modify-write,无版本号/CAS。对单步分支的 `any` 组(如 friend-request 的 approve/reject),双花需要两个事务在对方 commit 前完成同一状态快照的读取。**本次在真实 PostgreSQL 16 上用 `Promise.all` 并发 dispatch 未能稳定触发**:观察到的行为是后到者在 `completeInteractionState` 重读时拿到已推进的状态,`findStateNode(uuid)!` 返回 `undefined` 后抛 `TypeError: Cannot read properties of undefined (reading 'complete')`——即当前实现"侥幸"以一个**未处理的 TypeError**(而非清晰的 `ActivityStateError`)挡住了这条竞争路径,且窗口是否可穿越取决于 guard 读与状态写的时序,属于时序运气而非设计保证。结论:(a) 已是确定性 bug 必须修;(b) 的修复(state 版本号条件 update,失败给出明确业务错误)应与 (a) 一起做,顺带消除这个 TypeError。
-
----
-
-## 三、显著问题(Significant)
+## 二、显著问题(Significant)
 
 ### runtime
 
@@ -140,7 +39,7 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 | S2 | **guard / mapEventData / afterDispatch 在 retry 边界内会被重放** | `Controller.ts` L608–638 | `RequireSerializableRetry` 与 40001 冲突都会整段重跑。`postCommit` 已正确隔离,但用户在 `afterDispatch`/`guard` 里做的非幂等外部 IO 会重复执行。README 有提示,但框架层面可考虑在 attemptArgs 上暴露 `attempt` 编号,并在错误信息中强化约束 |
 | S3 | **global dict 变更触发依赖它的 property 计算时全表扫描 `['*']`** | `Scheduler.ts` L451–464 | 对每个依赖该 dict 的 property computation 做 host entity 全表 find 且在事务内,大表下是延迟与锁放大的隐患 |
 | S4 | **`computeOldRecord` 对关联路径返回 `{...newRecord}` 占位** | `Scheduler.ts` L440–446(带 FIXME) | 关联实体变更时 oldRecord 是当前记录副本,依赖 old/new diff 的下游判断(如 membership 变化)可能误判 |
-| S5 | **Property 级聚合在 relation delete 时不复位 per-item bound state** | `Summation.ts` L235–238、`WeightedSummation.ts` L204–207、`Count.ts` L232–242 | Global 路径在 `dd5feef` 中已修复并加了 CAUTION 注释,property 路径行为不对称;filtered relation 成员资格退出后再进入会读到陈旧 state |
+| S5 | **Property 级聚合在 relation delete 时不复位 per-item bound state** | `Summation.ts` L235–238、`WeightedSummation.ts` L204–207、`Count.ts` L241–251(各 property handle 的 relation delete 分支) | Global 路径在 `dd5feef` 中已修复并加了 CAUTION 注释,property 路径行为不对称;filtered relation 成员资格退出后再进入会读到陈旧 state |
 | S6 | **`Controller.addEventListener`/`callbacks` 是死代码** | `Controller.ts` L568、L734–739 | `callbacks` 只写不读;另外 `agentspace/knowledge/filtered-entity-usage-guide.md` L252/256 示例的 `system.addEventListener(recordName, type, cb)` 在 System/MonoSystem 上**根本不存在**(签名也与 Controller 版不同),文档描述的是虚构 API。删除或接入,并修文档 |
 | S7 | **GlobalAverage 对 null 字段的语义**:null 计 0 且计入分母 | `Average.ts` L63–77 | 与 SQL `AVG`(忽略 null)不同,应文档化或改为不计 count |
 | S8 | **manifest/migration log 写入用字符串拼接 SQL** | `MonoSystem.ts` L1323–1331 等 | 目前 value 是框架生成的 hash/JSON,风险低,但属于埋雷,应统一参数化 |
@@ -158,17 +57,16 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 | S15 | **`Property/UniqueConstraint/NonNullConstraint.create` 不执行 name 格式校验** | `Property.ts` L87–98、`Constraint.ts` | `static.public.name.constraints.format` 声明了却不执行;property 名直接进入 SQL 列名,Entity/Relation 已在 create 强校验,此处不一致 |
 | S16 | **`types.ts` 对 `CustomInstance` 值导入形成循环依赖** | `types.ts` L19 | `types → Custom → Computation → types`,当前靠 ESM 部分初始化侥幸工作,应改 `import type` |
 
-### builtins(除 F 级外)
+### builtins
 
 | # | 问题 | 位置 | 说明 |
 |---|------|------|------|
-| S17 | **`saveUserRefs` 对 `isCollection` payload 取 `.id` 得 undefined** | `ActivityCall.ts` L379–385 | collection 时 `payloadItem` 是数组,`(payloadItem as {id}).id` 为 undefined,refs 被污染;且 `checkUserRef`(L392–396)对数组 refs 用 `===` 比较恒 false。collection itemRef 从未真正工作过 |
-| S18 | **`AnyActivityStateNode.onChange` 返回值被丢弃** | `ActivityCall.ts` L416–426 | 已升级并入 F7(a):确定性双花,见 `review-repro-activity.spec.ts` 复现 |
+| S17 | **`saveUserRefs` 对 `isCollection` payload 取 `.id` 得 undefined** | `ActivityCall.ts` L383–401 | collection 时 `payloadItem` 是数组,`(payloadItem as {id}).id` 为 undefined,refs 被污染;且 `checkUserRef`(L405–409)对数组 refs 用 `===` 比较恒 false。collection itemRef 从未真正工作过 |
 | S19 | **`findStateNode` 嵌套 Group 时多取一层 `.current`** | `ActivityCall.ts` L90–95 | `find(child => child.findStateNode(uuid))?.current` 返回的是 seq 的 current 而非命中的 state node,嵌套 group 下 `completeInteraction` 会拿错节点 |
 | S20 | **`PayloadItem.type` 声明了但从不校验** | `checkPayload` 全函数 | runtime 类型检查缺失,`type: 'string'` 传对象也通过 |
 | S21 | **`DataAttributive`/`DataAttributives` 定义并导出但零接入** | `Data.ts` | `retrieveData` 只使用 `dataPolicy.match`,DataAttributive 是悬空 API,要么接入 `GetAction` 的 resolve 链,要么移除 |
 | S22 | **未知 ActivityGroup type 直接 `new undefined()`** | `ActivityCall.ts` L132 | `GroupStateNodeType.get(type)!` 无校验,应在 Activity.create 时报清晰错误 |
-| S23 | **头/非头 Interaction 的 guard 路径不一致** | `ActivityManager.ts` L98–117 | 头节点走 `interaction.guard`(无 isRef 支持),非头节点走 `fullGuardWithUserRef`(不含 `interaction.guard` 中的完整逻辑),两套代码漂移。应提取统一的 guard runner |
+| S23 | **头/非头 Interaction 的 guard 路径不一致** | `ActivityManager.ts` L105–124 | 头节点走 `interaction.guard`(遇 isRef attributive 会显式报错,无法消费 refs),非头节点走 `fullGuardWithUserRef`(不含 `interaction.guard` 中的完整逻辑),两套代码漂移。应提取统一的 guard runner |
 
 ### 分层违规
 
@@ -176,38 +74,14 @@ Activity 路径的 `fullGuardWithUserRef`(`ActivityCall.ts` L340–346)对 `attr
 
 ---
 
-## 四、修复优先级建议
+## 三、修复优先级建议
 
-**P0(安全/正确性,改动小、收益大,建议立即修):**
-1. F1 `checkPayload` 的 `return` → `continue`(一行)。
-2. F2 GlobalCount/GlobalEvery update 路径改为 findOne 拉全量(照抄 Any 的实现,各约 5 行)。
-3. F3 PropertyAverage 复用 Summation 的 relationMatchKey 三分支逻辑(建议抽公共函数,一并消除三处重复)。
-4. F5 中的 1/2/5(checkConcept 的三处 fail-open,均为局部小改)。
-5. F7(a) `any` 组剪枝:让 `transferToNext` 消费 `onChange` 的返回值或改为 `onChange` 内直接修改 `this.children`。
+(原 P0/P1 中的致命项均已修复,见文首维护说明;以下为遗留项的建议顺序。)
 
 **P1(需要设计,但属于框架可信度基石):**
-6. F6 isRef 语义统一 + F5-4 `undefined` fail-closed(可能破坏依赖隐式放行的现有用户,需要 changelog)。
-7. F7(b) Activity state 版本号 CAS,顺带把并发落败路径的 `TypeError` 换成明确错误。
-8. S9 Relation `isTargetReliance` 覆盖修复。
+1. S9 Relation `isTargetReliance` 覆盖修复。
 
 **P2(债务清理):**
-9. F4 Gateway:短期在 create 时禁用并报错,长期决定是否完整实现。
-10. S10/S11/S12 序列化与 registry 一致性(或正式废弃这条管道)。
-11. S1 计算拓扑排序、S3 global-dep 全表扫描、S17/S19 Activity 细节、M-1 分层违规。
-12. 清理 `count-callback.spec.ts` / `count-hard-deletion.spec.ts` 头部过期的 "BUG ... This assertion FAILS" 注释:这些 bug 已由 `0875658`/`06375f0` 修复,测试断言正确值并通过,但注释仍宣称断言会失败,会严重误导读者(包括自动化 agent)对现状的判断。
-
----
-
-## 五、复现测试
-
-**已提交进仓库**(全部 `test.fails` 标注:断言正确行为、当前必然失败,套件保持全绿;bug 修复后对应测试转红提醒移除 `.fails`):
-
-| 文件 | 覆盖 | 内容 |
-|------|------|------|
-| `tests/runtime/review-repro-guards.spec.ts` | F1、F5-1/3/4、F6 | 可选字段提前 return 绕过必填;Attributive base 不执行;isRef 不存在 id 放行;`undefined` fail-open;isRef 降级为角色检查 |
-| `tests/runtime/review-repro-activity.spec.ts` | F4a、F4b、F7(a) | Gateway 卡死;Gateway 出边被覆盖;`any` 组剪枝失效顺序双花 |
-| `tests/runtime/review-repro-computations.spec.ts` | F2×2、F3 | GlobalCount/GlobalEvery partial record;PropertyAverage match key 崩溃 |
-
-**未提交的核实记录**:
-
-- **F7(b) 并发路径**:在本机安装 PostgreSQL 16,用 `Promise.all` 并发 dispatch `any` 组两个互斥分支(附带拉长 guard 与 afterDispatch 窗口的延时),未能稳定穿越竞争窗口:后到者在 `completeInteractionState` 重读时状态已推进,`findStateNode(uuid)!` 为 `undefined`,抛 `TypeError: Cannot read properties of undefined (reading 'complete')` 使 dispatch 回滚。即互斥性目前由一个未处理的 TypeError"侥幸"守住,不是设计保证;确定性的双花走 F7(a) 已复现。
+2. S10/S11/S12 序列化与 registry 一致性(或正式废弃这条管道)。
+3. S1 计算拓扑排序、S3 global-dep 全表扫描、S17/S19 Activity 细节、M-1 分层违规。
+4. 清理 `count-callback.spec.ts` / `count-hard-deletion.spec.ts` 头部过期的 "BUG ... This assertion FAILS" 注释:这些 bug 已由 `0875658`/`06375f0` 修复,测试断言正确值并通过,但注释仍宣称断言会失败,会严重误导读者(包括自动化 agent)对现状的判断。

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -257,7 +257,11 @@ function buildInteractionResolve(interaction: InteractionInstance): (this: Contr
   };
 }
 
-export async function checkCondition(controller: { system: { storage: any }, ignoreGuard: boolean }, interaction: InteractionInstance, eventArgs: InteractionEventArgs) {
+// Guard checks only need storage access and the ignoreGuard flag; using a structural
+// type keeps them callable from both Controller and the activity runtime wrappers.
+export type GuardController = { system: { storage: any }, ignoreGuard?: boolean }
+
+export async function checkCondition(controller: GuardController, interaction: InteractionInstance, eventArgs: InteractionEventArgs) {
   if (!interaction.conditions) return;
 
   const conditions = Conditions.is(interaction.conditions)
@@ -265,19 +269,22 @@ export async function checkCondition(controller: { system: { storage: any }, ign
     : BoolExp.atom<ConditionInstance>(interaction.conditions as ConditionInstance);
 
   const handleAttribute = async (condition: ConditionInstance) => {
-    if (!condition) return true;
-    if (condition.content) {
-      let result;
-      try {
-        result = await condition.content.call(controller, eventArgs);
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return `Condition '${condition.name}' threw exception: ${errorMessage}`;
-      }
-      if (result === undefined) return true;
-      return result;
+    // fail-closed: a condition placed on the guard chain must be executable,
+    // and its callback must explicitly return a boolean.
+    if (!condition || !condition.content) {
+      return `Condition '${(condition as ConditionInstance | undefined)?.name ?? '(unnamed)'}' has no content to execute`;
     }
-    return true;
+    let result;
+    try {
+      result = await condition.content.call(controller, eventArgs);
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      return `Condition '${condition.name}' threw exception: ${errorMessage}`;
+    }
+    if (result === undefined) {
+      return `Condition '${condition.name}' returned undefined; guard callbacks must explicitly return a boolean (did you forget a return statement?)`;
+    }
+    return result;
   };
 
   const result = await conditions.evaluateAsync(handleAttribute);
@@ -290,18 +297,24 @@ export async function checkCondition(controller: { system: { storage: any }, ign
   }
 }
 
-async function checkAttributive(controller: Controller, attributive: AttributiveInstance, eventArgs: InteractionEventArgs | undefined, target: unknown): Promise<boolean> {
-  if (attributive.content) {
-    let result;
-    try {
-      result = await attributive.content.call(controller, target, eventArgs);
-    } catch (_e) {
-      result = false;
-    }
-    if (result === undefined) return true;
-    return result;
+// Returns `true`/`false` from the attributive callback, or an error-message string
+// (treated as failure by BoolExp.evaluateAsync) for definition-level problems.
+export async function checkAttributive(controller: GuardController, attributive: AttributiveInstance, eventArgs: InteractionEventArgs | undefined, target: unknown): Promise<boolean | string> {
+  // fail-closed: an attributive on the guard chain without executable content
+  // must not silently grant access.
+  if (!attributive.content) {
+    return `Attributive '${attributive.name ?? '(unnamed)'}' has no content to execute`;
   }
-  return true;
+  let result;
+  try {
+    result = await attributive.content.call(controller, target, eventArgs);
+  } catch (_e) {
+    result = false;
+  }
+  if (result === undefined) {
+    return `Attributive '${attributive.name ?? '(unnamed)'}' returned undefined; guard callbacks must explicitly return a boolean (did you forget a return statement?)`;
+  }
+  return result;
 }
 
 async function checkUser(controller: Controller, interaction: InteractionInstance, eventArgs: InteractionEventArgs) {
@@ -312,6 +325,15 @@ async function checkUser(controller: Controller, interaction: InteractionInstanc
     : BoolExp.atom<AttributiveInstance>(interaction.userAttributives as AttributiveInstance);
 
   const checkHandle = (attributive: AttributiveInstance) => {
+    // `isRef` means "must be the specific user bound in the activity refs".
+    // A standalone interaction has no activity refs, so evaluating it here would
+    // silently degrade to an unrelated role check — reject the definition instead.
+    if (attributive.isRef) {
+      throw new InteractionGuardError(
+        `Attributive '${attributive.name ?? '(unnamed)'}' has isRef: true, which can only be checked inside an activity. Use it on an activity interaction, or remove isRef for a standalone interaction.`,
+        { type: 'isRef attributive outside activity', checkType: 'user' }
+      );
+    }
     return checkAttributive(controller, attributive, eventArgs, eventArgs.user);
   };
 
@@ -325,7 +347,7 @@ async function checkUser(controller: Controller, interaction: InteractionInstanc
   }
 }
 
-export async function checkPayload(_controller: unknown, interaction: InteractionInstance, eventArgs: InteractionEventArgs) {
+export async function checkPayload(controller: GuardController, interaction: InteractionInstance, eventArgs: InteractionEventArgs) {
   const payload = eventArgs.payload || {};
   const payloadDefs = interaction.payload?.items || [];
 
@@ -348,7 +370,9 @@ export async function checkPayload(_controller: unknown, interaction: Interactio
     }
 
     const payloadItem = payload[payloadDef.name!];
-    if (payloadItem === undefined) return;
+    // CAUTION must be `continue`, not `return`: a missing optional field only skips
+    // its own checks, never the validation of the fields defined after it.
+    if (payloadItem === undefined) continue;
 
     if (payloadDef.isCollection && !Array.isArray(payloadItem)) {
       throw new InteractionGuardError(
@@ -373,19 +397,34 @@ export async function checkPayload(_controller: unknown, interaction: Interactio
       }
     }
 
-    if (payloadDef.base) {
-      if (payloadDef.isCollection) {
-        for (const item of payloadItem as unknown[]) {
-          const result = await checkConcept(item, payloadDef.base as unknown as Concept);
-          if (result !== true) {
-            throw new InteractionGuardError(
-              `Concept check failed for field '${payloadDef.name}'`,
-              { type: `${payloadDef.name} check concept failed`, checkType: 'concept', error: result }
-            );
-          }
+    // isRef payloads must reference an existing record of the declared entity/relation:
+    // a made-up id (or an id belonging to another entity) must be rejected at the guard,
+    // before any event record is created with wrong semantics.
+    const baseRecordName = Entity.is(payloadDef.base) || Relation.is(payloadDef.base)
+      ? (payloadDef.base as EntityInstance).name
+      : undefined;
+    if (payloadDef.isRef && baseRecordName) {
+      const items = (payloadDef.isCollection ? payloadItem : [payloadItem]) as { id: string }[];
+      for (const item of items) {
+        const existing = await controller.system.storage.findOne(
+          baseRecordName,
+          BoolExp.atom({ key: 'id', value: ['=', item.id] }),
+          undefined,
+          ['id']
+        );
+        if (!existing) {
+          throw new InteractionGuardError(
+            `Payload validation failed for field '${payloadDef.name}': referenced ${baseRecordName} with id '${item.id}' does not exist`,
+            { type: `${payloadDef.name} ref not found`, checkType: 'payload' }
+          );
         }
-      } else {
-        const result = await checkConcept(payloadItem, payloadDef.base as unknown as Concept);
+      }
+    }
+
+    if (payloadDef.base) {
+      const items = payloadDef.isCollection ? (payloadItem as unknown[]) : [payloadItem];
+      for (const item of items) {
+        const result = await checkConcept(controller, eventArgs, item, payloadDef.base as unknown as Concept);
         if (result !== true) {
           throw new InteractionGuardError(
             `Concept check failed for field '${payloadDef.name}'`,
@@ -397,34 +436,68 @@ export async function checkPayload(_controller: unknown, interaction: Interactio
   }
 }
 
-async function checkConcept(instance: ConceptInstance, concept: Concept): Promise<true | { name: string, type: string, error: string }> {
-  if ((concept as DerivedConcept).base) {
-    const derived = concept as DerivedConcept;
-    if (derived.attributive) {
-      return checkConcept(instance, derived.base!);
-    }
-    return checkConcept(instance, derived.base!);
+// Evaluates an Attributive or an Attributives (bool expression of attributives)
+// attached to a concept against a payload item.
+async function checkConceptAttributive(controller: GuardController, attributive: unknown, eventArgs: InteractionEventArgs, target: unknown): Promise<boolean | string> {
+  if (Attributives.is(attributive)) {
+    const combined = BoolExp.fromValue<AttributiveInstance>((attributive as AttributivesInstance).content! as ExpressionData<AttributiveInstance>);
+    const result = await combined.evaluateAsync((atom: AttributiveInstance) => checkAttributive(controller, atom, eventArgs, target));
+    return result === true ? true : 'attributives check failed';
+  }
+  if (Attributive.is(attributive)) {
+    return checkAttributive(controller, attributive, eventArgs, target);
+  }
+  return `unsupported attributive type in concept: ${JSON.stringify(attributive)}`;
+}
+
+async function checkConcept(controller: GuardController, eventArgs: InteractionEventArgs, instance: ConceptInstance, concept: Concept): Promise<true | { name: string, type: string, error: string }> {
+  if (Attributive.is(concept as unknown) || Attributives.is(concept as unknown)) {
+    const result = await checkConceptAttributive(controller, concept, eventArgs, instance);
+    if (result === true) return true;
+    return {
+      name: (concept as { name?: string }).name || '',
+      type: 'attributiveCheck',
+      error: typeof result === 'string' ? result : 'attributive check failed'
+    };
+  }
+
+  if (Entity.is(concept as unknown) || Relation.is(concept as unknown)) {
+    if (instance && typeof instance === 'object') return true;
+    return { name: (concept as { name?: string }).name || '', type: 'conceptCheck', error: 'invalid entity data' };
   }
 
   if ((concept as ConceptAlias).for) {
     for (const c of (concept as ConceptAlias).for!) {
-      const result = await checkConcept(instance, c);
+      const result = await checkConcept(controller, eventArgs, instance, c);
       if (result === true) return true;
     }
     return { name: (concept as { name?: string }).name || '', type: 'conceptAlias', error: 'no match' };
   }
 
-  if (Attributive.is(concept as unknown)) {
+  if ((concept as DerivedConcept).base) {
+    const derived = concept as DerivedConcept;
+    const baseResult = await checkConcept(controller, eventArgs, instance, derived.base!);
+    if (baseResult !== true) return baseResult;
+    if (derived.attributive) {
+      const result = await checkConceptAttributive(controller, derived.attributive, eventArgs, instance);
+      if (result !== true) {
+        return {
+          name: derived.name || '',
+          type: 'derivedConceptCheck',
+          error: typeof result === 'string' ? result : 'attributive check failed'
+        };
+      }
+    }
     return true;
   }
 
-  if (Entity.is(concept as unknown)) {
-    if (instance && typeof instance === 'object') return true;
-    return { name: (concept as { name?: string }).name || '', type: 'conceptCheck', error: 'invalid entity data' };
-  }
-
-  if (instance && typeof instance === 'object') return true;
-  return true;
+  // fail-closed: an unrecognized concept type on a payload definition is a definition
+  // error, not a license to skip validation.
+  return {
+    name: (concept as { name?: string })?.name || '',
+    type: 'conceptCheck',
+    error: `unknown concept type; payload base must be an Entity, Relation, Attributive(s), ConceptAlias or DerivedConcept`
+  };
 }
 
 async function retrieveData(controller: Controller, interaction: InteractionInstance, eventArgs: InteractionEventArgs) {

--- a/src/builtins/interaction/activity/ActivityCall.ts
+++ b/src/builtins/interaction/activity/ActivityCall.ts
@@ -1,7 +1,7 @@
 import { ActivityGroup, ActivityGroupInstance, ActivityInstance, TransferInstance } from '../Activity.js';
 import { Attributive, AttributiveInstance, Attributives } from '../Attributive.js';
 import { Gateway, GatewayInstance } from '../Gateway.js';
-import { InteractionInstance, InteractionEventArgs, InteractionGuardError, EventUser, checkCondition as interactionCheckCondition, checkPayload as interactionCheckPayload } from '../Interaction.js';
+import { InteractionInstance, InteractionEventArgs, InteractionGuardError, EventUser, checkCondition as interactionCheckCondition, checkPayload as interactionCheckPayload, checkAttributive } from '../Interaction.js';
 import { assert } from "@runtime";
 import { MatchExp } from "@storage";
 import { BoolExp, ExpressionData } from "@core";
@@ -171,7 +171,10 @@ class ActivityState{
         return this.root.isInteractionAvailable(uuid)
     }
     completeInteraction(uuid: string) {
-        const stateNode = this.root.findStateNode(uuid)!
+        const stateNode = this.root.findStateNode(uuid)
+        if (!stateNode) {
+            throw new Error(`interaction ${uuid} is not available in the current activity state; it may have been completed by a concurrent dispatch`)
+        }
         stateNode.complete()
         return true
     }
@@ -190,19 +193,22 @@ export class ActivityCall {
         this.graph = this.buildGraph(activity)
     }
     buildGraph(activity: ActivityInstance, parentGroup?: ActivityGroupNode) : Seq {
-        const rawGatewayToNode = new Map<GatewayInstance, GatewayNode>()
+        // CAUTION Gateway control flow (fork/join/conditional branching) is not implemented
+        //  by the activity runtime: the state machine tracks a single `current` node per
+        //  sequence, and Gateway definitions carry no branching conditions. Building a graph
+        //  through a Gateway would silently produce a broken state machine (the activity
+        //  gets stuck on a node that can never be dispatched), so reject the definition
+        //  explicitly. Use ActivityGroup (type 'any' / 'every' / 'race') to model branches.
+        if (activity.gateways?.length || activity.transfers?.some(t => Gateway.is(t.source) || Gateway.is(t.target))) {
+            throw new Error(`Activity "${activity.name}" uses Gateway nodes, which are not supported by the activity runtime. Model branching with ActivityGroup (type 'any'/'every'/'race') instead.`)
+        }
+
         const seq = {}
 
         for(let interaction of activity.interactions!) {
             const node: InteractionNode = { content: interaction, next: null, uuid: interaction.uuid, parentGroup, parentSeq: seq as Seq, }
             this.uuidToNode.set(interaction.uuid, node)
             this.rawToNode.set(interaction, node)
-        }
-
-        for(let gateway of activity.gateways!) {
-            const node: GatewayNode = { content: gateway, next: [], prev: [], uuid: gateway.uuid }
-            this.uuidToNode.set(gateway.uuid, node)
-            this.rawToNode.set(gateway, node)
         }
 
         for(let group of activity.groups!) {
@@ -222,22 +228,13 @@ export class ActivityCall {
         const candidateEnd = new Set<InteractionInstance|ActivityGroupInstance>([...Object.values(activity.interactions!), ...Object.values(activity.groups!)])
 
         activity.transfers?.forEach((transfer:TransferInstance) => {
-            const sourceNode = (this.rawToNode.get(transfer.source as InteractionInstance) || rawGatewayToNode.get(transfer.source as InteractionInstance))!
-            const targetNode = (this.rawToNode.get(transfer.target as InteractionInstance) || rawGatewayToNode.get(transfer.target as GatewayInstance))!
+            const sourceNode = this.rawToNode.get(transfer.source as InteractionInstance)! as InteractionNode|ActivityGroupNode
+            const targetNode = this.rawToNode.get(transfer.target as InteractionInstance)! as InteractionNode|ActivityGroupNode
 
             assert(!!sourceNode, `cannot find source ${(transfer.source as InteractionInstance).name!}`)
-            assert(!!targetNode, `cannot find target ${(transfer.source as InteractionInstance).name!}`)
-            if (Gateway.is(sourceNode)) {
-                (sourceNode as GatewayNode).next.push(targetNode)
-            } else {
-                sourceNode.next = targetNode
-            }
-
-            if (Gateway.is(targetNode)) {
-                (targetNode as GatewayNode).prev.push(sourceNode)
-            } else {
-                targetNode.prev = sourceNode
-            }
+            assert(!!targetNode, `cannot find target ${(transfer.target as InteractionInstance).name!}`)
+            sourceNode.next = targetNode
+            targetNode.prev = sourceNode
 
             candidateEnd.delete(transfer.source as InteractionInstance)
             candidateStart.delete(transfer.target as InteractionInstance)
@@ -262,6 +259,7 @@ export class ActivityCall {
             name: this.activity.name,
             uuid: this.activity.uuid,
             state: initialStateData,
+            stateVersion: 0,
             refs: {},
         })
         return {
@@ -341,7 +339,7 @@ export class ActivityCall {
                 if (attributive.isRef) {
                     return this.checkUserRef(controller, attributive, args.user, args.activityId!)
                 } else {
-                    return checkAttributiveContent(controller, attributive, args, args.user)
+                    return checkAttributive(controller, attributive, args, args.user)
                 }
             }
             const result = await userAttributiveCombined.evaluateAsync(checkHandle)
@@ -360,11 +358,26 @@ export class ActivityCall {
     }
 
     async completeInteractionState(storage: StorageAccess, activityId: string, interactionUuid: string) {
-        const state = new ActivityState(await this.getState(storage, activityId), this)
-        const stateCompleteResult = state.completeInteraction(interactionUuid)
-        assert(stateCompleteResult, 'change activity state failed')
+        const activity = await this.getActivity(storage, activityId)
+        const state = new ActivityState(activity.state, this)
+        state.completeInteraction(interactionUuid)
         const nextState = state.toJSON()
-        await this.setActivity(storage, activityId, { 'state': nextState })
+
+        // CAUTION optimistic concurrency control: state advancement is a read-modify-write,
+        //  so the write is conditioned on the version we read. A concurrent dispatch that
+        //  advanced the state in between makes this update match zero rows — fail with a
+        //  clear error (aborting this transaction) instead of silently losing an update.
+        const currentVersion = activity.stateVersion ?? 0
+        const match = MatchExp.atom({ key: 'id', value: ['=', activityId] })
+            .and({ key: 'stateVersion', value: ['=', currentVersion] })
+        const updated = await storage.system.storage.update(
+            ActivityCall.ACTIVITY_RECORD,
+            match,
+            { state: nextState, stateVersion: currentVersion + 1 }
+        )
+        if (!updated || (Array.isArray(updated) && updated.length === 0)) {
+            throw new Error(`activity ${activityId} state was modified concurrently while completing interaction ${interactionUuid}; the dispatch has been aborted and can be retried`)
+        }
     }
 
     async saveUserRefs(storage: StorageAccess, activityId: string, interaction: InteractionInstance, interactionEventArgs: InteractionEventArgs) {
@@ -397,31 +410,23 @@ export class ActivityCall {
 }
 
 
-async function checkAttributiveContent(controller: StorageAccess, attributive: AttributiveInstance, eventArgs: InteractionEventArgs, target: any): Promise<boolean> {
-    if ((attributive as any).content) {
-        let result
-        try {
-            result = await (attributive as any).content.call(controller, target, eventArgs)
-        } catch (_e) {
-            result = false
-        }
-        if (result === undefined) return true
-        return result
-    }
-    return true
-}
-
-
 class AnyActivityStateNode extends InteractionState{
     onChange(childPrevUUID: string, childNextUUID? : string) {
         if (this.graph.isStartNode(childPrevUUID)) {
             if (childNextUUID) {
-                return {
-                    children: this.children!.filter(childSeq => childSeq.current?.node!.uuid === childNextUUID)
-                }
+                // 'any' is an exclusive choice: once one branch advances past its head,
+                // the sibling branches must be pruned so they can no longer be dispatched.
+                this.children = this.children!.filter(childSeq => childSeq.current?.node!.uuid === childNextUUID)
             } else {
+                // single-step branch completed: the whole group completes immediately
                 this.complete()
+                return
             }
+        }
+        // multi-step branch: after pruning, the group completes when the surviving
+        // branch runs to its end.
+        if (this.isGroupCompleted()) {
+            this.complete()
         }
     }
 }

--- a/src/builtins/interaction/activity/ActivityManager.ts
+++ b/src/builtins/interaction/activity/ActivityManager.ts
@@ -26,6 +26,13 @@ export const ActivityStateEntity = Entity.create({
             type: 'object',
             collection: false,
         }),
+        // optimistic-lock version for `state`: bumped on every state advancement so a
+        // concurrent read-modify-write can be detected instead of silently lost.
+        Property.create({
+            name: 'stateVersion',
+            type: 'number',
+            collection: false,
+        }),
         Property.create({
             name: 'refs',
             type: 'object',

--- a/src/runtime/computations/Any.ts
+++ b/src/runtime/computations/Any.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext } from "./Computation.js";
 import { Any } from "@core";
 import { Controller } from "../Controller.js";
 import { AnyInstance, RelationInstance } from "@core";
-import { ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
+import { buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
 import { DataBasedComputation } from "./Computation.js";
 import { EtityMutationEvent } from "../ComputationSourceMap.js";
 import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
@@ -219,12 +219,7 @@ export class PropertyAnyHandle implements DataBasedComputation {
             // 关联关系或者关联实体的更新
             // relatedAttribute 是从当前 dataContext 出发
             // 现在要把匹配的 key 改成从关联关系出发。
-            const relationMatchKey = mutationEvent.relatedAttribute[1] === '&' ? 
-                mutationEvent.relatedAttribute.slice(2).concat('id').join('.') : // 从2开始就是关联关系的字段了
-                (mutationEvent.relatedAttribute.length === 1 ? 
-                    `${this.isSource ? 'target' : 'source'}.id` : // 只有1个字段，就是关联实体的 id
-                    `${this.isSource ? 'target' : 'source'}.${mutationEvent.relatedAttribute.slice(1).concat('id').join('.')}` // 有多个字段，就是关联实体再关联上的字段
-                )
+            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
 
             const relationMatch = MatchExp.atom({
                 key: relationMatchKey,

--- a/src/runtime/computations/Average.ts
+++ b/src/runtime/computations/Average.ts
@@ -1,7 +1,7 @@
 import { DataContext, PropertyDataContext } from "./Computation.js";
 import { Average, AverageInstance, RelationInstance, EntityInstance } from "@core";
 import { Controller } from "../Controller.js";
-import { ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, RecordBoundState, GlobalBoundState, IncrementalPlan, RecordsDataDep } from "./Computation.js";
+import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, RecordBoundState, GlobalBoundState, IncrementalPlan, RecordsDataDep } from "./Computation.js";
 import { EtityMutationEvent } from "../Scheduler.js";
 import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
 import { assert } from "../util.js";
@@ -285,9 +285,11 @@ export class PropertyAverageHandle implements DataBasedComputation {
             countDelta = -1;
         } else if (relatedMutationEvent.type === 'update') {
             // 可能是关系更新也可能是关联实体更新
+            // relatedAttribute 是从当前 dataContext 出发，要转换成从关联关系出发的 match key。
+            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
             const newRelationWithEntity = await this.controller.system.storage.findOne(
                 this.relation.name!, 
-                MatchExp.atom({key: mutationEvent.relatedAttribute.slice(2).concat('id').join('.'), value: ['=', relatedMutationEvent.oldRecord!.id]}), 
+                MatchExp.atom({key: relationMatchKey, value: ['=', relatedMutationEvent.oldRecord!.id]}), 
                 undefined, 
                 this.relationAttributeQuery
             );

--- a/src/runtime/computations/Computation.ts
+++ b/src/runtime/computations/Computation.ts
@@ -4,7 +4,7 @@ import {
     type ComputationRecord
 } from "@core";
 import { Controller } from "../Controller";
-import { AttributeQueryData, MatchExp, MatchExpressionData, ModifierData } from "@storage";
+import { AttributeQueryData, LINK_SYMBOL, MatchExp, MatchExpressionData, ModifierData } from "@storage";
 import { type ComputationPhase, PHASE_AFTER_ALL, PHASE_BEFORE_ALL, PHASE_NORMAL} from "../ComputationSourceMap";
 import type { EtityMutationEvent } from "../ComputationSourceMap.js";
 
@@ -277,6 +277,24 @@ export type DataDepEventContext = {
 export function externalDataDepKeys(dataDeps: Record<string, DataDep>, primaryKeys: string[]) {
     const primary = new Set(primaryKeys)
     return Object.keys(dataDeps).filter(key => !primary.has(key))
+}
+
+/**
+ * property 级增量计算处理 update 事件时，需要把「从当前 dataContext 出发」的 relatedAttribute
+ * 转换成「从关联关系出发」的 match key，用 relatedMutationEvent.oldRecord.id 反查关系记录。
+ * 三种形态：
+ *  - relatedAttribute[1] 是 LINK_SYMBOL('&')：更新发生在关系自身的字段上，去掉前两段即为关系上的路径；
+ *  - 长度为 1（如 ['students']）：更新发生在关联实体自身的字段上，用 `source/target.id` 匹配；
+ *  - 更长：更新发生在关联实体再关联的记录上，用 `source/target.<剩余路径>.id` 匹配。
+ */
+export function buildRelationSideMatchKey(relatedAttribute: string[], relationSide: 'source' | 'target'): string {
+    if (relatedAttribute[1] === LINK_SYMBOL) {
+        return relatedAttribute.slice(2).concat('id').join('.')
+    }
+    if (relatedAttribute.length === 1) {
+        return `${relationSide}.id`
+    }
+    return `${relationSide}.${relatedAttribute.slice(1).concat('id').join('.')}`
 }
 
 export function defaultDataBasedIncrementalPlan(

--- a/src/runtime/computations/Count.ts
+++ b/src/runtime/computations/Count.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext } from "./Computation.js";
 import { Count } from "@core";
 import { Controller } from "../Controller.js";
 import { CountInstance, EntityInstance, RelationInstance } from "@core";
-import { ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
+import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
 import { EtityMutationEvent } from "../Scheduler.js";
 import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
 import { assert } from "../util.js";
@@ -84,9 +84,18 @@ export class GlobalCountHandle implements DataBasedComputation {
             //  陈旧的 true 导致增量为 0。物理删除场景下行已不存在，setInternal 会安全地忽略。
             await this.state.isItemMatch.setInternal(mutationEvent.record, false)
         } else if (mutationEvent.type === 'update') {
-            const newItemMatch = !!this.callback.call(this.controller, mutationEvent.record, dataDeps)
-            const { oldValue } = await this.state.isItemMatch.replace(mutationEvent.record, newItemMatch)
-            delta = Number(newItemMatch) - Number(!!oldValue)
+            // 没有 callback 时所有记录恒匹配，字段更新不会改变计数。
+            if (this.args.callback) {
+                // CAUTION update 事件的 record 只携带本次变更的字段，callback 可能依赖其他字段，
+                //  必须拉取全量的 new record 数据再判断（与 Any/Summation 的 update 路径一致）。
+                const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
+                    key: 'id',
+                    value: ['=', mutationEvent.record!.id]
+                }), undefined, this.args.attributeQuery)
+                const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
+                const { oldValue } = await this.state.isItemMatch.replace(newRecord, newItemMatch)
+                delta = Number(newItemMatch) - Number(!!oldValue)
+            }
         }
         
         const count = await this.state.count.increment(delta)
@@ -245,12 +254,7 @@ export class PropertyCountHandle implements DataBasedComputation {
             if(this.callback) {
                 // relatedAttribute 是从当前 dataContext 出发
                 // 现在要把匹配的 key 改成从关联关系出发。
-                const relationMatchKey = mutationEvent.relatedAttribute[1] === LINK_SYMBOL ? 
-                    mutationEvent.relatedAttribute.slice(2).concat('id').join('.') : // 从2开始就是关联关系的字段了
-                    (mutationEvent.relatedAttribute.length === 1 ? 
-                        `${this.isSource ? 'target' : 'source'}.id` : // 只有1个字段，就是关联实体的 id
-                        `${this.isSource ? 'target' : 'source'}.${mutationEvent.relatedAttribute.slice(1).concat('id').join('.')}` // 有多个字段，就是关联实体再关联上的字段
-                    )
+                const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
                 
                 const newRelationWithEntity = await this.controller.system.storage.findOne(
                     this.relation.name!, 

--- a/src/runtime/computations/Every.ts
+++ b/src/runtime/computations/Every.ts
@@ -1,6 +1,6 @@
 import { PropertyDataContext } from "./Computation.js";
 import { Every } from "@core";
-import { ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
+import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
 import { EveryInstance, RelationInstance } from "@core";
 import { Controller } from "../Controller.js";
 import { DataContext } from "./Computation.js";
@@ -82,8 +82,14 @@ export class GlobalEveryHandle implements DataBasedComputation {
             //  否则记录再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
             await this.state!.isItemMatch.setInternal(mutationEvent.record, false)
         } else if (mutationEvent.type === 'update') {
-            const newItemMatch = !!this.callback.call(this.controller, mutationEvent.record, dataDeps)
-            const { oldValue } = await this.state!.isItemMatch.replace(mutationEvent.record, newItemMatch)
+            // CAUTION update 事件的 record 只携带本次变更的字段，callback 可能依赖其他字段，
+            //  必须拉取全量的 new record 数据再判断（与 Any/Summation 的 update 路径一致）。
+            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
+                key: 'id',
+                value: ['=', mutationEvent.record!.id]
+            }), undefined, this.args.attributeQuery)
+            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
+            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
             matchDelta = Number(newItemMatch) - Number(!!oldValue)
         }
 
@@ -240,12 +246,7 @@ export class PropertyEveryHandle implements DataBasedComputation {
             // relatedAttribute 是从当前 dataContext 出发
             // 现在要把匹配的 key 改成从关联关系出发。
         
-            const relationMatchKey = mutationEvent.relatedAttribute[1] === LINK_SYMBOL ? 
-                mutationEvent.relatedAttribute.slice(2).concat('id').join('.') : // 从2开始就是关联关系的字段了
-                (mutationEvent.relatedAttribute.length ===1 ? 
-                    `${this.isSource ? 'target' : 'source'}.id` : // 只有1个字段，就是关联实体的 id
-                    `${this.isSource ? 'target' : 'source'}.${mutationEvent.relatedAttribute.slice(1).concat('id').join('.')}` // 有多个字段，就是关联实体再关联上的字段
-                )
+            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
 
             const relationMatch = MatchExp.atom({
                 key: relationMatchKey,

--- a/src/runtime/computations/Summation.ts
+++ b/src/runtime/computations/Summation.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext, RecordBoundState, GlobalBoundState } 
 import { Summation } from "@core";
 import { Controller } from "../Controller.js";
 import { SummationInstance, EntityInstance, RelationInstance } from "@core";
-import { ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep } from "./Computation.js";
+import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep } from "./Computation.js";
 import { EtityMutationEvent } from "../Scheduler.js";
 import { MatchExp, AttributeQueryData, LINK_SYMBOL } from "@storage";
 import { assert } from "../util.js";
@@ -239,12 +239,7 @@ export class PropertySumHandle implements DataBasedComputation {
         } else if (relatedMutationEvent.type === 'update') {
             // relatedAttribute 是从当前 dataContext 出发
             // 现在要把匹配的 key 改成从关联关系出发。
-            const relationMatchKey = mutationEvent.relatedAttribute[1] === LINK_SYMBOL ? 
-                mutationEvent.relatedAttribute.slice(2).concat('id').join('.') : // 从2开始就是关联关系的字段了
-                (mutationEvent.relatedAttribute.length === 1 ? 
-                    `${this.isSource ? 'target' : 'source'}.id` : // 只有1个字段，就是关联实体的 id
-                    `${this.isSource ? 'target' : 'source'}.${mutationEvent.relatedAttribute.slice(1).concat('id').join('.')}` // 有多个字段，就是关联实体再关联上的字段
-                )
+            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
             
             const newRelationWithEntity = await this.controller.system.storage.findOne(
                 this.relation.name!, 

--- a/src/runtime/computations/WeightedSummation.ts
+++ b/src/runtime/computations/WeightedSummation.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext } from "./Computation.js";
 import { WeightedSummation } from "@core";
 import { Controller } from "../Controller.js";
 import { WeightedSummationInstance, EntityInstance, RelationInstance } from "@core";
-import { ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep, RecordBoundState, GlobalBoundState } from "./Computation.js";
+import { buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep, RecordBoundState, GlobalBoundState } from "./Computation.js";
 import { DataBasedComputation } from "./Computation.js";
 import { EtityMutationEvent } from "../Scheduler.js";
 import { AttributeQueryData, MatchExp, LINK_SYMBOL, RecordQueryData } from "@storage";
@@ -209,12 +209,7 @@ export class PropertyWeightedSummationHandle implements DataBasedComputation {
         } else if (relatedMutationEvent.type === 'update') {
             // relatedAttribute 是从当前 dataContext 出发
             // 现在要把匹配的 key 改成从关联关系出发。
-            const relationMatchKey = mutationEvent.relatedAttribute[1] === LINK_SYMBOL ? 
-                mutationEvent.relatedAttribute.slice(2).concat('id').join('.') : // 从2开始就是关联关系的字段了
-                (mutationEvent.relatedAttribute.length === 1 ? 
-                    `${this.isSource ? 'target' : 'source'}.id` : // 只有1个字段，就是关联实体的 id
-                    `${this.isSource ? 'target' : 'source'}.${mutationEvent.relatedAttribute.slice(1).concat('id').join('.')}` // 有多个字段，就是关联实体再关联上的字段
-                )
+            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
             
             const newRelationWithEntity = await this.controller.system.storage.findOne(
                 this.relation.name!, 

--- a/tests/runtime/condition.spec.ts
+++ b/tests/runtime/condition.spec.ts
@@ -368,7 +368,8 @@ describe('condition checks', () => {
             const incompleteCondition = Condition.create({
                 name: 'incompleteCondition',
                 content: async function(this: Controller, event: any) {
-                    // Returns undefined - framework treats as true (passes)
+                    // Returns undefined - fail-closed: guard callbacks must
+                    // explicitly return a boolean
                     return undefined as any
                 }
             })
@@ -389,11 +390,15 @@ describe('condition checks', () => {
 
             const user = await system.storage.create('User', { name: 'TestUser' })
 
-            // Framework treats undefined as true (condition passes)
+            // fail-closed: undefined is rejected with a clear message instead of
+            // silently passing the guard
             const result = await controller.dispatch(IncompleteInteraction, {
                 user: user
             })
-            expect(result.error).toBeUndefined()
+            expect(result.error).toBeDefined()
+            const conditionError = result.error as ConditionError
+            expect(conditionError.type).toBe('condition check failed')
+            expect(conditionError.error.error).toContain('returned undefined')
         })
     })
 })

--- a/tests/runtime/interactionEdgePaths.spec.ts
+++ b/tests/runtime/interactionEdgePaths.spec.ts
@@ -13,6 +13,10 @@ import {
 } from '../../src/builtins/interaction/Interaction.js';
 import { Conditions } from '../../src/builtins/interaction/Conditions.js';
 
+// checkPayload only touches storage for isRef+Entity payloads; these edge-path
+// tests exercise pure validation logic, so a minimal stub is enough.
+const guardControllerStub = { system: { storage: {} } };
+
 describe('checkPayload with concept validation', () => {
     test('checkPayload passes when payload has base Entity and valid object data', async () => {
         const UserEntity = Entity.create({ name: 'PayloadUser' });
@@ -30,7 +34,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { user: { name: 'Alice' } },
             })
@@ -53,7 +57,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { userData: null },
             })
@@ -77,7 +81,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { items: [{ name: 'a' }, { name: 'b' }] },
             })
@@ -98,7 +102,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { unknown: 'value' },
             })
@@ -120,7 +124,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: {},
             })
@@ -142,7 +146,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { items: 'not-an-array' },
             })
@@ -165,7 +169,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { refs: [{ name: 'no-id' }] },
             })
@@ -187,7 +191,7 @@ describe('checkPayload with concept validation', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { ref: { name: 'no-id' } },
             })
@@ -282,7 +286,7 @@ describe('checkPayload with DerivedConcept and ConceptAlias', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { item: { name: 'valid-data' } },
             })
@@ -312,7 +316,7 @@ describe('checkPayload with DerivedConcept and ConceptAlias', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { multi: { data: 'some-value' } },
             })
@@ -341,7 +345,7 @@ describe('checkPayload with DerivedConcept and ConceptAlias', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { noMatch: 42 },
             })
@@ -365,7 +369,7 @@ describe('checkPayload with DerivedConcept and ConceptAlias', () => {
         });
 
         await expect(
-            checkPayload(null, interaction, {
+            checkPayload(guardControllerStub, interaction, {
                 user: { id: 'u1' },
                 payload: { attrItem: { data: 'x' } },
             })

--- a/tests/runtime/review-repro-activity.spec.ts
+++ b/tests/runtime/review-repro-activity.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Reproduction tests for review findings F5 (Gateway broken) and
+ * F8b/S18 (any-group pruning discarded)
+ * (agentspace/output/core-runtime-builtins-review.md).
+ *
+ * Every test asserts the CORRECT behavior and is marked `test.fails`:
+ * it passes today because the bug makes the assertion fail. When a bug is
+ * fixed, the corresponding test will turn red - remove `.fails` then.
+ */
+import { describe, expect, test } from 'vitest';
+import {
+    Entity, Property, KlassByName,
+    Controller, MonoSystem,
+    Interaction, Action, Activity, ActivityGroup, Transfer, Gateway, ActivityManager,
+} from 'interaqt';
+import { SQLiteDB } from '@drivers';
+
+function makeInteraction(name: string) {
+    return Interaction.create({ name, action: Action.create({ name }) });
+}
+
+async function buildActivityController(activity: any) {
+    const User = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+    const activityManager = new ActivityManager([activity]);
+    const out = activityManager.getOutput();
+    const system = new MonoSystem(new SQLiteDB());
+    system.conceptClass = KlassByName;
+    const controller = new Controller({
+        system,
+        entities: [User, ...out.entities],
+        relations: [...out.relations],
+        eventSources: [...out.eventSources],
+    });
+    await controller.setup(true);
+    const user = await system.storage.create('User', { name: 'u' });
+    return { controller, system, user, activityManager };
+}
+
+describe('F5: Activity Gateway', () => {
+    // BUG: transferToNext parks the persisted state on the GatewayNode's uuid.
+    // isInteractionAvailable only ever matches Interaction/Group uuids, and a
+    // Gateway uuid can never be dispatched, so the activity is stuck forever.
+    test.fails('F5a: linear activity with a gateway in the middle can proceed past the gateway', async () => {
+        const step1 = makeInteraction('gwStep1');
+        const step2 = makeInteraction('gwStep2');
+        const gw = Gateway.create({ name: 'gw1' });
+        const activity = Activity.create({
+            name: 'gatewayLinear',
+            interactions: [step1, step2],
+            gateways: [gw],
+            transfers: [
+                Transfer.create({ name: 't1', source: step1, target: gw }),
+                Transfer.create({ name: 't2', source: gw, target: step2 }),
+            ],
+        });
+        const { controller, system, user } = await buildActivityController(activity);
+
+        const step1ES = controller.findEventSourceByName('gatewayLinear:gwStep1')!;
+        const step2ES = controller.findEventSourceByName('gatewayLinear:gwStep2')!;
+
+        const res1 = await controller.dispatch(step1ES, { user });
+        expect(res1.error).toBeUndefined();
+        const activityId = res1.context!.activityId as string;
+
+        // Gateway should be transparent: step2 must now be available.
+        const res2 = await controller.dispatch(step2ES, { user, activityId });
+        expect(res2.error).toBeUndefined();
+        await system.destroy();
+    });
+
+    // BUG: in buildGraph, `Gateway.is(sourceNode)` tests the graph-node wrapper
+    // (which has no `_type`), so it is always false and `sourceNode.next = targetNode`
+    // overwrites the GatewayNode's `next: []` array - only the last outgoing
+    // edge survives, destroying fork topology.
+    test.fails('F5b: gateway with two outgoing transfers keeps both edges in the graph', async () => {
+        const a = makeInteraction('gwA');
+        const b = makeInteraction('gwB');
+        const c = makeInteraction('gwC');
+        const d = makeInteraction('gwD');
+        const gw = Gateway.create({ name: 'gwFork' });
+        const activity = Activity.create({
+            name: 'gatewayFork',
+            interactions: [a, b, c, d],
+            gateways: [gw],
+            transfers: [
+                Transfer.create({ name: 'f1', source: a, target: gw }),
+                Transfer.create({ name: 'f2', source: gw, target: b }),
+                Transfer.create({ name: 'f3', source: gw, target: c }),
+                Transfer.create({ name: 'f4', source: b, target: d }),
+                Transfer.create({ name: 'f5', source: c, target: d }),
+            ],
+        });
+
+        const activityManager = new ActivityManager([activity]);
+        const activityCall = activityManager.getActivityCallByName('gatewayFork')!;
+        const gwNode = activityCall.getNodeByUUID(gw.uuid)! as any;
+
+        expect(Array.isArray(gwNode.next)).toBe(true);
+        expect(gwNode.next.length).toBe(2);
+    });
+});
+
+describe('F8b/S18: any-group exclusivity with multi-step branches', () => {
+    // BUG: AnyActivityStateNode.onChange returns `{ children: <pruned> }` but
+    // nothing consumes the return value, so after one branch of an 'any' group
+    // advances, sibling branches remain live. Mutually exclusive branches can
+    // then BOTH be executed to completion - sequentially, no concurrency needed.
+    test.fails('advancing one branch of an any-group prunes the sibling branch', async () => {
+        const send = makeInteraction('xorSend');
+        const approve1 = makeInteraction('xorApprove1');
+        const approve2 = makeInteraction('xorApprove2');
+        const reject1 = makeInteraction('xorReject1');
+        const reject2 = makeInteraction('xorReject2');
+
+        const responseGroup = ActivityGroup.create({
+            type: 'any',
+            activities: [
+                Activity.create({
+                    name: 'xorApproveSeq',
+                    interactions: [approve1, approve2],
+                    transfers: [Transfer.create({ name: 'a12', source: approve1, target: approve2 })],
+                }),
+                Activity.create({
+                    name: 'xorRejectSeq',
+                    interactions: [reject1, reject2],
+                    transfers: [Transfer.create({ name: 'r12', source: reject1, target: reject2 })],
+                }),
+            ],
+        });
+
+        const activity = Activity.create({
+            name: 'xorActivity',
+            interactions: [send],
+            groups: [responseGroup],
+            transfers: [Transfer.create({ name: 't', source: send, target: responseGroup })],
+        });
+        const { controller, system, user } = await buildActivityController(activity);
+
+        const sendES = controller.findEventSourceByName('xorActivity:xorSend')!;
+        const approve1ES = controller.findEventSourceByName('xorActivity:xorApprove1')!;
+        const reject1ES = controller.findEventSourceByName('xorActivity:xorReject1')!;
+
+        const res1 = await controller.dispatch(sendES, { user });
+        expect(res1.error).toBeUndefined();
+        const activityId = res1.context!.activityId as string;
+
+        // Take the approve branch: this must prune the reject branch.
+        const res2 = await controller.dispatch(approve1ES, { user, activityId });
+        expect(res2.error).toBeUndefined();
+
+        // 'any' = exclusive choice; the reject branch must no longer be available.
+        const res3 = await controller.dispatch(reject1ES, { user, activityId });
+        expect(res3.error).toBeTruthy();
+        await system.destroy();
+    });
+});

--- a/tests/runtime/review-repro-activity.spec.ts
+++ b/tests/runtime/review-repro-activity.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Reproduction tests for review findings F5 (Gateway broken) and
- * F8b/S18 (any-group pruning discarded)
+ * Reproduction tests for review findings F4 (Gateway broken) and
+ * F7(a)/S18 (any-group pruning discarded)
  * (agentspace/output/core-runtime-builtins-review.md).
  *
  * Every test asserts the CORRECT behavior and is marked `test.fails`:
@@ -36,11 +36,11 @@ async function buildActivityController(activity: any) {
     return { controller, system, user, activityManager };
 }
 
-describe('F5: Activity Gateway', () => {
+describe('F4: Activity Gateway', () => {
     // BUG: transferToNext parks the persisted state on the GatewayNode's uuid.
     // isInteractionAvailable only ever matches Interaction/Group uuids, and a
     // Gateway uuid can never be dispatched, so the activity is stuck forever.
-    test.fails('F5a: linear activity with a gateway in the middle can proceed past the gateway', async () => {
+    test.fails('F4a: linear activity with a gateway in the middle can proceed past the gateway', async () => {
         const step1 = makeInteraction('gwStep1');
         const step2 = makeInteraction('gwStep2');
         const gw = Gateway.create({ name: 'gw1' });
@@ -72,7 +72,7 @@ describe('F5: Activity Gateway', () => {
     // (which has no `_type`), so it is always false and `sourceNode.next = targetNode`
     // overwrites the GatewayNode's `next: []` array - only the last outgoing
     // edge survives, destroying fork topology.
-    test.fails('F5b: gateway with two outgoing transfers keeps both edges in the graph', async () => {
+    test.fails('F4b: gateway with two outgoing transfers keeps both edges in the graph', async () => {
         const a = makeInteraction('gwA');
         const b = makeInteraction('gwB');
         const c = makeInteraction('gwC');
@@ -100,7 +100,7 @@ describe('F5: Activity Gateway', () => {
     });
 });
 
-describe('F8b/S18: any-group exclusivity with multi-step branches', () => {
+describe('F7(a)/S18: any-group exclusivity with multi-step branches', () => {
     // BUG: AnyActivityStateNode.onChange returns `{ children: <pruned> }` but
     // nothing consumes the return value, so after one branch of an 'any' group
     // advances, sibling branches remain live. Mutually exclusive branches can

--- a/tests/runtime/review-repro-activity.spec.ts
+++ b/tests/runtime/review-repro-activity.spec.ts
@@ -1,11 +1,18 @@
 /**
- * Reproduction tests for review findings F4 (Gateway broken) and
- * F7(a)/S18 (any-group pruning discarded)
+ * Regression tests for review findings F4 (Gateway) and F7 (any-group
+ * exclusivity + concurrent state advancement)
  * (agentspace/output/core-runtime-builtins-review.md).
  *
- * Every test asserts the CORRECT behavior and is marked `test.fails`:
- * it passes today because the bug makes the assertion fail. When a bug is
- * fixed, the corresponding test will turn red - remove `.fails` then.
+ * Originally committed as failing-by-design (`test.fails`) reproductions;
+ * the bugs are fixed, so these now assert the correct behavior:
+ * - F4: Gateway control flow is not implemented by the activity runtime, so
+ *   building the runtime state machine for an activity that uses Gateway
+ *   nodes fails loudly instead of silently producing a stuck state machine.
+ * - F7(a): 'any' groups are exclusive - once one branch advances, sibling
+ *   branches are pruned and can no longer be dispatched.
+ * - F7(b): activity state advancement is guarded by an optimistic version
+ *   (stateVersion); a lost-update or an already-advanced state produces a
+ *   clear error instead of an unhandled TypeError.
  */
 import { describe, expect, test } from 'vitest';
 import {
@@ -14,6 +21,7 @@ import {
     Interaction, Action, Activity, ActivityGroup, Transfer, Gateway, ActivityManager,
 } from 'interaqt';
 import { SQLiteDB } from '@drivers';
+import { MatchExp } from '@storage';
 
 function makeInteraction(name: string) {
     return Interaction.create({ name, action: Action.create({ name }) });
@@ -36,11 +44,12 @@ async function buildActivityController(activity: any) {
     return { controller, system, user, activityManager };
 }
 
-describe('F4: Activity Gateway', () => {
-    // BUG: transferToNext parks the persisted state on the GatewayNode's uuid.
-    // isInteractionAvailable only ever matches Interaction/Group uuids, and a
-    // Gateway uuid can never be dispatched, so the activity is stuck forever.
-    test.fails('F4a: linear activity with a gateway in the middle can proceed past the gateway', async () => {
+describe('F4: Activity Gateway is explicitly rejected by the runtime', () => {
+    // Gateway definitions carry no branching conditions and the activity state
+    // machine tracks a single current node per sequence, so Gateway control flow
+    // cannot be executed. Building the runtime must fail loudly instead of
+    // producing an activity that gets stuck on an undispatchable node.
+    test('an activity routed through a gateway is rejected when building the runtime', () => {
         const step1 = makeInteraction('gwStep1');
         const step2 = makeInteraction('gwStep2');
         const gw = Gateway.create({ name: 'gw1' });
@@ -53,59 +62,27 @@ describe('F4: Activity Gateway', () => {
                 Transfer.create({ name: 't2', source: gw, target: step2 }),
             ],
         });
-        const { controller, system, user } = await buildActivityController(activity);
 
-        const step1ES = controller.findEventSourceByName('gatewayLinear:gwStep1')!;
-        const step2ES = controller.findEventSourceByName('gatewayLinear:gwStep2')!;
-
-        const res1 = await controller.dispatch(step1ES, { user });
-        expect(res1.error).toBeUndefined();
-        const activityId = res1.context!.activityId as string;
-
-        // Gateway should be transparent: step2 must now be available.
-        const res2 = await controller.dispatch(step2ES, { user, activityId });
-        expect(res2.error).toBeUndefined();
-        await system.destroy();
+        expect(() => new ActivityManager([activity])).toThrowError(/Gateway/);
     });
 
-    // BUG: in buildGraph, `Gateway.is(sourceNode)` tests the graph-node wrapper
-    // (which has no `_type`), so it is always false and `sourceNode.next = targetNode`
-    // overwrites the GatewayNode's `next: []` array - only the last outgoing
-    // edge survives, destroying fork topology.
-    test.fails('F4b: gateway with two outgoing transfers keeps both edges in the graph', async () => {
-        const a = makeInteraction('gwA');
-        const b = makeInteraction('gwB');
-        const c = makeInteraction('gwC');
-        const d = makeInteraction('gwD');
-        const gw = Gateway.create({ name: 'gwFork' });
+    test('a gateway declared but unused in transfers is also rejected', () => {
+        const a = makeInteraction('gwOnlyA');
+        const b = makeInteraction('gwOnlyB');
+        const gw = Gateway.create({ name: 'gwUnusedInTransfers' });
         const activity = Activity.create({
-            name: 'gatewayFork',
-            interactions: [a, b, c, d],
+            name: 'gatewayDeclared',
+            interactions: [a, b],
             gateways: [gw],
-            transfers: [
-                Transfer.create({ name: 'f1', source: a, target: gw }),
-                Transfer.create({ name: 'f2', source: gw, target: b }),
-                Transfer.create({ name: 'f3', source: gw, target: c }),
-                Transfer.create({ name: 'f4', source: b, target: d }),
-                Transfer.create({ name: 'f5', source: c, target: d }),
-            ],
+            transfers: [Transfer.create({ name: 't', source: a, target: b })],
         });
 
-        const activityManager = new ActivityManager([activity]);
-        const activityCall = activityManager.getActivityCallByName('gatewayFork')!;
-        const gwNode = activityCall.getNodeByUUID(gw.uuid)! as any;
-
-        expect(Array.isArray(gwNode.next)).toBe(true);
-        expect(gwNode.next.length).toBe(2);
+        expect(() => new ActivityManager([activity])).toThrowError(/Gateway/);
     });
 });
 
-describe('F7(a)/S18: any-group exclusivity with multi-step branches', () => {
-    // BUG: AnyActivityStateNode.onChange returns `{ children: <pruned> }` but
-    // nothing consumes the return value, so after one branch of an 'any' group
-    // advances, sibling branches remain live. Mutually exclusive branches can
-    // then BOTH be executed to completion - sequentially, no concurrency needed.
-    test.fails('advancing one branch of an any-group prunes the sibling branch', async () => {
+describe('F7(a): any-group exclusivity with multi-step branches', () => {
+    test('advancing one branch of an any-group prunes the sibling branch', async () => {
         const send = makeInteraction('xorSend');
         const approve1 = makeInteraction('xorApprove1');
         const approve2 = makeInteraction('xorApprove2');
@@ -134,11 +111,13 @@ describe('F7(a)/S18: any-group exclusivity with multi-step branches', () => {
             groups: [responseGroup],
             transfers: [Transfer.create({ name: 't', source: send, target: responseGroup })],
         });
-        const { controller, system, user } = await buildActivityController(activity);
+        const { controller, system, user, activityManager } = await buildActivityController(activity);
 
         const sendES = controller.findEventSourceByName('xorActivity:xorSend')!;
         const approve1ES = controller.findEventSourceByName('xorActivity:xorApprove1')!;
+        const approve2ES = controller.findEventSourceByName('xorActivity:xorApprove2')!;
         const reject1ES = controller.findEventSourceByName('xorActivity:xorReject1')!;
+        const reject2ES = controller.findEventSourceByName('xorActivity:xorReject2')!;
 
         const res1 = await controller.dispatch(sendES, { user });
         expect(res1.error).toBeUndefined();
@@ -151,6 +130,95 @@ describe('F7(a)/S18: any-group exclusivity with multi-step branches', () => {
         // 'any' = exclusive choice; the reject branch must no longer be available.
         const res3 = await controller.dispatch(reject1ES, { user, activityId });
         expect(res3.error).toBeTruthy();
+        const res4 = await controller.dispatch(reject2ES, { user, activityId });
+        expect(res4.error).toBeTruthy();
+
+        // The surviving branch keeps working and completes the group (and here the
+        // whole activity, since the group is the tail).
+        const res5 = await controller.dispatch(approve2ES, { user, activityId });
+        expect(res5.error).toBeUndefined();
+
+        const activityCall = activityManager.getActivityCallByName('xorActivity')!;
+        const finalState = await activityCall.getState(controller, activityId);
+        expect(finalState.current).toBeUndefined();
+        await system.destroy();
+    });
+});
+
+describe('F7(b): activity state advancement is version-guarded', () => {
+    async function buildTwoStepActivity() {
+        const step1 = makeInteraction('casStep1');
+        const step2 = makeInteraction('casStep2');
+        const activity = Activity.create({
+            name: 'casActivity',
+            interactions: [step1, step2],
+            transfers: [Transfer.create({ name: 't', source: step1, target: step2 })],
+        });
+        const built = await buildActivityController(activity);
+        return { ...built, step1, step2 };
+    }
+
+    test('stateVersion increments on every state advancement', async () => {
+        const { controller, system, user } = await buildTwoStepActivity();
+        const step1ES = controller.findEventSourceByName('casActivity:casStep1')!;
+        const step2ES = controller.findEventSourceByName('casActivity:casStep2')!;
+
+        const res1 = await controller.dispatch(step1ES, { user });
+        expect(res1.error).toBeUndefined();
+        const activityId = res1.context!.activityId as string;
+
+        let record = await system.storage.findOne('_Activity_',
+            MatchExp.atom({ key: 'id', value: ['=', activityId] }), undefined, ['*']);
+        expect(record.stateVersion).toBe(1);
+
+        const res2 = await controller.dispatch(step2ES, { user, activityId });
+        expect(res2.error).toBeUndefined();
+
+        record = await system.storage.findOne('_Activity_',
+            MatchExp.atom({ key: 'id', value: ['=', activityId] }), undefined, ['*']);
+        expect(record.stateVersion).toBe(2);
+        await system.destroy();
+    });
+
+    test('completing an interaction that is no longer in the state fails with a clear error, not a TypeError', async () => {
+        const { controller, system, user, activityManager, step1 } = await buildTwoStepActivity();
+        const step1ES = controller.findEventSourceByName('casActivity:casStep1')!;
+
+        const res1 = await controller.dispatch(step1ES, { user });
+        expect(res1.error).toBeUndefined();
+        const activityId = res1.context!.activityId as string;
+
+        // Simulate the loser of a concurrent race: the state has already advanced
+        // past step1, so completing it again must produce a clear business error
+        // (previously: `TypeError: Cannot read properties of undefined (reading 'complete')`).
+        const activityCall = activityManager.getActivityCallByName('casActivity')!;
+        await expect(activityCall.completeInteractionState(controller, activityId, step1.uuid))
+            .rejects.toThrowError(/not available/);
+        await system.destroy();
+    });
+
+    test('a concurrent state bump makes the conditional update fail with a clear error', async () => {
+        const { controller, system, user, activityManager, step2 } = await buildTwoStepActivity();
+        const step1ES = controller.findEventSourceByName('casActivity:casStep1')!;
+
+        const res1 = await controller.dispatch(step1ES, { user });
+        expect(res1.error).toBeUndefined();
+        const activityId = res1.context!.activityId as string;
+
+        // Simulate a lost update: another dispatch bumped stateVersion between our
+        // read and write. Intercept getActivity to return a stale version.
+        const activityCall = activityManager.getActivityCallByName('casActivity')!;
+        const originalGetActivity = activityCall.getActivity.bind(activityCall);
+        activityCall.getActivity = async (storage: any, id: string) => {
+            const activity = await originalGetActivity(storage, id);
+            return { ...activity, stateVersion: (activity.stateVersion ?? 0) - 1 };
+        };
+        try {
+            await expect(activityCall.completeInteractionState(controller, activityId, step2.uuid))
+                .rejects.toThrowError(/concurrently/);
+        } finally {
+            activityCall.getActivity = originalGetActivity;
+        }
         await system.destroy();
     });
 });

--- a/tests/runtime/review-repro-computations.spec.ts
+++ b/tests/runtime/review-repro-computations.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Reproduction tests for review findings F2 (partial-record callbacks) and
+ * F3 (PropertyAverage relation match key)
+ * (agentspace/output/core-runtime-builtins-review.md).
+ *
+ * Every test asserts the CORRECT behavior and is marked `test.fails`:
+ * it passes today because the bug makes the assertion fail. When a bug is
+ * fixed, the corresponding test will turn red - remove `.fails` then.
+ */
+import { describe, expect, test } from 'vitest';
+import {
+    Entity, Property, Relation, Count, Every, Average, Dictionary, KlassByName,
+    Controller, MonoSystem,
+} from 'interaqt';
+import { SQLiteDB } from '@drivers';
+import { MatchExp } from '@storage';
+
+describe('F2: GlobalCount/GlobalEvery incremental update uses the partial update record', () => {
+    // BUG: storage update events carry only the changed fields in `record`.
+    // GlobalCount's update branch passes that partial record straight to the
+    // user callback; any field not part of this update reads as undefined.
+    // (GlobalAny/GlobalSummation already re-fetch the full record - see Any.ts.)
+    test.fails('GlobalCount callback sees the full record on update', async () => {
+        const Task = Entity.create({
+            name: 'F2CountTask',
+            properties: [
+                Property.create({ name: 'status', type: 'string' }),
+                Property.create({ name: 'score', type: 'number' }),
+            ],
+        });
+        const dict = Dictionary.create({
+            name: 'f2ActiveHighScoreCount',
+            type: 'number',
+            collection: false,
+            computation: Count.create({
+                record: Task,
+                attributeQuery: ['status', 'score'],
+                callback: (t: any) => t.status === 'active' && t.score > 50,
+            }),
+        });
+        const system = new MonoSystem(new SQLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Task], relations: [], dict: [dict] });
+        await controller.setup(true);
+
+        const t1 = await system.storage.create('F2CountTask', { status: 'inactive', score: 80 });
+        expect(await system.storage.dict.get('f2ActiveHighScoreCount')).toBe(0);
+
+        // update only `status`; callback also needs `score`, which is not in the event payload
+        await system.storage.update('F2CountTask', MatchExp.atom({ key: 'id', value: ['=', t1.id] }), { status: 'active' });
+        expect(await system.storage.dict.get('f2ActiveHighScoreCount')).toBe(1);
+        await system.destroy();
+    });
+
+    test.fails('GlobalEvery callback sees the full record on update', async () => {
+        const Task = Entity.create({
+            name: 'F2EveryTask',
+            properties: [
+                Property.create({ name: 'status', type: 'string' }),
+                Property.create({ name: 'score', type: 'number' }),
+            ],
+        });
+        const dict = Dictionary.create({
+            name: 'f2AllGood',
+            type: 'boolean',
+            collection: false,
+            computation: Every.create({
+                record: Task,
+                attributeQuery: ['status', 'score'],
+                callback: (t: any) => t.status === 'active' && t.score > 50,
+                notEmpty: true,
+            }),
+        });
+        const system = new MonoSystem(new SQLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Task], relations: [], dict: [dict] });
+        await controller.setup(true);
+
+        const t1 = await system.storage.create('F2EveryTask', { status: 'inactive', score: 80 });
+        expect(await system.storage.dict.get('f2AllGood')).toBe(false);
+
+        await system.storage.update('F2EveryTask', MatchExp.atom({ key: 'id', value: ['=', t1.id] }), { status: 'active' });
+        expect(await system.storage.dict.get('f2AllGood')).toBe(true);
+        await system.destroy();
+    });
+});
+
+describe('F3: PropertyAverage update path builds a wrong relation match key', () => {
+    // BUG: the update branch always uses `relatedAttribute.slice(2)` for the
+    // match key. For a related-entity field update relatedAttribute is
+    // ['students'], so the key becomes plain 'id' - matching the RELATION's id
+    // against the STUDENT's id. Whenever those ids diverge (here: extra
+    // students created before the relation), findOne returns undefined and the
+    // computation throws `Cannot read properties of undefined (reading 'target')`,
+    // aborting the whole dispatch/update transaction.
+    // (Summation/Count build the key correctly with a three-way branch.)
+    test.fails('updating a related entity field recomputes the average when relation ids diverge from entity ids', async () => {
+        const Teacher = Entity.create({ name: 'F3Teacher', properties: [Property.create({ name: 'name', type: 'string' })] });
+        const Student = Entity.create({ name: 'F3Student', properties: [Property.create({ name: 'score', type: 'number' })] });
+        const rel = Relation.create({
+            source: Teacher,
+            sourceProperty: 'students',
+            target: Student,
+            targetProperty: 'teacher',
+            type: '1:n',
+        });
+        Teacher.properties.push(Property.create({
+            name: 'avgScore',
+            type: 'number',
+            computation: Average.create({ property: 'students', attributeQuery: ['score'] }),
+        }));
+
+        const system = new MonoSystem(new SQLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Teacher, Student], relations: [rel] });
+        await controller.setup(true);
+
+        const teacher = await system.storage.create('F3Teacher', { name: 'T1' });
+        // create extra students first so entity ids diverge from relation ids
+        await system.storage.create('F3Student', { score: 1 });
+        await system.storage.create('F3Student', { score: 2 });
+        const s1 = await system.storage.create('F3Student', { score: 80 });
+
+        await system.storage.addRelationByNameById(rel.name!, teacher.id, s1.id);
+
+        let found = await system.storage.findOne('F3Teacher',
+            MatchExp.atom({ key: 'id', value: ['=', teacher.id] }), undefined, ['*']);
+        expect(found.avgScore).toBe(80);
+
+        await system.storage.update('F3Student',
+            MatchExp.atom({ key: 'id', value: ['=', s1.id] }),
+            { score: 100 }
+        );
+
+        found = await system.storage.findOne('F3Teacher',
+            MatchExp.atom({ key: 'id', value: ['=', teacher.id] }), undefined, ['*']);
+        expect(found.avgScore).toBe(100);
+        await system.destroy();
+    });
+});

--- a/tests/runtime/review-repro-computations.spec.ts
+++ b/tests/runtime/review-repro-computations.spec.ts
@@ -1,11 +1,14 @@
 /**
- * Reproduction tests for review findings F2 (partial-record callbacks) and
+ * Regression tests for review findings F2 (partial-record callbacks) and
  * F3 (PropertyAverage relation match key)
  * (agentspace/output/core-runtime-builtins-review.md).
  *
- * Every test asserts the CORRECT behavior and is marked `test.fails`:
- * it passes today because the bug makes the assertion fail. When a bug is
- * fixed, the corresponding test will turn red - remove `.fails` then.
+ * Originally committed as failing-by-design (`test.fails`) reproductions;
+ * the bugs are fixed, so these now assert the correct behavior:
+ * - F2: GlobalCount/GlobalEvery re-fetch the full record on update instead of
+ *   passing the partial (changed-fields-only) event record to the callback.
+ * - F3: PropertyAverage builds the relation match key with the shared
+ *   three-way logic instead of always slicing the relatedAttribute path.
  */
 import { describe, expect, test } from 'vitest';
 import {
@@ -16,11 +19,10 @@ import { SQLiteDB } from '@drivers';
 import { MatchExp } from '@storage';
 
 describe('F2: GlobalCount/GlobalEvery incremental update uses the partial update record', () => {
-    // BUG: storage update events carry only the changed fields in `record`.
-    // GlobalCount's update branch passes that partial record straight to the
-    // user callback; any field not part of this update reads as undefined.
-    // (GlobalAny/GlobalSummation already re-fetch the full record - see Any.ts.)
-    test.fails('GlobalCount callback sees the full record on update', async () => {
+    // Storage update events carry only the changed fields in `record`; the
+    // update branch must re-fetch the full record before calling the user
+    // callback (same as GlobalAny/GlobalSummation).
+    test('GlobalCount callback sees the full record on update', async () => {
         const Task = Entity.create({
             name: 'F2CountTask',
             properties: [
@@ -52,7 +54,7 @@ describe('F2: GlobalCount/GlobalEvery incremental update uses the partial update
         await system.destroy();
     });
 
-    test.fails('GlobalEvery callback sees the full record on update', async () => {
+    test('GlobalEvery callback sees the full record on update', async () => {
         const Task = Entity.create({
             name: 'F2EveryTask',
             properties: [
@@ -86,15 +88,11 @@ describe('F2: GlobalCount/GlobalEvery incremental update uses the partial update
 });
 
 describe('F3: PropertyAverage update path builds a wrong relation match key', () => {
-    // BUG: the update branch always uses `relatedAttribute.slice(2)` for the
-    // match key. For a related-entity field update relatedAttribute is
-    // ['students'], so the key becomes plain 'id' - matching the RELATION's id
-    // against the STUDENT's id. Whenever those ids diverge (here: extra
-    // students created before the relation), findOne returns undefined and the
-    // computation throws `Cannot read properties of undefined (reading 'target')`,
-    // aborting the whole dispatch/update transaction.
-    // (Summation/Count build the key correctly with a three-way branch.)
-    test.fails('updating a related entity field recomputes the average when relation ids diverge from entity ids', async () => {
+    // For a related-entity field update relatedAttribute is ['students'], so the
+    // match key must be `target.id` (relation side), not a plain 'id' that would
+    // match the RELATION's id against the STUDENT's id. The scenario creates extra
+    // students first so relation ids diverge from entity ids.
+    test('updating a related entity field recomputes the average when relation ids diverge from entity ids', async () => {
         const Teacher = Entity.create({ name: 'F3Teacher', properties: [Property.create({ name: 'name', type: 'string' })] });
         const Student = Entity.create({ name: 'F3Student', properties: [Property.create({ name: 'score', type: 'number' })] });
         const rel = Relation.create({

--- a/tests/runtime/review-repro-guards.spec.ts
+++ b/tests/runtime/review-repro-guards.spec.ts
@@ -1,10 +1,16 @@
 /**
- * Reproduction tests for review findings F1 / F5 / F6
+ * Regression tests for review findings F1 / F5 / F6
  * (agentspace/output/core-runtime-builtins-review.md).
  *
- * Every test asserts the CORRECT behavior and is marked `test.fails`:
- * it passes today because the bug makes the assertion fail. When a bug is
- * fixed, the corresponding test will turn red - remove `.fails` then.
+ * Originally committed as failing-by-design (`test.fails`) reproductions;
+ * the bugs are fixed, so these now assert the correct guard-chain behavior:
+ * - F1: a missing optional payload field must not skip later field checks
+ * - F5: the guard chain is fail-closed (attributive base executes, unknown
+ *   concept types are rejected, isRef payloads must reference existing
+ *   records, undefined callback results are rejected, derived-concept
+ *   attributives execute)
+ * - F6: isRef user attributives are rejected outside an activity instead of
+ *   silently degrading to a role check
  */
 import { describe, expect, test } from 'vitest';
 import {
@@ -29,12 +35,8 @@ async function buildController(interaction: any, entities: any[] = []) {
     return { controller, system };
 }
 
-describe('F1: checkPayload early return', () => {
-    // BUG: `if (payloadItem === undefined) return;` in checkPayload should be
-    // `continue`. A missing OPTIONAL field defined before a REQUIRED field
-    // aborts the whole loop, skipping the required check (and every other
-    // check for the remaining fields).
-    test.fails('missing optional field before a required field must not bypass the required check', async () => {
+describe('F1: checkPayload must not stop at a missing optional field', () => {
+    test('missing optional field before a required field must not bypass the required check', async () => {
         const interaction = Interaction.create({
             name: 'f1CreateItem',
             action: Action.create({ name: 'f1CreateItem' }),
@@ -49,21 +51,23 @@ describe('F1: checkPayload early return', () => {
 
         const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: {} });
         expect(res.error).toBeTruthy();
+
+        // providing the required field (still omitting the optional one) passes
+        const ok = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { title: 'hello' } });
+        expect(ok.error).toBeUndefined();
         await system.destroy();
     });
 });
 
-describe('F5: guard chain fail-open', () => {
-    // BUG: checkConcept returns true for any Attributive base without ever
-    // calling its content - payload-level attributive checks are a no-op.
-    test.fails('F5-1: payload item with an Attributive base executes the attributive', async () => {
+describe('F5: guard chain is fail-closed', () => {
+    test('F5-1: payload item with an Attributive base executes the attributive', async () => {
         const RejectEverything = Attributive.create({
             name: 'RejectEverything',
             content: function () { return false; },
         });
         const interaction = Interaction.create({
-            name: 'f6AttributiveBase',
-            action: Action.create({ name: 'f6AttributiveBase' }),
+            name: 'f5AttributiveBase',
+            action: Action.create({ name: 'f5AttributiveBase' }),
             payload: Payload.create({
                 items: [
                     PayloadItem.create({ name: 'thing', type: 'Entity', base: RejectEverything as any }),
@@ -77,13 +81,49 @@ describe('F5: guard chain fail-open', () => {
         await system.destroy();
     });
 
-    // BUG: isRef payloads are only shape-checked ({id}); the referenced record
-    // is never verified to exist (or to belong to the declared entity).
-    test.fails('F5-3: isRef payload referencing a nonexistent record is rejected', async () => {
-        const Doc = Entity.create({ name: 'F6Doc', properties: [Property.create({ name: 'title', type: 'string' })] });
+    test('F5-1b: payload item with an accepting Attributive base passes', async () => {
+        const AcceptEverything = Attributive.create({
+            name: 'AcceptEverything',
+            content: function () { return true; },
+        });
         const interaction = Interaction.create({
-            name: 'f6IsRef',
-            action: Action.create({ name: 'f6IsRef' }),
+            name: 'f5AttributiveBaseOk',
+            action: Action.create({ name: 'f5AttributiveBaseOk' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'thing', type: 'Entity', base: AcceptEverything as any }),
+                ],
+            }),
+        });
+        const { controller, system } = await buildController(interaction);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { thing: { foo: 1 } } });
+        expect(res.error).toBeUndefined();
+        await system.destroy();
+    });
+
+    test('F5-2: unknown concept type as payload base is rejected instead of silently passing', async () => {
+        const interaction = Interaction.create({
+            name: 'f5UnknownConcept',
+            action: Action.create({ name: 'f5UnknownConcept' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'thing', type: 'Entity', base: { name: 'NotAConcept' } as any }),
+                ],
+            }),
+        });
+        const { controller, system } = await buildController(interaction);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { thing: { foo: 1 } } });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
+
+    test('F5-3: isRef payload referencing a nonexistent record is rejected', async () => {
+        const Doc = Entity.create({ name: 'F5Doc', properties: [Property.create({ name: 'title', type: 'string' })] });
+        const interaction = Interaction.create({
+            name: 'f5IsRef',
+            action: Action.create({ name: 'f5IsRef' }),
             payload: Payload.create({
                 items: [
                     PayloadItem.create({ name: 'doc', type: 'Entity', base: Doc, isRef: true }),
@@ -92,15 +132,17 @@ describe('F5: guard chain fail-open', () => {
         });
         const { controller, system } = await buildController(interaction, [Doc]);
 
-        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { doc: { id: 'no-such-id-999' } } });
-        expect(res.error).toBeTruthy();
+        const bad = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { doc: { id: 'no-such-id-999' } } });
+        expect(bad.error).toBeTruthy();
+
+        // an existing record passes
+        const doc = await system.storage.create('F5Doc', { title: 't' });
+        const ok = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { doc: { id: doc.id } } });
+        expect(ok.error).toBeUndefined();
         await system.destroy();
     });
 
-    // BUG: `if (result === undefined) return true` - an attributive callback
-    // that forgets to return grants access (fail-open). Thrown exceptions are
-    // fail-closed, undefined is not; the two should be consistent.
-    test.fails('F5-4: attributive callback returning undefined is fail-closed', async () => {
+    test('F5-4: attributive callback returning undefined is fail-closed', async () => {
         const ForgotReturn = Attributive.create({
             name: 'ForgotReturn',
             content: function (this: any, user: any) {
@@ -109,8 +151,8 @@ describe('F5: guard chain fail-open', () => {
             },
         });
         const interaction = Interaction.create({
-            name: 'f6Undefined',
-            action: Action.create({ name: 'f6Undefined' }),
+            name: 'f5Undefined',
+            action: Action.create({ name: 'f5Undefined' }),
             userAttributives: ForgotReturn,
         });
         const { controller, system } = await buildController(interaction);
@@ -119,19 +161,40 @@ describe('F5: guard chain fail-open', () => {
         expect(res.error).toBeTruthy();
         await system.destroy();
     });
+
+    test('F5-5: DerivedConcept attributive is executed, not skipped', async () => {
+        const Doc = Entity.create({ name: 'F5DerivedDoc', properties: [Property.create({ name: 'title', type: 'string' })] });
+        const RejectEverything = Attributive.create({
+            name: 'F5DerivedReject',
+            content: function () { return false; },
+        });
+        const derivedConcept = { name: 'RejectedDoc', base: Doc, attributive: RejectEverything };
+        const interaction = Interaction.create({
+            name: 'f5Derived',
+            action: Action.create({ name: 'f5Derived' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'doc', type: 'Entity', base: derivedConcept as any }),
+                ],
+            }),
+        });
+        const { controller, system } = await buildController(interaction, [Doc]);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { doc: { title: 't' } } });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
 });
 
 describe('F6: isRef attributive on a standalone interaction', () => {
     // isRef semantics = "must be the specific user bound in the activity refs".
-    // BUG: standalone checkUser has no isRef branch, so the attributive runs
-    // as a plain role check (`user.roles.includes('Approver')`). Outside an
-    // activity there are no refs, so an isRef attributive should be rejected
-    // (fail-closed) instead of silently changing meaning.
-    test.fails('isRef userAttributive outside an activity must not degrade to a role check', async () => {
+    // A standalone interaction has no refs context, so an isRef attributive must be
+    // rejected (fail-closed) instead of silently degrading into a role check.
+    test('isRef userAttributive outside an activity must not degrade to a role check', async () => {
         const boundApprover = createUserRoleAttributive({ name: 'Approver', isRef: true });
         const interaction = Interaction.create({
-            name: 'f7IsRefStandalone',
-            action: Action.create({ name: 'f7IsRefStandalone' }),
+            name: 'f6IsRefStandalone',
+            action: Action.create({ name: 'f6IsRefStandalone' }),
             userAttributives: boundApprover,
         });
         const { controller, system } = await buildController(interaction);

--- a/tests/runtime/review-repro-guards.spec.ts
+++ b/tests/runtime/review-repro-guards.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Reproduction tests for review findings F1 / F6 / F7
+ * Reproduction tests for review findings F1 / F5 / F6
  * (agentspace/output/core-runtime-builtins-review.md).
  *
  * Every test asserts the CORRECT behavior and is marked `test.fails`:
@@ -53,10 +53,10 @@ describe('F1: checkPayload early return', () => {
     });
 });
 
-describe('F6: guard chain fail-open', () => {
+describe('F5: guard chain fail-open', () => {
     // BUG: checkConcept returns true for any Attributive base without ever
     // calling its content - payload-level attributive checks are a no-op.
-    test.fails('F6-1: payload item with an Attributive base executes the attributive', async () => {
+    test.fails('F5-1: payload item with an Attributive base executes the attributive', async () => {
         const RejectEverything = Attributive.create({
             name: 'RejectEverything',
             content: function () { return false; },
@@ -79,7 +79,7 @@ describe('F6: guard chain fail-open', () => {
 
     // BUG: isRef payloads are only shape-checked ({id}); the referenced record
     // is never verified to exist (or to belong to the declared entity).
-    test.fails('F6-3: isRef payload referencing a nonexistent record is rejected', async () => {
+    test.fails('F5-3: isRef payload referencing a nonexistent record is rejected', async () => {
         const Doc = Entity.create({ name: 'F6Doc', properties: [Property.create({ name: 'title', type: 'string' })] });
         const interaction = Interaction.create({
             name: 'f6IsRef',
@@ -100,7 +100,7 @@ describe('F6: guard chain fail-open', () => {
     // BUG: `if (result === undefined) return true` - an attributive callback
     // that forgets to return grants access (fail-open). Thrown exceptions are
     // fail-closed, undefined is not; the two should be consistent.
-    test.fails('F6-4: attributive callback returning undefined is fail-closed', async () => {
+    test.fails('F5-4: attributive callback returning undefined is fail-closed', async () => {
         const ForgotReturn = Attributive.create({
             name: 'ForgotReturn',
             content: function (this: any, user: any) {
@@ -121,7 +121,7 @@ describe('F6: guard chain fail-open', () => {
     });
 });
 
-describe('F7: isRef attributive on a standalone interaction', () => {
+describe('F6: isRef attributive on a standalone interaction', () => {
     // isRef semantics = "must be the specific user bound in the activity refs".
     // BUG: standalone checkUser has no isRef branch, so the attributive runs
     // as a plain role check (`user.roles.includes('Approver')`). Outside an

--- a/tests/runtime/review-repro-guards.spec.ts
+++ b/tests/runtime/review-repro-guards.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Reproduction tests for review findings F1 / F6 / F7
+ * (agentspace/output/core-runtime-builtins-review.md).
+ *
+ * Every test asserts the CORRECT behavior and is marked `test.fails`:
+ * it passes today because the bug makes the assertion fail. When a bug is
+ * fixed, the corresponding test will turn red - remove `.fails` then.
+ */
+import { describe, expect, test } from 'vitest';
+import {
+    Entity, Property, KlassByName,
+    Controller, MonoSystem,
+    Interaction, Action, Payload, PayloadItem,
+    Attributive, createUserRoleAttributive,
+} from 'interaqt';
+import { SQLiteDB } from '@drivers';
+
+async function buildController(interaction: any, entities: any[] = []) {
+    const User = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+    const system = new MonoSystem(new SQLiteDB());
+    system.conceptClass = KlassByName;
+    const controller = new Controller({
+        system,
+        entities: [User, ...entities],
+        relations: [],
+        eventSources: [interaction],
+    });
+    await controller.setup(true);
+    return { controller, system };
+}
+
+describe('F1: checkPayload early return', () => {
+    // BUG: `if (payloadItem === undefined) return;` in checkPayload should be
+    // `continue`. A missing OPTIONAL field defined before a REQUIRED field
+    // aborts the whole loop, skipping the required check (and every other
+    // check for the remaining fields).
+    test.fails('missing optional field before a required field must not bypass the required check', async () => {
+        const interaction = Interaction.create({
+            name: 'f1CreateItem',
+            action: Action.create({ name: 'f1CreateItem' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'note', type: 'string', required: false }),
+                    PayloadItem.create({ name: 'title', type: 'string', required: true }),
+                ],
+            }),
+        });
+        const { controller, system } = await buildController(interaction);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: {} });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
+});
+
+describe('F6: guard chain fail-open', () => {
+    // BUG: checkConcept returns true for any Attributive base without ever
+    // calling its content - payload-level attributive checks are a no-op.
+    test.fails('F6-1: payload item with an Attributive base executes the attributive', async () => {
+        const RejectEverything = Attributive.create({
+            name: 'RejectEverything',
+            content: function () { return false; },
+        });
+        const interaction = Interaction.create({
+            name: 'f6AttributiveBase',
+            action: Action.create({ name: 'f6AttributiveBase' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'thing', type: 'Entity', base: RejectEverything as any }),
+                ],
+            }),
+        });
+        const { controller, system } = await buildController(interaction);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { thing: { foo: 1 } } });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
+
+    // BUG: isRef payloads are only shape-checked ({id}); the referenced record
+    // is never verified to exist (or to belong to the declared entity).
+    test.fails('F6-3: isRef payload referencing a nonexistent record is rejected', async () => {
+        const Doc = Entity.create({ name: 'F6Doc', properties: [Property.create({ name: 'title', type: 'string' })] });
+        const interaction = Interaction.create({
+            name: 'f6IsRef',
+            action: Action.create({ name: 'f6IsRef' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'doc', type: 'Entity', base: Doc, isRef: true }),
+                ],
+            }),
+        });
+        const { controller, system } = await buildController(interaction, [Doc]);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1' }, payload: { doc: { id: 'no-such-id-999' } } });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
+
+    // BUG: `if (result === undefined) return true` - an attributive callback
+    // that forgets to return grants access (fail-open). Thrown exceptions are
+    // fail-closed, undefined is not; the two should be consistent.
+    test.fails('F6-4: attributive callback returning undefined is fail-closed', async () => {
+        const ForgotReturn = Attributive.create({
+            name: 'ForgotReturn',
+            content: function (this: any, user: any) {
+                // developer forgot `return`; intent was to reject non-admins
+                user.roles?.includes('admin');
+            },
+        });
+        const interaction = Interaction.create({
+            name: 'f6Undefined',
+            action: Action.create({ name: 'f6Undefined' }),
+            userAttributives: ForgotReturn,
+        });
+        const { controller, system } = await buildController(interaction);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'u1', roles: [] } });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
+});
+
+describe('F7: isRef attributive on a standalone interaction', () => {
+    // isRef semantics = "must be the specific user bound in the activity refs".
+    // BUG: standalone checkUser has no isRef branch, so the attributive runs
+    // as a plain role check (`user.roles.includes('Approver')`). Outside an
+    // activity there are no refs, so an isRef attributive should be rejected
+    // (fail-closed) instead of silently changing meaning.
+    test.fails('isRef userAttributive outside an activity must not degrade to a role check', async () => {
+        const boundApprover = createUserRoleAttributive({ name: 'Approver', isRef: true });
+        const interaction = Interaction.create({
+            name: 'f7IsRefStandalone',
+            action: Action.create({ name: 'f7IsRefStandalone' }),
+            userAttributives: boundApprover,
+        });
+        const { controller, system } = await buildController(interaction);
+
+        const res = await controller.dispatch(interaction, { user: { id: 'intruder', roles: ['Approver'] } });
+        expect(res.error).toBeTruthy();
+        await system.destroy();
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes all fatal (F-level) issues identified in `agentspace/output/core-runtime-builtins-review.md`. Each issue was first re-verified against the source and via the committed failing-by-design reproduction tests before fixing. The review report itself is then cleaned up: fixed entries are deleted so the document only lists outstanding work.

### Fixes

- **F1** — `checkPayload` used `return` instead of `continue` when an optional field was missing, skipping all later field validation (including `required`). One-line fix plus a guarding comment.
- **F2** — `GlobalCountHandle` / `GlobalEveryHandle` passed the partial (changed-fields-only) update event record straight to the user callback. Both now re-fetch the full record via `findOne`, matching the already-correct `Any`/`Summation`/`WeightedSummation`/`Average` update paths. `Count` skips the fetch entirely when there is no callback (updates can't change membership then).
- **F3** — `PropertyAverageHandle`'s update branch always used `relatedAttribute.slice(2)` for the relation match key, crashing (`Cannot read properties of undefined (reading 'target')`) whenever relation ids diverge from entity ids. The correct three-way key construction was duplicated in 5 other handles; it is now extracted into `buildRelationSideMatchKey` in `Computation.ts` and shared by all six call sites.
- **F4** — Gateway support was broken end-to-end (`Gateway.is(graphNodeWrapper)` never true, `rawGatewayToNode` never populated, gateway uuid never dispatchable → activity stuck forever). Since Gateway definitions carry no branching conditions and the state model tracks a single `current` per sequence, full support isn't implementable without a redesign; `ActivityCall.buildGraph` now rejects activities that use Gateway nodes with a clear error pointing to `ActivityGroup` as the supported branching construct. The dead gateway wiring code was removed. (Pure structural definitions — `Gateway.create`, serialization — keep working.)
- **F5** — Guard chain is now fail-closed:
  - Attributive payload bases execute their content (previously an unconditional `return true`), including `Attributives` bool expressions.
  - Unknown concept types on a payload base are rejected instead of silently passing.
  - `isRef` payloads with an Entity/Relation base are verified to reference an existing record (uses `BoolExp.atom` from `@core` to avoid a new layering violation).
  - Guard callbacks (conditions and attributives) that return `undefined` or have no content fail with an explicit "did you forget a return statement?" message instead of granting access.
  - `DerivedConcept.attributive` executes (previously dead code with two identical branches).
- **F6** — An `isRef` user attributive on a standalone interaction previously degraded silently into a role check. It now throws a clear `InteractionGuardError` explaining that `isRef` can only be checked inside an activity.
- **F7(a)** — `AnyActivityStateNode.onChange` returned a pruned `children` array that no caller consumed, so mutually exclusive branches of an `any` group could all be executed sequentially (deterministic double-spend). `onChange` now prunes `this.children` in place, and the group completes when the surviving multi-step branch runs to its end.
- **F7(b)** — `completeInteractionState` was an unguarded read-modify-write; the concurrent-loser path crashed with an unhandled `TypeError`. Activity records now carry a `stateVersion` optimistic lock: the state write is conditioned on the version read, a conflict aborts with a clear retriable error, and completing an interaction that is no longer in the state raises an explicit "not available" error.

### Behavioral changes (fail-open → fail-closed)

Users relying on implicit passes will now see explicit errors: guard callbacks returning `undefined`, unknown payload concept types, dangling `isRef` payload ids, `isRef` user attributives on standalone interactions, and Gateway-based activities. All error messages state the cause and the fix.

### Review report cleanup

`agentspace/output/core-runtime-builtins-review.md` no longer lists the fixed fatal issues: the whole Fatal section, the S18 row (merged into F7(a)), the fixed P0/P1/P2 priority entries, and the repro-test section were deleted so the report can't mislead future work. A maintenance note at the top records what was fixed and where the regression tests live; remaining sections were renumbered and stale line references updated.

### Tests

- The three `tests/runtime/review-repro-*.spec.ts` files (previously `test.fails` reproductions) were converted into regular regression tests asserting the fixed behavior, and extended with coverage for F5-1b/2/5, gateway rejection, any-group completion + pruning, `stateVersion` increments, and the CAS conflict path.
- `tests/runtime/interactionEdgePaths.spec.ts` updated for the new `checkPayload` controller parameter; `tests/runtime/condition.spec.ts`'s undefined-return test updated to assert the new fail-closed semantics.
- Full suite: **1653 passed / 26 skipped** (baseline before this PR: 1636 passed / 26 skipped), `npm run check` clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e66332d-5af5-47cb-a393-0ee6351d9cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e66332d-5af5-47cb-a393-0ee6351d9cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

