### PR TITLE
Third-round deep review: fix 5 reproduced fatal bugs + hardening, with combination-matrix test coverage

### DIFF
--- a/agent/agentspace/knowledge/usage/04-reactive-computations.md
+++ b/agent/agentspace/knowledge/usage/04-reactive-computations.md
@@ -89,6 +89,11 @@ Custom computations are different because interaqt cannot inspect user callback 
 
 Custom incremental computations must declare an incremental plan. Use `incrementalDataDeps: [...]` for the common case, or `planIncremental(event, record, context)` when the computation needs to choose between incremental, full recompute, and skip per event. Incremental callbacks receive only the planned partial `dataDeps`; the runtime no longer resolves all declared dependencies before incremental execution.
 
+Two contract details for Custom `dataDeps`:
+
+- **`records` dataDeps must declare `attributeQuery`.** Setup fails fast otherwise, because an undeclared field set would resolve to id-only records and field updates would never re-trigger the computation. Declare the fields your `compute` reads (e.g. `attributeQuery: ['price']`), or pass an explicit `attributeQuery: []` when the computation only depends on record membership (create/delete).
+- **`incrementalDataDeps` names the dependency values to resolve and pass into `incrementalCompute`; it is not an event filter.** Events from every declared `dataDep` reach `incrementalCompute` — distinguish sources by `event.recordName` inside the callback, or use `planIncremental` to return different plans per dependency. (Create/update events of unrelated global dicts are already filtered by key at the source-map level and never trigger the computation.)
+
 Because retry replays the transaction attempt, `guard`, `mapEventData`, `resolve`, computation callbacks, `afterDispatch`, and `asyncReturn` must be deterministic and retry-safe. Put irreversible external IO in `postCommit` for interaction-specific effects or `recordMutationSideEffects` for mutation-driven effects; both run after the final commit.
 
 ### Scoped Atomic Sequences

--- a/agentspace/output/deep-review-2026-07-09-r3.md
+++ b/agentspace/output/deep-review-2026-07-09-r3.md
@@ -1,0 +1,289 @@
+# 全代码库深度 Review 报告（2026-07-09 第三轮）
+
+- 日期：2026-07-09
+- 基线：`main` @ `9e2b1e99`（PR #18 合入之后，前两轮 review 修复全部落地）
+- 范围：`src/core`、`src/runtime`（含 computations、migration、ScopedSequence）、`src/storage`、`src/builtins`、`src/drivers` 全量
+- 方法：五个方向并行深度探查（storage 读路径 / storage 写路径 / runtime 主路径 / computations / core+builtins+drivers+migration）→ 人工精读交叉验证 → **对每个致命候选编写最小复现测试并实际运行**（PGLiteDB / SQLiteDB）。只有「已运行复现确认」的问题列为致命；仅凭精读判定的问题单独分级并标注置信度。
+- 与既有报告的关系：第一轮（`full-codebase-review-2026-07.md`）与第二轮（`deep-review-2026-07-08-r2.md`）的致命与重要项已全部修复并有回归测试；其「明确遗留」项（R-6/I-15 驱动类型映射、I-5 级联深度、I-6 async task 清理、I-7~I-11 合表事件、I-12/I-13 migration 运维、I-14/I-16/I-17、S1~S4/S8）仍然有效，本报告不重复展开。本报告发现均为**新增**。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1693 passed / 26 skipped，全部通过。
+
+---
+
+## 一、结论摘要
+
+前两轮修复后，运行时主干（dispatch/事务/增量聚合边界）已明显收敛。本轮火力集中在**上一轮修复的完备性**与**未覆盖的正交组合**：computed 属性 × filtered entity、复合谓词 × filtered relation、relation-as-source × x:n 查询、Custom 的增量协议、以及 `keys`/关系变更事件的联动。发现 5 个已复现的致命问题、2 个已复现的重要问题和 7 个高置信度重要问题。
+
+值得注意的规律：**F-1、F-3、F-5、R-1 全部是「上一轮修复只覆盖了名义路径」的产物**——F-3（r2 修复了裸 property dataDep，漏了 records dataDep 的同族问题）、F-1/R-1（r2 让 update 事件带上 `keys`，但成员资格 diff 与关系变更路径没有对齐同一套「实际写入集合」语义）、F-5（内置聚合的 `defaultDataBasedIncrementalPlan` 有 depRole 兜底，Custom 的 fallback 分支没有）。修复时建议按「同族路径全覆盖」的标准处理。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现） | 5 | computed 属性上的 filtered entity 无成员资格事件、filtered relation 复合谓词查询崩溃、records dataDep 缺 attributeQuery 静默错值、relation 侧 x:n 属性查询崩溃、Custom incrementalDataDeps 喂入无关事件产出垃圾值 |
+| 重要（已复现） | 2 | 纯关系变更不发宿主 update 事件（trigger.keys 死路径二号）、SQLite insert() 污染返回记录 |
+| 重要（精读，高置信度） | 7 | Every/Any findOne 空守卫缺失、asyncReturn 残余竞态、RealTime 无时间调度器、迁移成功先于 listener 注册、Transform lockRecord miss 留孤儿、批量 1:n 孤儿静默丢弃、filtered rebase 防御性错误 |
+| 显著改进 | 若干 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认）
+
+### F-1 `computed` 属性上的 filtered entity：更新输入字段后**不产生成员资格事件**，下游增量计算永久脏数据
+
+- 位置：
+  - `src/storage/erstorage/UpdateExecutor.ts` L61（`changedFields = Object.keys(newEntityData.getData())`——只含**用户 payload 的键**）、L68（以该集合调用 `collectMembershipChecks`）；
+  - `src/storage/erstorage/FilteredEntityManager.ts` L381–384（依赖属性与 `changedFields` 无交集时直接 `continue`，跳过快照）；
+  - 对照：`src/storage/erstorage/NewRecordData.ts` L216–229（`getSameRowFieldAndValue` **确实**重算并落库了 computed 列，且 r2 修复后 update 事件的 `keys` 也包含它）。
+- 复现（REPRO-1，实测输出）：`Task.isActive = computed(status === 'active')`，`ActiveTask = Task[isActive = true]`，`Count({record: ActiveTask})`。`update Task {status: 'inactive'}` 后：
+
+```
+查询侧：find('ActiveTask') → 0 行 ✓（谓词实时求值，正确）
+事件侧：events = [{type:'update', recordName:'Task', keys:['status','isActive']}]
+        ← 没有 ActiveTask 的 delete 事件 ❌
+计算侧：activeTaskCount 停留 1 ❌（对照组：谓词直接建在普通属性上时 delete 事件正常产生）
+```
+
+- 影响：与 r2 的 F-1（迁移期谓词变更）同构的运行期版本——查询侧永远正确、计算侧永久错误、无任何告警。凡是 filtered 谓词引用了 `computed` 属性的建模（例如「派生状态列 + 视图」这一常见组合）全部踩中。
+- 修复方向：`collectMembershipChecks` 的 `changedFields` 改用**实际写入集合**（即 `getSameRowFieldAndValue` 的输出，与 update 事件的 `keys` 同源），而不是 payload 键；或在 setup 时把 computed 列的输入字段注册进 filtered 依赖的属性集合。前者一处改动同时对齐两套语义，更优。
+
+### F-2 filtered relation 的 attributeQuery 带**复合** matchExpression：查询构造期崩溃
+
+- 位置：`src/storage/erstorage/AttributeQuery.ts` L174——`rebasedMatchExp.and(subMatchExp.data)`。`subMatchExp` 是 `BoolExp`，而 `BoolExp.data` 只在 **atom** 上有定义（`BoolExp.ts` L270–272）；复合表达式（`.and()`/`.or()` 过的）取到 `undefined`，随后 `MatchExp.and` 的 `assert(condition.key !== undefined)`（`MatchExp.ts` L401）抛出。
+- 复现（REPRO-2，实测输出）：`PinnedPosts`（filtered relation）上带 `MatchExp.atom(...).and({...})` 的嵌套查询：
+
+```
+TypeError: Cannot read properties of undefined (reading 'key')
+  at MatchExp.and (MatchExp.ts:401)
+  at AttributeQuery.ts:174 ❌
+```
+
+- 影响：单 atom 的嵌套过滤正常，任何复合过滤在 filtered relation 属性上直接崩——合法查询形态不可用，且错误信息（`key cannot be undefined`）与用户写法毫无关联。
+- 修复方向：L174 改为 `rebasedMatchExp.and(subMatchExp instanceof BoolExp ? subMatchExp : ...)` 并让 `MatchExp.and` 接受 BoolExp/ExpressionData（它对 atom-like 对象的分支已存在，缺表达式分支）；或统一走 `BoolExp.standardizeData`。
+
+### F-3 `records` dataDep 不带 `attributeQuery`：compute 只拿到 `{id}`、update 永不触发——静默错误值
+
+- 位置：`src/runtime/ComputationSourceMap.ts` L314–323（records 依赖的 update 监听只在能提取出 attributeQuery/match/modifier 字段时注册，否则静默跳过）；取数侧对无 attributeQuery 的 records 依赖只查 `id`。
+- 复现（REPRO-4，实测输出）：`Custom.create({ dataDeps: { items: { type: 'records', source: Item } }, compute: sum(price) })`：
+
+```
+create Item{price:10} 后：compute 被调 1 次，items = [{"id":"..."}]（没有 price）→ dict = 0 ❌（应为 10）
+update price→99 后：compute 不再被调（callsAfterUpdate 仍为 1）→ dict = 0 ❌（应为 99）
+```
+
+- 影响：这是 r2 F-2（裸 property dataDep）的**同族问题**：r2 对 property 依赖加了 setup 期 fail-fast（`ComputationSourceMap.ts` L333–341），但 records 依赖的同样形态漏掉了。双重静默：值錯（字段缺失）+ 停滞（无 update 监听）。
+- 修复方向：与 property 依赖对齐——records dataDep 无 attributeQuery 时要么 setup 期抛 `ComputationProtocolError`（推荐，符合显式控制），要么明确语义为「监听全字段 + 取全字段」。二选一，不能维持现状。
+
+### F-4 relation-as-source 的 x:n 关系：从 relation 侧查询**必然崩溃**于内部 assert
+
+- 位置：`src/storage/erstorage/EntityToTableMap.ts` L380–390——`getReverseAttribute` 对 `record.isRelation` 的记录断言 `attribute === 'source' || 'target'`，但 relation 记录上完全可以携带**其他关系属性**（`Relation.create({ source: someRelation, sourceProperty: 'tags', ... })` 是合法建模，测试数据 `tests/storage/data/common.ts` L112–119 的 `teamBaseRelation` 即为此形态的 1:1 版本）。调用链：`QueryExecutor.findXToManyRelatedRecords` L547 / `findRecords` L275 → `AttributeInfo.getReverseInfo` L151 → 崩溃。
+- 复现（REPRO-3/3b/11，实测输出）：`LinkTag = Relation.create({ source: PersonProfile /* relation */, sourceProperty: 'tags', target: Tag, type: 'n:n' })`：
+
+```
+setup ✓；create 链路 ✓（从 Tag 侧写入 links 正常）；从 Tag 侧查询 links ✓
+find(relationName, ..., [['tags', {...}]])                     → 崩溃 ❌
+find('Person', ..., [['profile', {aq: [['&', {aq: [['tags',…]]}]]}]]) → 崩溃 ❌
+Error: wrong attribute tags for relation R3Person_profile_owner_R3Profile
+```
+
+- 影响：合法建模形态（关系上的标注/标签是常见需求）可以建表、可以写入、可以从实体侧读，唯独从 relation 侧读必崩，且错误是内部断言。半可用状态比完全不支持更危险。
+- 修复方向：`getReverseAttribute` 对 relation 记录先查 `record.attributes[attribute]` 是否为普通 RecordAttribute（走与实体相同的 linkName 反查分支），仅在 attribute 确为 source/target 时走特殊分支。x:1 方向（`teamBaseRelation.base`）已能工作，说明其余管线基本就绪。
+
+### F-5 Custom `incrementalDataDeps`：所有事件（包括自身 dict 创建、未声明依赖的事件）都被喂进 `incrementalCompute`——静默垃圾值
+
+- 位置：`src/runtime/computations/Custom.ts` L192–204——`incrementalDataDeps` 的 fallback plan 只看 `context.skip / context.requiresFullRecompute`，从不检查**事件属于哪个 dataDep**；对照内置聚合的 `defaultDataBasedIncrementalPlan`（`Computation.ts` L312–314）会对 `depRole !== 'primary'` 的事件返回 fullRecompute。
+- 复现（REPRO-8，实测输出）：`dataDeps: { items: records, threshold: global }`、`incrementalDataDeps: ['threshold']`、`incrementalCompute` 按 Item 事件形态写：
+
+```
+实际喂入 incrementalCompute 的事件序列：
+  _Dictionary_ create (r3dSum 自身!)、_Dictionary_ create (threshold)、
+  R3dItem create、_Dictionary_ update (threshold)
+最终 dict 值："0[object Object][object Object]5[object Object]" ❌（应为 5）
+```
+
+- 影响：按文档（`04-reactive-computations.md` L90「Use incrementalDataDeps for the common case」）写出的声明产出字符串垃圾并持久化，无任何错误。用户 `incrementalCompute` 的事件契约完全不可依赖。
+- 修复方向：fallback plan 中根据 `context.depName/depRole` 判断——事件不属于 `incrementalDataDeps` 声明的依赖时返回 `fullRecompute`；自身 bound-state / 输出 dict 的事件应直接 skip。同时补文档明确事件契约。
+
+---
+
+## 三、重要问题
+
+### R-1 纯关系变更不发宿主 update 事件：`trigger.keys` 指向关系属性时静默永不触发（已复现）
+
+- 位置：`src/storage/erstorage/CreationExecutor.ts` L186–207——宿主 update 事件以 `newEntityData.valueAttributes.length` 为门槛；`{profile: {id}}` 这类纯关系 payload 的 valueAttributes 为空 → 只有 link create/delete 事件，无宿主 update、无 `keys`。
+- 复现（REPRO-7，实测输出）：`StateTransfer.trigger = { recordName:'Person', type:'update', keys:['profile'] }`，`storage.update('Person', ..., {profile:{id}})`：
+
+```
+events = [{type:'create', recordName:'Person_profile_owner_Profile'}]（无宿主 update）
+status 停留 'draft' ❌（应为 'assigned'）
+```
+
+- 影响：与 r2 已修复的 F-3（trigger.keys 死 API）同族——类型系统允许的声明静默失效。可以说 r2 的修复只救活了值属性的 keys，关系属性的 keys 仍是死路径。
+- 修复方向：关系替换成功时（`handleUpdateReliance` 的 unlink+addLink 路径）为宿主合成一条 `update` 事件、`keys` 含被替换的关系属性名；或在 `TransitionFinder`/setup 期对指向关系属性的 `keys` 抛出明确的「不支持」错误。两者都比现状好，前者语义更完整。
+
+### R-2 SQLite `insert()` 仍用 `.run()`：创建返回的记录被 better-sqlite3 元数据污染（已复现）
+
+- 位置：`src/drivers/SQLite.ts` L131（`INSERT ... RETURNING _rowId` + `.run()`）；`CreationExecutor.insertSameRowData` L270–272 将返回值 `Object.assign` 进记录。
+- 复现（REPRO-10，实测输出）：
+
+```
+storage.create('Doc', {title:'t'}) → {"changes":1,"lastInsertRowid":1,"title":"t","id":1} ❌
+```
+
+- 影响：`changes`/`lastInsertRowid` 两个垃圾键随记录返回（并可能进入 create 事件的 record），与 PG/PGLite 驱动（返回 RETURNING 行）契约不一致。r2 R-5 修了 `update()`，`insert()` 漏掉了——同一族第二次漏修。
+- 修复方向：`.all()` 取行并返回首行（与 `update()` 修复一致）；顺带审查 `Mysql.ts` insert 契约。
+
+### R-3 `PropertyEveryHandle` / `PropertyAnyHandle` 缺 `findOne` 空守卫（fa3e5d38 修复不完整；精读，高置信度）
+
+- 位置：`Every.ts` L220–226（create 分支）、L264–266（update 分支）；`Any.ts` 同族——`findOne` 返回 null 时直接解引用 `[isSource?'target':'source']` 抛 TypeError。对照 `Count.ts` L232–234、L272–274 已加守卫并回退 `fullRecompute`。
+- 影响：filtered relation 成员资格时序 / 级联竞态下计算调度硬崩溃而非优雅重算。上一轮同一修复（fa3e5d38）覆盖了 Count/Sum/Avg/Weighted，漏了 Every/Any——六 handle 复制粘贴漂移（既有遗留 I-1）的又一实证。
+- 修复方向：移植相同守卫；根治靠抽取共享模板。
+
+### R-4 `handleAsyncReturn` 残余竞态窗口（PostgreSQL READ COMMITTED；精读，中高置信度，未复现）
+
+- 位置：`src/runtime/Scheduler.ts` L916–991 + `MonoSystem.ts` L1064–1078。r2 修复（6ff6b08a）对**已存在**的同 freshnessKey 行取锁是正确的，但仍有两个窗口：(1) `lockRows` 是「先 find 再 FOR UPDATE」的快照，两步之间并发插入的新 task（幻影行）不在锁集内；(2) `isLatest` 判定通过后到 `applyResult` 提交之间，另一连接可插入并应用更新的 task，旧结果后写覆盖。
+- 修复方向：对 freshnessKey 做 advisory lock（PG `pg_advisory_xact_lock(hash(freshnessKey))`），或 apply 后在同事务内二次校验 isLatest。通用 `lockRows`（`Transform.ts` L152 也在用）的 find-then-lock 语义应在能力声明中写明。
+
+### R-5 RealTime 的 `nextRecomputeTime` 只落库、无任何调度器消费——纯时间驱动的 RealTime 永久冻结（精读+grep 确认）
+
+- 位置：`RealTime.ts` L91–94/L152–155 持久化 `nextRecomputeTime`；`rg 'RealTime' src/runtime/Scheduler.ts` 零命中，`src/runtime` 无 setInterval/timer/轮询消费该状态。文档（`14-api-reference.md`）却给出「Update every second / every 5 minutes」的示例。
+- 影响：没有 dataDep 变更的 RealTime 值在首次计算后永不刷新，与文档承诺直接矛盾。测试（`realTime.spec.ts`）只断言了状态落库，从未等待定时重算——掩盖了缺口。
+- 修复方向：要么实现基于 `nextRecomputeTime` 的调度入口（例如 controller 暴露 `runDueRealTimeComputations()` 供宿主定时调用，符合显式控制原则），要么在文档与 API 上明确「时间驱动重算需要外部调度」，并让 `realTime.spec.ts` 覆盖该契约。
+
+### R-6 迁移 `succeeded` 落账早于 `scheduler.setup(false)`：后者失败时数据库已迁移但**无任何计算监听器**（精读，高置信度）
+
+- 位置：`src/runtime/Controller.ts` L490–498（CAUTION 注释已自认这一拆分）。
+- 影响：migration log 显示成功、schema/manifest 均为新版，但 mutation listeners 未注册——后续 dispatch 落数据而所有增量计算冻结，属「静默失效框架」。虽是有意的 resume 取舍，但缺少一个可观测的中间态。
+- 修复方向：增加 `listeners-registered` 之类的终态 phase（成功 = `succeeded` + 该 phase 完成）；`scheduler.setup` 失败时在 migration log 里追加明确的 warning 记录，而不是仅向上抛。
+
+### R-7 Transform update 路径：`lockRecord` miss 返回 `[]`，既有派生行成为孤儿（精读，中高置信度）
+
+- 位置：`src/runtime/computations/Transform.ts` L145–147。update patch 路径中源记录锁不到（并发删除/竞态）时直接返回空 patch；对照 delete 路径（L185–190）会删除全部映射行。
+- 修复方向：lockRecord miss 时按 delete 语义清理该 sourceRecordId 的全部派生行（幂等），或返回 `fullRecompute`。
+
+### R-8 批量 1:n 回填：父记录解析失败的子行被静默丢弃（精读，高置信度）
+
+- 位置：`src/storage/erstorage/QueryExecutor.ts` L434–467——`findXToManyRelatedRecordsBatched` 按反向属性 id 分组，`parent` 找不到时子行不进任何结果、无日志。引用不一致或反向属性注入 bug 时数据「看起来合法地为空」。
+- 修复方向：至少 `console.warn`/logger 记录 orphan 数量；更严格可抛 `DatabaseError`。
+
+### R-9 filtered rebase 的旧成员查询用了新 base——防御性错误，当前不可达（已验证被阻断）
+
+- 位置：`src/runtime/migration.ts` L3352–3372——`recomputeFilteredMemberships` 对 predicate-changed 的记录统一以 `change.newRecord.resolvedBaseRecordName` 查询旧成员集合；若 filtered 记录 rebase（同名换 base），旧成员将在错误的表上求值。
+- 实测（REPRO-9）：rebase 场景在 `Controller.migrate` L444–446 被 blocking change（`physical-path-move: fact record table changed`）**先行拦截**，migration 直接抛错，故该代码缺陷当前不可达。列为防御性修复项：改用 `change.oldRecord.resolvedBaseRecordName`，并留注释说明 rebase 被 blocking check 拦截的前提。
+
+---
+
+## 四、显著值得改进的地方
+
+### 4.1 storage
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | `MatchExp.fromObject` 类型签名与实现矛盾 | `MatchExp.ts` L31–39 | 签名声明 `{[k]: MatchAtom}`，实现按原始值处理（`value: ['=', value]`），文档示例用原始值。按声明类型传 MatchAtom 会把对象嵌成 RHS。改签名为 `{[k]: unknown}` 或支持两种形态；补测试 |
+| I-2 | x:n 谓词一律禁用 SQL LIMIT，即使走 EXISTS 无扇出 | `QueryExecutor.ts` L343–348 | `['exist', ...]` 在 SQLBuilder 里是 EXISTS 子查询、不产生行扇出，却仍触发 post-pagination 全量拉取。热查询 `limit 20` 退化为全表读。可按 atom 粒度判定是否真有 JOIN 扇出 |
+| I-3 | `updateRecord` 返回值遗漏 dependency 合并 | `UpdateExecutor.ts` L72 vs L81 | `result.push` 用了原始 `newEntityData` 而非 L72 的 `newEntityDataWithDep`，嵌套创建的依赖数据不在返回记录中 |
+| I-4 | `completeXToOneLeftoverRecords` 的根 parentLink 路径缺空守卫 | `QueryExecutor.ts` L482–498、L525–528 | 与 F-4 同块代码；可空 x:1 为 null 时 `[].concat(...)` 得 `[null]` 继续递归。修 F-4 时一并加守卫 |
+| I-5 | 合表 create 事件 / relocate 事件完整性 | （既有遗留 I-7~I-9） | 维持上一轮结论，等待 mergeLinks 去留决策 |
+
+### 4.2 runtime / computations
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-6 | `trigger.keys: []` 空数组恒真匹配 | `TransitionFinder.ts` L14–15 | `[].every()` vacuous true；应在 StateTransfer 构造时拒绝空数组或文档化 |
+| I-7 | `shouldTriggerUpdateComputation` 不消费 `event.keys` | `ComputationSourceMap.ts` L190–209 | 现靠 record/oldRecord 字段对比间接对齐；keys 已是一等公民，触发判定应统一用它，避免未来局部事件形态走偏 |
+| I-8 | PropertyAverage 无负 count 守卫；Every/Any update 分支死赋值 | `Average.ts` L308–311；`Every.ts` L251、`Any.ts` L221 | 与 Count 的 `count < 0 throw` 不对称；死代码顺手清理 |
+| I-9 | Global Count/Every/Any/WeightedSummation 的 create 分支用事件局部 record 求 callback，Sum/Average 用 findOne | `Count.ts` L74–77 等 | 本轮 REPRO-5 实测简单嵌套场景未出错（事件 record 含创建 payload），但六 handle 两种策略并存是漂移温床；抽共享模板时统一为 findOne + attributeQuery |
+| I-10 | ScopedSequence match 不拦截非命中记录的手工 serial 值 | `ScopedSequence.ts` L48–52 | match 不命中时 payload 里的 serialNumber 原样落库，`allowManualValue: false` 只在命中时生效；至少文档化 |
+| I-11 | ScopedSequence 迁移 seed 的 SQL 快路径不支持点路径 match，全量回退 JS 过滤 | `migration.ts` L2532 | 正确性有兜底，大表迁移性能风险；可扩展 SQL 编译支持 `project.id` |
+
+### 4.3 core / builtins / migration
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-12 | activity `refs` 是无版本的 read-modify-write | `ActivityCall.ts` L375–395 | stateVersion CAS（r2 R-1 修复）不覆盖 refs 合并；并发 every 分支可互相覆盖 refs。建议 refs 合并进同一 CAS 行或对 refs 行加锁 |
+| I-13 | head interaction 带 `activityId` 时走 `interaction.guard` 而非 `fullGuardWithUserRef` | `ActivityManager.ts` L106–123 | 头交互 + isRef userAttributive + 重放/自建 activityId 的组合下 guard 语义与非头交互不一致 |
+| I-14 | `filtered-predicate-changed` 只进 `changes` 不进 `requiredDecisions` | `migration.ts` L1667–1677 | 语义变更自动 rebuild 是对的，但审阅者不被强制确认；大 diff 中易被忽略 |
+| I-15 | `rename-candidate-reviewed` 决策在 migrate 期恒被拒绝 | `migration.ts` L1927–1928 | rename 工作流有类型、无实现；要么补实现要么从类型面移除 |
+| I-16 | `decodeFunctionValues` 对反序列化字符串 `new Function` | `core/utils.ts` L78–80 | manifest 来源可信时可接受；应在文档中写明信任边界 |
+| I-17 | `computedUpdateEvent.spec.ts` 未断言 `keys` 包含 computed 字段 | 测试缺口 | F-3（r2）回归网漏洞；本轮 REPRO-1b 实测 keys 行为正确，补一行断言即可锁定 |
+| I-18 | filtered **relation** 谓词变更迁移零回归覆盖 | 测试缺口 | 代码同路径（`recomputeFilteredMemberships` 不分 entity/relation），但 manifest 反序列化/normalizeMatch 的回归无网兜底 |
+
+### 4.4 既有报告遗留项（仍有效）
+
+第一轮的 I-2、I-5、I-7、I-9~I-12、S1~S4、S8；第二轮的 R-6/I-15（驱动类型映射）、I-5（级联深度）、I-6（async task 清理）、I-7~I-11（合表事件）、I-12/I-13（migration 运维）、I-14/I-16/I-17。本轮 R-3/I-8/I-9 再次证明：**六个聚合 handle 的共享模板抽取（第一轮 I-1）应提升优先级**——三轮 review 中它累计贡献了 7 个具体缺陷。
+
+---
+
+## 五、修复优先级建议
+
+**P0（静默错误数据 / 合法声明不可用，全部有复现可转回归）：**
+1. F-1 成员资格 diff 的 `changedFields` 改用实际写入集合（与 `keys` 同源）——「查询正确 + 计算永久错」组合最危险
+2. F-5 Custom incrementalDataDeps 的事件过滤（非声明依赖 → fullRecompute；自身输出事件 → skip）
+3. F-3 records dataDep 缺 attributeQuery 的 setup 期 fail-fast（与 r2 property 修复对齐）
+4. F-2 filtered relation 复合谓词合并（一处 standardize）
+5. F-4 relation 记录的 getReverseAttribute 支持普通关系属性
+
+**P1（同族补漏 / 并发正确性）：**
+R-1 关系变更的宿主 update 事件（或 fail-fast）、R-2 SQLite insert() `.all()`、R-3 Every/Any 空守卫移植、R-7 Transform lockRecord miss 清理、R-4 asyncReturn advisory lock、R-9 rebase 防御性修正 + I-17/I-18 测试补漏。
+
+**P2（契约与运维）：**
+R-5 RealTime 调度契约（实现或文档化）、R-6 迁移终态 phase、I-1~I-16。
+
+---
+
+## 附录：复现测试代码（验证用，未提交为正式测试）
+
+以下测试在 `9e2b1e99` 上以 PGLiteDB/SQLiteDB 运行，结果如注释所示。修复时可改造为回归测试（断言改为正确语义）。
+
+```ts
+// F-1 (REPRO-1)：computed 属性上的 filtered entity 无成员资格事件
+const Task = Entity.create({ name: 'Task', properties: [
+  Property.create({ name: 'status', type: 'string' }),
+  Property.create({ name: 'isActive', type: 'boolean', computed: r => r.status === 'active' }),
+]})
+const ActiveTask = Entity.create({ name: 'ActiveTask', baseEntity: Task,
+  matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }) })
+// Count({record: ActiveTask}) 挂在 dict 上；create {status:'active'} → count=1
+await storage.update('Task', matchId, { status: 'inactive' }, events)
+// events 只有 Task update（keys 含 isActive ✓），无 ActiveTask delete ❌；count 停留 1 ❌
+
+// F-2 (REPRO-2)：filtered relation + 复合 matchExpression
+await storage.find('User', matchId, undefined, [
+  ['pinnedPosts', { attributeQuery: ['title'],
+    matchExpression: MatchExp.atom({key:'title',value:['like','Al%']})
+      .and({key:'status',value:['=','published']}) }],   // ← 复合
+])
+// TypeError: Cannot read properties of undefined (reading 'key') @ MatchExp.and ❌
+
+// F-3 (REPRO-4)：records dataDep 缺 attributeQuery
+Custom.create({ dataDeps: { items: { type: 'records', source: Item } },  // 无 attributeQuery
+  compute: deps => deps.items.reduce((a, i) => a + (i.price ?? 0), 0), getDefaultValue: () => 0 })
+// create {price:10}：compute 收到 items=[{id}] → 0 ❌；update price→99：compute 不触发 ❌
+
+// F-4 (REPRO-3/11)：relation-as-source x:n 查询
+const LinkTag = Relation.create({ source: PersonProfile /* relation */,
+  sourceProperty: 'tags', target: Tag, targetProperty: 'links', type: 'n:n' })
+// 写入 ✓、Tag 侧查询 ✓；relation 侧：
+await storage.find(PersonProfile.name, undefined, undefined, ['id', ['tags', {...}]])
+// Error: wrong attribute tags for relation ... @ getReverseAttribute ❌
+
+// F-5 (REPRO-8)：incrementalDataDeps 喂入无关事件
+Custom.create({ useLastValue: true,
+  dataDeps: { items: {type:'records',source:Item,attributeQuery:['value']},
+              threshold: {type:'global',source:thresholdDict} },
+  incrementalDataDeps: ['threshold'],
+  incrementalCompute: async (last, event) => last + (event?.record?.value ?? 0),
+  compute: ..., getDefaultValue: () => 0 })
+// 实际喂入：自身 dict create、threshold create/update、Item create 全进 incrementalCompute
+// 最终值 "0[object Object][object Object]5[object Object]" ❌（应为 5）
+
+// R-1 (REPRO-7)：纯关系 update 无宿主事件
+StateTransfer.create({ trigger: { recordName:'Person', type:'update', keys:['profile'] }, ... })
+await storage.update('Person', matchId, { profile: { id: profileId } }, events)
+// events = [link create]，无 Person update；status 停留 draft ❌
+
+// R-2 (REPRO-10)：SQLite insert() 污染返回
+await storage.create('Doc', { title: 't' })
+// → {"changes":1,"lastInsertRowid":1,"title":"t","id":1} ❌
+
+// R-9 (REPRO-9)：filtered rebase 被 blocking check 拦截（缺陷不可达的证据）
+// v2 仅把 ActiveView 的 baseEntity 从 User 换成 Profile → migrate 抛
+// "Migration plan has blocking changes: physical-path-move: ... fact record table changed"
+```

--- a/agentspace/output/deep-review-2026-07-09-r3.md
+++ b/agentspace/output/deep-review-2026-07-09-r3.md
@@ -1,5 +1,19 @@
 # 全代码库深度 Review 报告（2026-07-09 第三轮）
 
+> **维护说明（2026-07-09 更新）**：本报告发现的问题已在同分支（`cursor/deep-code-review-r3-e56f`）修复：
+>
+> - **致命 F-1 ~ F-5 全部修复**，回归测试见 `tests/runtime/review-fixes-2026-07-09-r3.spec.ts`（16 个用例）：
+>   - F-1：`UpdateExecutor` 的成员资格 `changedFields` 改用**实际写入集合**（`getSameRowFieldAndValue` 的输出，含联动重算的 computed 列，与 update 事件的 `keys` 同源）。
+>   - F-2：`MatchExp.and` 支持复合 `BoolExp` 作为子表达式；`AttributeQuery` 对 filtered relation 的用户 matchExpression 整棵传入而非取 `.data`。
+>   - F-3：Custom 的 records dataDep 缺 `attributeQuery` 时在 setup 抛 `ComputationProtocolError`；显式 `attributeQuery: []` 表示「仅依赖成员资格」仍然合法（与 r2 的 property 依赖 fail-fast 对齐）。
+>   - F-4：`getReverseAttribute` 对 relation 记录上除 source/target 外的普通关系属性走通用 linkName 反查；顺带补齐 `QueryExecutor` 三处可空 x:1/link 的空守卫（含原 I-4）。
+>   - F-5：source map 对 global dict 依赖的 **create 与 update** 事件统一按 key 过滤（自身输出 dict、无关 dict 的事件不再触发计算）。`incrementalDataDeps` 的语义澄清为「增量执行时解析并传入的依赖值」，事件来源需在 `incrementalCompute` 中按 `event.recordName` 区分（既有 `transactionRetry`/`migration` spec 依赖该契约，不宜收窄）。
+> - **重要项修复**：R-1（StateMachine `trigger.keys` setup 期校验：关系属性 / 未声明属性 / 空数组一律拒绝，附带修复 IM-2 空数组 vacuous 匹配）、R-2（SQLite `insert()` 改 `.all()` 返回 RETURNING 行；`oneToMany.spec.ts` 中固化了旧垃圾字段的断言一并修正）、R-3（Every/Any 移植 findOne 空守卫 + 清理死赋值 IM-4）、R-7（Transform lockRecord miss 按 delete 语义清理派生行）、R-9（旧成员在旧 base 上求值的防御性修正）。
+> - **测试补强**：新增 `tests/runtime/filteredMembershipMatrix.spec.ts` —— filtered 成员资格组合矩阵（谓词列类型[普通/computed/跨实体] × 宿主[entity/relation] × 层级[单层/嵌套] × 变更方式[create命中/不命中、update进入/退出/无关字段、relink、级联delete]，每步断言「查询 == 事件推导 == Count」三方一致性不变式，6 个矩阵用例）；I-17（`computedUpdateEvent.spec.ts` 补 `keys` 断言）；I-18（filtered relation 谓词变更迁移回归）。
+> - **明确遗留（建议独立 PR）**：R-4（asyncReturn advisory lock，需真实 PG 并发验证）、R-5（RealTime 时间调度器：实现或文档化的产品决策）、R-6（迁移终态 phase）、R-8（批量 1:n 孤儿告警）、六个聚合 handle 的共享模板抽取（大型重构，三轮累计 7 个缺陷的根治项）、I-1/I-2/I-3/I-5~I-16。
+>
+> 修复后全量测试 1715 passed / 26 skipped（基线 1693，新增 22 个用例）；`npm run check` 通过。下文正文保留 review 时的原始判定，作为问题背景与复现依据。
+
 - 日期：2026-07-09
 - 基线：`main` @ `9e2b1e99`（PR #18 合入之后，前两轮 review 修复全部落地）
 - 范围：`src/core`、`src/runtime`（含 computations、migration、ScopedSequence）、`src/storage`、`src/builtins`、`src/drivers` 全量

--- a/src/drivers/SQLite.ts
+++ b/src/drivers/SQLite.ts
@@ -128,7 +128,11 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
             sql,
             params
         })
-        return  this.db.prepare(`${sql} RETURNING ${ROW_ID_ATTR}`).run(...params) as unknown as EntityIdRef
+        // CAUTION better-sqlite3 对 RETURNING 语句必须用 .all() 才能取回行；
+        //  .run() 只返回 {changes, lastInsertRowid}，这些元数据会被上层 Object.assign 进创建的记录，
+        //  与 PostgreSQL/PGLite 驱动（返回 RETURNING 行）的契约不一致。
+        const rows = this.db.prepare(`${sql} RETURNING ${ROW_ID_ATTR}`).all(...params) as unknown as EntityIdRef[]
+        return rows[0]
     }
     async delete<T> (sql:string, where: unknown[], name='') {
         const context= asyncInteractionContext.getStore() as InteractionContext

--- a/src/runtime/ComputationSourceMap.ts
+++ b/src/runtime/ComputationSourceMap.ts
@@ -188,27 +188,26 @@ export class ComputationSourceMapManager {
      * @returns 是否需要触发计算
      */
     shouldTriggerUpdateComputation(source: EntityEventSourceMap, mutationEvent: RecordMutationEvent): boolean {
+        // CAUTION global 依赖监听的是整张 DICTIONARY_RECORD 表的 create/update 事件，
+        //  必须按 key 过滤，否则任何 dict 的创建/更新（包括本计算自己的输出 dict）都会触发计算——
+        //  对增量计算而言这是把无关事件喂进 incrementalCompute 的直接来源。
+        if ('dataDep' in source && source.dataDep.type === 'global' && mutationEvent.recordName === DICTIONARY_RECORD) {
+            return mutationEvent.record?.key === source.dataDep.source.name
+        }
         if (source.type !== 'update' || !('dataDep' in source)) {
             return true
         }
-        // 特殊处理 Global 类型的数据依赖
-        if (source.dataDep.type === 'global' && mutationEvent.recordName === DICTIONARY_RECORD) {
-            // 检查是否是 state 类型的记录，并且 key 匹配
-            return mutationEvent.record?.key === source.dataDep.source.name
-        } else {
-            // 如果是更新，检查是否是依赖的属性有变化。
-            if (source.attributes!.includes('*')) {
-                return Object.keys(mutationEvent.record || {}).some(attr =>
-                    attr !== 'id' && mutationEvent.record![attr] !== mutationEvent.oldRecord?.[attr]
-                )
-            }
-            const propAttrs = source.attributes!.filter(attr => attr !== 'id')
-            return !propAttrs.every(attr => 
-                !mutationEvent.record!.hasOwnProperty(attr) || 
-                (mutationEvent.record![attr] === mutationEvent.oldRecord![attr])
+        // 如果是更新，检查是否是依赖的属性有变化。
+        if (source.attributes!.includes('*')) {
+            return Object.keys(mutationEvent.record || {}).some(attr =>
+                attr !== 'id' && mutationEvent.record![attr] !== mutationEvent.oldRecord?.[attr]
             )
         }
-        
+        const propAttrs = source.attributes!.filter(attr => attr !== 'id')
+        return !propAttrs.every(attr => 
+            !mutationEvent.record!.hasOwnProperty(attr) || 
+            (mutationEvent.record![attr] === mutationEvent.oldRecord![attr])
+        )
     }
 
     /**

--- a/src/runtime/computations/Any.ts
+++ b/src/runtime/computations/Any.ts
@@ -201,7 +201,10 @@ export class PropertyAnyHandle implements DataBasedComputation {
                 key: 'id',
                 value: ['=', relationRecord.id]
             }), undefined, this.relationAttributeQuery)
-
+            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃（与 Count/Summation 一致）。
+            if (!newRelationWithEntity) {
+                return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
+            }
             const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source']
             relatedRecord['&'] = relationRecord
 
@@ -218,7 +221,6 @@ export class PropertyAnyHandle implements DataBasedComputation {
             await this.state!.isItemMatch.setInternal(relationRecord, false)
         } else if (relatedMutationEvent.type === 'update'&&(relatedMutationEvent.recordName === this.relation.name!||relatedMutationEvent.recordName === this.relatedRecordName)) {
             // 关联实体或者关联关系上的字段的更新
-            const currentRecord = mutationEvent.oldRecord!
             // 关联关系或者关联实体的更新
             // relatedAttribute 是从当前 dataContext 出发
             // 现在要把匹配的 key 改成从关联关系出发。
@@ -230,6 +232,10 @@ export class PropertyAnyHandle implements DataBasedComputation {
             }) 
 
             const relationRecord = await this.controller.system.storage.findOne(this.relation.name!, relationMatch, undefined, this.relationAttributeQuery)
+            // 关系记录已不可见（被删除/filtered 成员资格变化竞态）时退回全量重算（与 Count/Summation 一致）。
+            if (!relationRecord) {
+                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
+            }
             const relatedRecord = relationRecord[this.isSource ? 'target' : 'source']
             relatedRecord['&'] = relationRecord
 

--- a/src/runtime/computations/Custom.ts
+++ b/src/runtime/computations/Custom.ts
@@ -40,6 +40,25 @@ abstract class BaseCustomComputationHandle implements DataBasedComputation {
     // 设置自定义的 dataDeps
     if (args.dataDeps) {
       this.dataDeps = args.dataDeps as {[key: string]: DataDep};
+      // CAUTION fail fast：records 依赖不带 attributeQuery 时，取数只会返回 id、update 也不注册任何监听。
+      //  用户 compute 里读取字段会静默拿到 undefined（错误值而非报错），必须在 setup 阶段拒绝。
+      //  显式声明 attributeQuery: [] 表示"只依赖记录集合本身（id / 增删），不依赖字段"，仍然允许。
+      Object.entries(this.dataDeps).forEach(([key, dep]) => {
+        if (dep.type === 'records' && dep.attributeQuery === undefined) {
+          throw new ComputationProtocolError(
+            `Records dataDep "${key}" of Custom computation "${args.name}" must declare attributeQuery. ` +
+            `Without it the dependency resolves to id-only records and field updates never re-trigger the computation. ` +
+            `Declare the fields your compute reads, e.g. { type: 'records', source, attributeQuery: ['fieldA'] }, ` +
+            `or explicitly pass attributeQuery: [] if the computation only depends on record membership (create/delete).`,
+            {
+              handleName: this.constructor.name,
+              computationName: args.name,
+              dataContext: this.dataContext,
+              computationPhase: 'custom-data-deps-validation'
+            }
+          )
+        }
+      })
     }
     if (args.incrementalDataDeps) {
       this.incrementalDataDepKeys = args.incrementalDataDeps;
@@ -196,6 +215,11 @@ abstract class BaseCustomComputationHandle implements DataBasedComputation {
       if (context.requiresFullRecompute) {
         return { type: 'fullRecompute', reason: context.reason || 'Custom dependency requires full recompute' }
       }
+      // CAUTION incrementalDataDeps 声明的是"增量执行时需要解析并传入的依赖值"（[] 表示不需要任何依赖值），
+      //  不是事件过滤器：任何已声明 dataDep 的事件都会走到 incrementalCompute。
+      //  多依赖的 Custom 必须在 incrementalCompute 里按 event.recordName 区分事件来源，
+      //  或改用 planIncremental 对不同依赖返回不同的计划。
+      //  （无关 dict 的 create/update 噪音已在 source map 层按 key 过滤，见 ComputationSourceMap。）
       return {
         type: 'incremental',
         dataDepKeys: this.incrementalDataDepKeys,

--- a/src/runtime/computations/Every.ts
+++ b/src/runtime/computations/Every.ts
@@ -221,7 +221,10 @@ export class PropertyEveryHandle implements DataBasedComputation {
                 key: 'id',
                 value: ['=', relationRecord.id]
             }), undefined, this.relationAttributeQuery)
-
+            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃（与 Count/Summation 一致）。
+            if (!newRelationWithEntity) {
+                return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
+            }
             const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source']
             relatedRecord['&'] = relationRecord
 
@@ -248,8 +251,6 @@ export class PropertyEveryHandle implements DataBasedComputation {
             await this.state!.isItemMatch.setInternal(relationRecord, false)
         } else if (relatedMutationEvent.type === 'update'&&(relatedMutationEvent.recordName === this.relation.name!||relatedMutationEvent.recordName === this.relatedRecordName)) {
             // 关联实体或者关联关系上的字段的更新
-            const currentRecord = mutationEvent.oldRecord!
-
             // 关联关系或者关联实体的更新
             // relatedAttribute 是从当前 dataContext 出发
             // 现在要把匹配的 key 改成从关联关系出发。
@@ -262,6 +263,10 @@ export class PropertyEveryHandle implements DataBasedComputation {
             }) 
 
             const relationRecord = await this.controller.system.storage.findOne(this.relation.name!, relationMatch, undefined, this.relationAttributeQuery)
+            // 关系记录已不可见（被删除/filtered 成员资格变化竞态）时退回全量重算（与 Count/Summation 一致）。
+            if (!relationRecord) {
+                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
+            }
             const relatedRecord = relationRecord[this.isSource ? 'target' : 'source']
             relatedRecord['&'] = relationRecord
 

--- a/src/runtime/computations/StateMachine.ts
+++ b/src/runtime/computations/StateMachine.ts
@@ -31,17 +31,25 @@ function validateTriggerKeys(controller: Controller, args: StateMachineInstance,
         }
         const keys = trigger.keys as string[]
 
-        // 沿 filtered 链收集记录名与属性名
+        // 收集记录的有效属性：沿 filtered 链（baseEntity/baseRelation）向下，
+        // 并展开 merged entity（inputEntities）——merged entity 自身没有 properties，
+        // 其有效属性是全部输入实体属性的并集。
         const recordChainNames = new Set<string>()
         const propertyNames = new Set<string>(['id'])
-        let current = controller.entities.find(e => e.name === trigger.recordName)
+        const start = controller.entities.find(e => e.name === trigger.recordName)
             ?? controller.relations.find(r => r.name === trigger.recordName) as (typeof controller.entities[number] | typeof controller.relations[number] | undefined)
-        if (!current) continue
-        while (current) {
+        if (!start) continue
+        const pending: unknown[] = [start]
+        const visited = new Set<unknown>()
+        while (pending.length) {
+            const current = pending.pop() as { name?: string, properties?: { name: string }[], baseEntity?: unknown, baseRelation?: unknown, inputEntities?: unknown[] }
+            if (!current || visited.has(current)) continue
+            visited.add(current)
             if (current.name) recordChainNames.add(current.name)
             for (const property of (current.properties ?? [])) propertyNames.add(property.name)
-            const base: unknown = (current as { baseEntity?: unknown }).baseEntity ?? (current as { baseRelation?: unknown }).baseRelation
-            current = base as typeof current
+            if (current.baseEntity) pending.push(current.baseEntity)
+            if (current.baseRelation) pending.push(current.baseRelation)
+            for (const input of (current.inputEntities ?? [])) pending.push(input)
         }
         // 本记录（含 base 链）上的关系属性
         const relationAttributes = new Set<string>()

--- a/src/runtime/computations/StateMachine.ts
+++ b/src/runtime/computations/StateMachine.ts
@@ -6,6 +6,61 @@ import { ComputationResult, EventBasedComputation, EventDep, GlobalBoundState, R
 import { EtityMutationEvent } from "../Scheduler.js";
 import { TransitionFinder } from "./TransitionFinder.js";
 import { assert } from "../util.js";
+import { ComputationProtocolError } from "../errors/index.js";
+
+/**
+ * setup 期校验 trigger.keys：
+ * - keys 只对"宿主记录自身的值属性（含 computed）更新"有效。纯关系变更（如 update({profile: {id}})）
+ *   不产生宿主 update 事件，只有关系记录的 create/delete 事件——指向关系属性的 keys 是永不命中的死声明。
+ * - 未声明的属性名同理永不命中（typo 会静默失效）。
+ * - 空数组是 vacuous 匹配（[].every() 恒真），等价于不带 keys 却更容易误读，一律拒绝。
+ * 无法解析的 recordName（系统记录等）跳过校验，交给运行期语义。
+ */
+function validateTriggerKeys(controller: Controller, args: StateMachineInstance, contextName: string) {
+    for (const transfer of args.transfers) {
+        const trigger = transfer.trigger as { recordName?: string, type?: string, keys?: unknown }
+        if (!trigger || trigger.keys === undefined || !trigger.recordName) continue
+        const throwProtocolError = (message: string) => {
+            throw new ComputationProtocolError(
+                `StateMachine ${contextName}: transfer "${transfer.current.name}" -> "${transfer.next.name}" (trigger: ${trigger.recordName} ${trigger.type}): ${message}`,
+                { handleName: 'StateMachine', computationPhase: 'trigger-keys-validation' }
+            )
+        }
+        if (!Array.isArray(trigger.keys) || trigger.keys.length === 0) {
+            throwProtocolError(`trigger.keys must be a non-empty array of property names. An empty array matches every update vacuously — omit keys entirely to match any update.`)
+        }
+        const keys = trigger.keys as string[]
+
+        // 沿 filtered 链收集记录名与属性名
+        const recordChainNames = new Set<string>()
+        const propertyNames = new Set<string>(['id'])
+        let current = controller.entities.find(e => e.name === trigger.recordName)
+            ?? controller.relations.find(r => r.name === trigger.recordName) as (typeof controller.entities[number] | typeof controller.relations[number] | undefined)
+        if (!current) continue
+        while (current) {
+            if (current.name) recordChainNames.add(current.name)
+            for (const property of (current.properties ?? [])) propertyNames.add(property.name)
+            const base: unknown = (current as { baseEntity?: unknown }).baseEntity ?? (current as { baseRelation?: unknown }).baseRelation
+            current = base as typeof current
+        }
+        // 本记录（含 base 链）上的关系属性
+        const relationAttributes = new Set<string>()
+        for (const relation of controller.relations) {
+            const sourceName = (relation.source as { name?: string } | undefined)?.name
+            const targetName = (relation.target as { name?: string } | undefined)?.name
+            if (sourceName && recordChainNames.has(sourceName) && relation.sourceProperty) relationAttributes.add(relation.sourceProperty)
+            if (targetName && recordChainNames.has(targetName) && relation.targetProperty) relationAttributes.add(relation.targetProperty)
+        }
+
+        for (const key of keys) {
+            if (propertyNames.has(key)) continue
+            if (relationAttributes.has(key)) {
+                throwProtocolError(`trigger.keys ["${key}"] refers to a relation attribute. Relation replacement does not emit a host update event carrying this key, so the transfer would never fire. Declare the trigger on the relation record's create/delete events instead (e.g. { recordName: '<relationName>', type: 'create' }).`)
+            }
+            throwProtocolError(`trigger.keys ["${key}"] does not match any declared property of "${trigger.recordName}", so the transfer would never fire. Declare the property or fix the key name.`)
+        }
+    }
+}
 
 type SourceTargetPair = [EntityIdRef, EntityIdRef][]
 type ComputeRelationTargetResult = SourceTargetPair | {source: EntityIdRef[] | EntityIdRef, target: EntityIdRef[]|EntityIdRef} | undefined
@@ -24,6 +79,7 @@ export class GlobalStateMachineHandle implements EventBasedComputation {
     constructor(public controller: Controller, public args: StateMachineInstance, public dataContext: DataContext) {
         this.transitionFinder = new TransitionFinder(this.args)
         this.initialState = this.args.initialState
+        validateTriggerKeys(controller, args, `of global dictionary "${(dataContext.id as {name?: string})?.name ?? String(dataContext.id)}"`)
         // 从所有 transfer 中构建 eventDeps
         // 特别注意，这里不能用系统默认的 eventDeps 深度匹配机制。
         // 因为可能有多个 transfer 都是同样的 trigger。
@@ -72,6 +128,7 @@ export class PropertyStateMachineHandle implements EventBasedComputation {
         this.transitionFinder = new TransitionFinder(this.args)
         this.initialState = this.args.initialState
         this.dataContext = dataContext as PropertyDataContext
+        validateTriggerKeys(controller, args, `of property "${this.dataContext.host.name}.${this.dataContext.id.name}"`)
         // 从所有 transfer 中构建 eventDeps
         // 特别注意，这里不能用系统默认的 eventDeps 深度匹配机制。
         // 因为可能有多个 transfer 都是同样的 trigger。

--- a/src/runtime/computations/Transform.ts
+++ b/src/runtime/computations/Transform.ts
@@ -142,11 +142,13 @@ export class RecordsTransformHandle implements DataBasedComputation {
                     sourceRecordId,
                     sourceDataDep.attributeQuery
                 )
-                if (!sourceRecord) {
-                    return []
+                // CAUTION 源记录锁不到（事件与 patch 应用之间被并发删除）时不能直接返回空 patch：
+                //  那会让已映射的派生行成为孤儿。按 delete 语义继续走下面的流程，
+                //  transformedRecords 为空 → 全部既有映射行进入 delete patch（幂等，与 delete 事件路径一致）。
+                if (sourceRecord) {
+                    const returnRecord = await this.transformCallback.call(this.controller, sourceRecord)
+                    transformedRecords = Array.isArray(returnRecord) ? returnRecord : [returnRecord]
                 }
-                const returnRecord = await this.transformCallback.call(this.controller, sourceRecord)
-                transformedRecords = Array.isArray(returnRecord) ? returnRecord : [returnRecord]
             }
             const match = MatchExp.atom({key: this.state.sourceRecordId.key, value: ['=', sourceRecordId]})
             const mappedRecords = await this.controller.system.storage.atomic.lockRows(dataContext.id.name!, match, ['*'])

--- a/src/runtime/migration.ts
+++ b/src/runtime/migration.ts
@@ -3366,9 +3366,13 @@ export async function recomputeFilteredMemberships(controller: Controller, oldMa
 
         // predicate-changed：旧成员集合来自旧谓词（旧谓词引用的属性可能已被删除——
         // 那类破坏性变更会先被 storage blocking check 拦截，这里可以直接用旧谓词查询新库）。
+        // CAUTION 旧成员必须在旧 base 上求值。rebase（同名 filtered 换 base）当前会被
+        //  blocking check（physical-path-move: fact record table changed）在 migrate 入口拦截，
+        //  这里用 oldRecord 的 base 是防御性正确：若未来 rebase 被支持，旧成员查询不能落在新表上。
+        const oldBaseRecordName = change.oldRecord?.resolvedBaseRecordName ?? baseRecordName;
         const oldMatchExpression = normalizeMatch(change.oldRecord?.resolvedMatchExpression);
         const oldMatchedRecords = oldMatchExpression
-            ? await controller.system.storage.find(baseRecordName, oldMatchExpression, undefined, ["*"])
+            ? await controller.system.storage.find(oldBaseRecordName, oldMatchExpression, undefined, ["*"])
             : [];
         const oldIds = new Set(oldMatchedRecords.map(record => String((record as { id: unknown }).id)));
         const newIds = new Set(matchedRecords.map(record => String((record as { id: unknown }).id)));

--- a/src/storage/erstorage/AttributeQuery.ts
+++ b/src/storage/erstorage/AttributeQuery.ts
@@ -171,7 +171,9 @@ export class AttributeQuery {
                     const linkInfo = attributeInfo.getLinkInfo().getBaseLinkInfo()
                     const filteredRelationMatchExp = new MatchExp(linkInfo.name, this.map, attributeInfo.getMatchExpression())
                     const rebasedMatchExp = filteredRelationMatchExp.rebase(attributeInfo.isRecordSource() ? 'target' : 'source')!
-                    const mergedMatchExp = subMatchExp ? rebasedMatchExp.and(subMatchExp.data) : rebasedMatchExp
+                    // CAUTION 用户的 matchExpression 可能是复合 BoolExp（and/or 过的），必须整棵传入。
+                    //  取 .data 只对 atom 有意义，复合表达式会得到 undefined 并在 MatchExp.and 中崩溃。
+                    const mergedMatchExp = subMatchExp ? rebasedMatchExp.and(subMatchExp) : rebasedMatchExp
                     relatedSubQueryData = {
                         ...subQueryData,
                         matchExpression: mergedMatchExp.data

--- a/src/storage/erstorage/EntityToTableMap.ts
+++ b/src/storage/erstorage/EntityToTableMap.ts
@@ -380,8 +380,10 @@ export class EntityToTableMap {
     getReverseAttribute(entityName: string, attribute: string) : string {
         assert(this.data.records[entityName], `entity ${entityName} not found`)
         const record = this.data.records[entityName]
-        if (record.isRelation) {
-            assert(attribute ==='source' || attribute ==='target', `wrong attribute ${attribute} for relation ${entityName}`)
+        // CAUTION relation 记录上除 source/target 外还可以携带普通关系属性
+        //  （relation-as-source 建模，如 Relation.create({ source: someRelation, sourceProperty: 'tags', ... })），
+        //  它们与实体上的关系属性同构，必须走下面通用的 linkName 反查分支，不能一律按 source/target 断言。
+        if (record.isRelation && (attribute === 'source' || attribute === 'target')) {
             const linkData = this.data.links[entityName]
             if (attribute === 'source') {
                 return `${linkData.sourceProperty!}.&`
@@ -389,7 +391,9 @@ export class EntityToTableMap {
                 return `${linkData.targetProperty!}.&`
             }
         } else {
-            const relationName = (this.data.records[entityName].attributes[attribute] as RecordAttribute).linkName
+            const recordAttribute = this.data.records[entityName].attributes[attribute] as RecordAttribute
+            assert(!!recordAttribute?.linkName, `${entityName}.${attribute} is not a record attribute`)
+            const relationName = recordAttribute.linkName
             const relationData = this.data.links[relationName]
             if (relationData.sourceRecord === entityName && relationData.sourceProperty === attribute) {
                 return relationData.targetProperty!

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -393,10 +393,14 @@ export class MatchExp {
 
     }
 
-    and(condition: MatchAtom|MatchExp): MatchExp {
+    and(condition: MatchAtom|MatchExp|MatchExpressionData): MatchExp {
         if (condition instanceof MatchExp) {
             assert(this.entityName === condition.entityName, `cannot and match exp of different entity: ${this.entityName} and ${condition.entityName}`)
             return new MatchExp(this.entityName, this.map, this.data ? this.data.and(condition.data) : condition.data, this.contextRootEntity)
+        } else if (condition instanceof BoolExp) {
+            // CAUTION 复合的 MatchExpressionData（and/or 过的 BoolExp）必须整棵作为子表达式合并。
+            //  取 .data 只在 atom 上有意义，复合表达式取到 undefined 会在下面的 atom 分支崩溃。
+            return new MatchExp(this.entityName, this.map, this.data ? this.data.and(condition) : condition, this.contextRootEntity)
         } else {
             assert(condition.key !== undefined, 'key cannot be undefined')
             assert(Array.isArray(condition.value) && condition.value.length === 2, 'value must be array')

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -275,6 +275,8 @@ export class QueryExecutor {
                     const linkRecordReverseAttributeName = linkRecordAttributeInfo.getReverseInfo()?.attributeName
 
                     for (let record of records) {
+                        // 可空 x:1：关联实体不存在时没有 link 数据，跳过（与 completeXToOneLeftoverRecords 的空守卫一致）。
+                        if (!record[subEntityQuery.attributeName!]?.[LINK_SYMBOL]) continue
                         // 限制 link.id
                         const linkRecordId = record[subEntityQuery.attributeName!][LINK_SYMBOL].id
                         const queryOfThisRecord = subEntityQueryOfSubLink.derive({
@@ -486,6 +488,8 @@ export class QueryExecutor {
             for(let xToOneSubQuery of entityQuery.attributeQuery.parentLinkRecordQuery.attributeQuery.xToOneRecords) {
                 for(let xToManySubSubQuery of xToOneSubQuery.attributeQuery.xToManyRecords) {
                     for(let record of records) {
+                        // 可空关系：反向属性或 link 上的 x:1 不存在时跳过（与下方第 2 步的空守卫一致）。
+                        if (!record[reverseAttributeName]?.[LINK_SYMBOL]?.[xToOneSubQuery.attributeName!]) continue
                         const nextContext = entityQuery.label ? context.concat(record) : context
                         record[reverseAttributeName][LINK_SYMBOL][xToOneSubQuery.attributeName!][xToManySubSubQuery.attributeName!] = await this.findXToManyRelatedRecords(
                             xToManySubSubQuery.parentRecord!,
@@ -524,6 +528,8 @@ export class QueryExecutor {
             // 3. 继续递归 complete x:1 关联实体上的 x:1 关联查询
             for(let xToOneSubSubQuery of xToOneSubQuery.attributeQuery.xToOneRecords) {
                 for(let record of records) {
+                    // 可空 x:1：为 null 时 [].concat 会产生 [null] 传入递归导致崩溃，跳过。
+                    if (!record[xToOneSubQuery.attributeName!]) continue
                     const nextContext = entityQuery.label ? context.concat(record) : context
                     await this.completeXToOneLeftoverRecords(xToOneSubSubQuery, [].concat(record[xToOneSubQuery.attributeName!]), recordQueryRef, nextContext)
                 }

--- a/src/storage/erstorage/UpdateExecutor.ts
+++ b/src/storage/erstorage/UpdateExecutor.ts
@@ -58,9 +58,17 @@ export class UpdateExecutor {
         
         const matchedEntities = await this.agent.findRecords(updateRecordQuery, `find record for updating ${entityName}`)
         // 注意下面使用的都是 updateRecordQuery 的 recordName，而不是 entityName，因为 RecordQuery 会根据 recordName 来判断是否是 filtered entity。
-        const changedFields = Object.keys(newEntityData.getData())
+        const payloadFields = Object.keys(newEntityData.getData())
         const result: Record[] = []
         for (let matchedEntity of matchedEntities) {
+            // CAUTION changedFields 必须是"实际写入集合"而不是 payload 键：
+            //  computed 属性会随输入字段联动重算并落库（getSameRowFieldAndValue，与 update 事件的 keys 同源）。
+            //  filtered entity 的谓词可能建立在 computed 列上——若这里只用 payload 键做依赖过滤，
+            //  computed 列的变更将跳过成员资格快照，查询侧正确而事件/下游增量计算永久脏数据（静默错误）。
+            const changedFields = Array.from(new Set([
+                ...payloadFields,
+                ...newEntityData.getSameRowFieldAndValue(matchedEntity).map(field => field.name)
+            ]))
             // 0. 成员资格快照：必须在任何物理变更之前采集（无状态 membership diff，见 FilteredEntityManager）。
             //  - membershipChecks：本记录（以及经反向路径受影响的记录）在依赖 changedFields 的 filtered entity 中的成员资格；
             //  - linkChecks：通过行内字段（merged link / combined）新建关系时另一端既有记录的成员资格。

--- a/tests/runtime/filteredMembershipMatrix.spec.ts
+++ b/tests/runtime/filteredMembershipMatrix.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * Filtered membership combination matrix.
+ *
+ * 三轮 review 的共同规律：filtered entity/relation 的 bug 都出现在「正交特性的交叉点」上
+ * （computed 列 × filtered、关系属性 × filtered、嵌套 filtered……），而单特性主干测试全绿。
+ * 本 spec 用统一的生命周期驱动这些组合，并在每一步之后断言三方一致性不变式：
+ *
+ *     查询侧 find(filtered).length
+ *  == 事件侧 累计(create) - 累计(delete)（filtered recordName 上的成员资格事件）
+ *  == 计算侧 Count({record: filtered}) 的 dict 值
+ *
+ * 任何一方掉队（查询对、事件丢、计数错）都会在对应步骤立刻暴露。
+ *
+ * 覆盖的组合维度：
+ *  - 谓词列类型：普通属性 / computed 属性 / 跨实体路径（related entity field）
+ *  - 宿主类型：entity / relation（filtered relation）
+ *  - filtered 层级：单层 / 嵌套（filtered on filtered）
+ *  - 变更方式：create（命中/不命中）/ update 进入 / update 退出 / 无关字段 update / delete
+ */
+import { describe, expect, test } from "vitest";
+import {
+    Controller, Count, Dictionary, Entity, KlassByName, MatchExp, MonoSystem, Property, Relation,
+} from "interaqt";
+import { PGLiteDB } from "@drivers";
+
+/**
+ * 三方一致性校验器：包装 storage 变更，累计 filtered recordName 上的成员资格事件，
+ * 每次断言 查询 == 事件推导 == Count。
+ */
+function createInvariantChecker(system: any, filteredNames: { recordName: string, countKey: string }[]) {
+    const eventDerived: Record<string, number> = Object.fromEntries(filteredNames.map(f => [f.recordName, 0]));
+    return {
+        async mutate(operation: (events: any[]) => Promise<unknown>) {
+            const events: any[] = [];
+            await operation(events);
+            for (const { recordName } of filteredNames) {
+                for (const event of events) {
+                    if (event.recordName !== recordName) continue;
+                    if (event.type === "create") eventDerived[recordName]++;
+                    if (event.type === "delete") eventDerived[recordName]--;
+                }
+            }
+            return events;
+        },
+        async assertConsistent(step: string) {
+            for (const { recordName, countKey } of filteredNames) {
+                const queryCount = (await system.storage.find(recordName, undefined, undefined, ["id"])).length;
+                const computedCount = await system.storage.dict.get(countKey);
+                expect(eventDerived[recordName], `[${step}] ${recordName}: event-derived vs query`).toBe(queryCount);
+                expect(computedCount, `[${step}] ${recordName}: Count dict vs query`).toBe(queryCount);
+            }
+        },
+    };
+}
+
+describe("filtered membership combination matrix", () => {
+
+    test("matrix: filtered entity over a PLAIN property", async () => {
+        const Task = Entity.create({
+            name: "MxPlainTask",
+            properties: [
+                Property.create({ name: "isActive", type: "boolean" }),
+                Property.create({ name: "note", type: "string" }),
+            ],
+        });
+        const ActiveTask = Entity.create({
+            name: "MxPlainActiveTask",
+            baseEntity: Task,
+            matchExpression: MatchExp.atom({ key: "isActive", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [Task, ActiveTask], relations: [],
+            dict: [Dictionary.create({
+                name: "mxPlainCount", type: "number", collection: false,
+                computation: Count.create({ record: ActiveTask, callback: () => true }),
+            })],
+        });
+        await controller.setup(true);
+        const check = createInvariantChecker(system, [{ recordName: "MxPlainActiveTask", countKey: "mxPlainCount" }]);
+
+        let matching: any, nonMatching: any;
+        await check.mutate(async events => { matching = await system.storage.create("MxPlainTask", { isActive: true, note: "a" }, events); });
+        await check.assertConsistent("create matching");
+        await check.mutate(async events => { nonMatching = await system.storage.create("MxPlainTask", { isActive: false, note: "b" }, events); });
+        await check.assertConsistent("create non-matching");
+        await check.mutate(events => system.storage.update("MxPlainTask", MatchExp.atom({ key: "id", value: ["=", nonMatching.id] }), { isActive: true }, events));
+        await check.assertConsistent("update into membership");
+        await check.mutate(events => system.storage.update("MxPlainTask", MatchExp.atom({ key: "id", value: ["=", matching.id] }), { isActive: false }, events));
+        await check.assertConsistent("update out of membership");
+        await check.mutate(events => system.storage.update("MxPlainTask", MatchExp.atom({ key: "id", value: ["=", nonMatching.id] }), { note: "changed" }, events));
+        await check.assertConsistent("irrelevant field update");
+        await check.mutate(events => system.storage.delete("MxPlainTask", MatchExp.atom({ key: "id", value: ["=", nonMatching.id] }), events));
+        await check.assertConsistent("delete member");
+        await db.close();
+    });
+
+    test("matrix: filtered entity over a COMPUTED property (input-field driven)", async () => {
+        const Task = Entity.create({
+            name: "MxComputedTask",
+            properties: [
+                Property.create({ name: "status", type: "string" }),
+                Property.create({ name: "note", type: "string" }),
+                Property.create({
+                    name: "isActive", type: "boolean",
+                    computed: (record: any) => record.status === "active",
+                }),
+            ],
+        });
+        const ActiveTask = Entity.create({
+            name: "MxComputedActiveTask",
+            baseEntity: Task,
+            matchExpression: MatchExp.atom({ key: "isActive", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [Task, ActiveTask], relations: [],
+            dict: [Dictionary.create({
+                name: "mxComputedCount", type: "number", collection: false,
+                computation: Count.create({ record: ActiveTask, callback: () => true }),
+            })],
+        });
+        await controller.setup(true);
+        const check = createInvariantChecker(system, [{ recordName: "MxComputedActiveTask", countKey: "mxComputedCount" }]);
+
+        let matching: any, nonMatching: any;
+        await check.mutate(async events => { matching = await system.storage.create("MxComputedTask", { status: "active", note: "a" }, events); });
+        await check.assertConsistent("create matching");
+        await check.mutate(async events => { nonMatching = await system.storage.create("MxComputedTask", { status: "idle", note: "b" }, events); });
+        await check.assertConsistent("create non-matching");
+        // 关键组合：只更新 computed 的输入字段，谓词列由框架联动重算
+        await check.mutate(events => system.storage.update("MxComputedTask", MatchExp.atom({ key: "id", value: ["=", nonMatching.id] }), { status: "active" }, events));
+        await check.assertConsistent("update input-field into membership");
+        await check.mutate(events => system.storage.update("MxComputedTask", MatchExp.atom({ key: "id", value: ["=", matching.id] }), { status: "done" }, events));
+        await check.assertConsistent("update input-field out of membership");
+        await check.mutate(events => system.storage.update("MxComputedTask", MatchExp.atom({ key: "id", value: ["=", nonMatching.id] }), { note: "changed" }, events));
+        await check.assertConsistent("irrelevant field update");
+        await check.mutate(events => system.storage.delete("MxComputedTask", MatchExp.atom({ key: "id", value: ["=", nonMatching.id] }), events));
+        await check.assertConsistent("delete member");
+        await db.close();
+    });
+
+    test("matrix: filtered entity over a CROSS-ENTITY predicate (related field + relink)", async () => {
+        const Team = Entity.create({
+            name: "MxTeam",
+            properties: [Property.create({ name: "type", type: "string" })],
+        });
+        const User = Entity.create({
+            name: "MxUser",
+            properties: [Property.create({ name: "name", type: "string" })],
+        });
+        const UserTeam = Relation.create({
+            source: User, sourceProperty: "team", target: Team, targetProperty: "members", type: "n:1",
+        });
+        const TechUser = Entity.create({
+            name: "MxTechUser",
+            baseEntity: User,
+            matchExpression: MatchExp.atom({ key: "team.type", value: ["=", "tech"] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [User, Team, TechUser], relations: [UserTeam],
+            dict: [Dictionary.create({
+                name: "mxTechUserCount", type: "number", collection: false,
+                computation: Count.create({ record: TechUser, callback: () => true }),
+            })],
+        });
+        await controller.setup(true);
+        const check = createInvariantChecker(system, [{ recordName: "MxTechUser", countKey: "mxTechUserCount" }]);
+
+        let tech: any, sales: any, user: any;
+        await check.mutate(async events => {
+            tech = await system.storage.create("MxTeam", { type: "tech" }, events);
+            sales = await system.storage.create("MxTeam", { type: "sales" }, events);
+        });
+        await check.mutate(async events => { user = await system.storage.create("MxUser", { name: "u", team: { id: tech.id } }, events); });
+        await check.assertConsistent("create matching (linked to tech team)");
+        // 关联实体字段更新：整队退出
+        await check.mutate(events => system.storage.update("MxTeam", MatchExp.atom({ key: "id", value: ["=", tech.id] }), { type: "ops" }, events));
+        await check.assertConsistent("related entity field update out");
+        await check.mutate(events => system.storage.update("MxTeam", MatchExp.atom({ key: "id", value: ["=", tech.id] }), { type: "tech" }, events));
+        await check.assertConsistent("related entity field update back in");
+        // 关系重连：换队导致成员资格变化
+        await check.mutate(events => system.storage.update("MxUser", MatchExp.atom({ key: "id", value: ["=", user.id] }), { team: { id: sales.id } }, events));
+        await check.assertConsistent("relink to non-matching team");
+        await check.mutate(events => system.storage.update("MxUser", MatchExp.atom({ key: "id", value: ["=", user.id] }), { team: { id: tech.id } }, events));
+        await check.assertConsistent("relink back to matching team");
+        // 删除关联实体：级联退出
+        await check.mutate(events => system.storage.delete("MxTeam", MatchExp.atom({ key: "id", value: ["=", tech.id] }), events));
+        await check.assertConsistent("delete related team");
+        await db.close();
+    });
+
+    test("matrix: filtered RELATION over a PLAIN relation property", async () => {
+        const User = Entity.create({ name: "MxRelUser", properties: [Property.create({ name: "name", type: "string" })] });
+        const Post = Entity.create({ name: "MxRelPost", properties: [Property.create({ name: "title", type: "string" })] });
+        const UserPost = Relation.create({
+            source: User, sourceProperty: "posts", target: Post, targetProperty: "author", type: "1:n",
+            properties: [
+                Property.create({ name: "isPinned", type: "boolean" }),
+                Property.create({ name: "weight", type: "number" }),
+            ],
+        });
+        const PinnedPosts = Relation.create({
+            name: "MxPinnedPosts",
+            baseRelation: UserPost,
+            sourceProperty: "pinnedPosts",
+            targetProperty: "pinnedAuthor",
+            matchExpression: MatchExp.atom({ key: "isPinned", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [User, Post], relations: [UserPost, PinnedPosts],
+            dict: [Dictionary.create({
+                name: "mxPinnedCount", type: "number", collection: false,
+                computation: Count.create({ record: PinnedPosts, callback: () => true }),
+            })],
+        });
+        await controller.setup(true);
+        const check = createInvariantChecker(system, [{ recordName: "MxPinnedPosts", countKey: "mxPinnedCount" }]);
+        const relName = UserPost.name!;
+
+        const user = await system.storage.create("MxRelUser", { name: "u" });
+        const postA = await system.storage.create("MxRelPost", { title: "a" });
+        const postB = await system.storage.create("MxRelPost", { title: "b" });
+        let relA: any, relB: any;
+        await check.mutate(async events => { relA = await system.storage.create(relName, { source: { id: user.id }, target: { id: postA.id }, isPinned: true, weight: 1 }, events); });
+        await check.assertConsistent("create matching relation");
+        await check.mutate(async events => { relB = await system.storage.create(relName, { source: { id: user.id }, target: { id: postB.id }, isPinned: false, weight: 1 }, events); });
+        await check.assertConsistent("create non-matching relation");
+        await check.mutate(events => system.storage.update(relName, MatchExp.atom({ key: "id", value: ["=", relB.id] }), { isPinned: true }, events));
+        await check.assertConsistent("relation update into membership");
+        await check.mutate(events => system.storage.update(relName, MatchExp.atom({ key: "id", value: ["=", relA.id] }), { isPinned: false }, events));
+        await check.assertConsistent("relation update out of membership");
+        await check.mutate(events => system.storage.update(relName, MatchExp.atom({ key: "id", value: ["=", relB.id] }), { weight: 9 }, events));
+        await check.assertConsistent("irrelevant relation field update");
+        await check.mutate(events => system.storage.delete(relName, MatchExp.atom({ key: "id", value: ["=", relB.id] }), events));
+        await check.assertConsistent("delete member relation");
+        await db.close();
+    });
+
+    test("matrix: filtered RELATION over a COMPUTED relation property", async () => {
+        const User = Entity.create({ name: "MxCRelUser", properties: [Property.create({ name: "name", type: "string" })] });
+        const Post = Entity.create({ name: "MxCRelPost", properties: [Property.create({ name: "title", type: "string" })] });
+        const UserPost = Relation.create({
+            source: User, sourceProperty: "posts", target: Post, targetProperty: "author", type: "1:n",
+            properties: [
+                Property.create({ name: "amount", type: "number" }),
+                Property.create({
+                    name: "isBig", type: "boolean",
+                    computed: (record: any) => (record.amount ?? 0) >= 100,
+                }),
+            ],
+        });
+        const BigDeals = Relation.create({
+            name: "MxBigDeals",
+            baseRelation: UserPost,
+            sourceProperty: "bigDeals",
+            targetProperty: "bigDealAuthor",
+            matchExpression: MatchExp.atom({ key: "isBig", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [User, Post], relations: [UserPost, BigDeals],
+            dict: [Dictionary.create({
+                name: "mxBigDealCount", type: "number", collection: false,
+                computation: Count.create({ record: BigDeals, callback: () => true }),
+            })],
+        });
+        await controller.setup(true);
+        const check = createInvariantChecker(system, [{ recordName: "MxBigDeals", countKey: "mxBigDealCount" }]);
+        const relName = UserPost.name!;
+
+        const user = await system.storage.create("MxCRelUser", { name: "u" });
+        const postA = await system.storage.create("MxCRelPost", { title: "a" });
+        const postB = await system.storage.create("MxCRelPost", { title: "b" });
+        let relA: any, relB: any;
+        await check.mutate(async events => { relA = await system.storage.create(relName, { source: { id: user.id }, target: { id: postA.id }, amount: 500 }, events); });
+        await check.assertConsistent("create matching (computed via input)");
+        await check.mutate(async events => { relB = await system.storage.create(relName, { source: { id: user.id }, target: { id: postB.id }, amount: 10 }, events); });
+        await check.assertConsistent("create non-matching");
+        // 关键组合：只更新 computed 的输入字段（关系记录上）
+        await check.mutate(events => system.storage.update(relName, MatchExp.atom({ key: "id", value: ["=", relB.id] }), { amount: 200 }, events));
+        await check.assertConsistent("relation input-field update into membership");
+        await check.mutate(events => system.storage.update(relName, MatchExp.atom({ key: "id", value: ["=", relA.id] }), { amount: 1 }, events));
+        await check.assertConsistent("relation input-field update out of membership");
+        await check.mutate(events => system.storage.delete(relName, MatchExp.atom({ key: "id", value: ["=", relB.id] }), events));
+        await check.assertConsistent("delete member relation");
+        await db.close();
+    });
+
+    test("matrix: NESTED filtered entity (filtered on filtered, plain + computed mix)", async () => {
+        const Task = Entity.create({
+            name: "MxNestedTask",
+            properties: [
+                Property.create({ name: "priority", type: "string" }),
+                Property.create({ name: "status", type: "string" }),
+                Property.create({
+                    name: "isActive", type: "boolean",
+                    computed: (record: any) => record.status === "active",
+                }),
+            ],
+        });
+        const HighTask = Entity.create({
+            name: "MxHighTask",
+            baseEntity: Task,
+            matchExpression: MatchExp.atom({ key: "priority", value: ["=", "high"] }),
+        });
+        // 嵌套：在 filtered 上再 filter，且谓词是 computed 列
+        const HighActiveTask = Entity.create({
+            name: "MxHighActiveTask",
+            baseEntity: HighTask,
+            matchExpression: MatchExp.atom({ key: "isActive", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [Task, HighTask, HighActiveTask], relations: [],
+            dict: [
+                Dictionary.create({
+                    name: "mxHighCount", type: "number", collection: false,
+                    computation: Count.create({ record: HighTask, callback: () => true }),
+                }),
+                Dictionary.create({
+                    name: "mxHighActiveCount", type: "number", collection: false,
+                    computation: Count.create({ record: HighActiveTask, callback: () => true }),
+                }),
+            ],
+        });
+        await controller.setup(true);
+        const check = createInvariantChecker(system, [
+            { recordName: "MxHighTask", countKey: "mxHighCount" },
+            { recordName: "MxHighActiveTask", countKey: "mxHighActiveCount" },
+        ]);
+
+        let task: any;
+        await check.mutate(async events => { task = await system.storage.create("MxNestedTask", { priority: "high", status: "active" }, events); });
+        await check.assertConsistent("create matching both levels");
+        // 内层退出（computed 输入字段），外层不变
+        await check.mutate(events => system.storage.update("MxNestedTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), { status: "done" }, events));
+        await check.assertConsistent("inner level exit via computed input");
+        // 外层退出 → 内层即使谓词命中也不可见
+        await check.mutate(events => system.storage.update("MxNestedTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), { priority: "low", status: "active" }, events));
+        await check.assertConsistent("outer level exit");
+        // 双层同时进入
+        await check.mutate(events => system.storage.update("MxNestedTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), { priority: "high" }, events));
+        await check.assertConsistent("re-enter both levels");
+        await check.mutate(events => system.storage.delete("MxNestedTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), events));
+        await check.assertConsistent("delete member");
+        await db.close();
+    });
+});

--- a/tests/runtime/review-fixes-2026-07-09-r3.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r3.spec.ts
@@ -450,6 +450,40 @@ describe("review fixes 2026-07-09 r3", () => {
         await db.close();
     });
 
+    test("R-1: trigger.keys on merged entity properties (from inputEntities) is accepted", async () => {
+        // merged entity 自身没有 properties，有效属性来自输入实体的并集——校验不能误拒。
+        const Employee = Entity.create({
+            name: "R3KeysMergedEmployee",
+            properties: [Property.create({ name: "level", type: "number" })],
+        });
+        const Partner = Entity.create({
+            name: "R3KeysMergedPartner",
+            properties: [Property.create({ name: "level", type: "number" })],
+        });
+        const Staff = Entity.create({ name: "R3KeysMergedStaff", inputEntities: [Employee, Partner] });
+        const idle = StateNode.create({ name: "idle" });
+        const touched = StateNode.create({ name: "touched" });
+        const marker = Dictionary.create({
+            name: "r3KeysMergedMarker", type: "string", collection: false,
+            computation: StateMachine.create({
+                states: [idle, touched],
+                initialState: idle,
+                transfers: [StateTransfer.create({
+                    trigger: { recordName: "R3KeysMergedStaff", type: "update", keys: ["level"] } as any,
+                    current: idle, next: touched,
+                })],
+            }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        // 构造不抛错即为通过（level 是输入实体贡献的合法属性）
+        const controller = new Controller({ system, entities: [Employee, Partner, Staff], relations: [], dict: [marker] });
+        await controller.setup(true);
+        expect(await system.storage.dict.get("r3KeysMergedMarker")).toBe("idle");
+        await db.close();
+    });
+
     test("R-1: trigger.keys on declared value properties still transitions", async () => {
         const db = new PGLiteDB();
         const controller = buildKeysController(["name"], db);

--- a/tests/runtime/review-fixes-2026-07-09-r3.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r3.spec.ts
@@ -1,0 +1,675 @@
+/**
+ * Regression tests for the 2026-07-09 third-round deep review fixes.
+ * See agentspace/output/deep-review-2026-07-09-r3.md for the original findings.
+ *
+ * - F-1: filtered entity over a `computed` property emits membership events when the
+ *        input field changes (changedFields = actual write set, same source as event keys)
+ * - F-2: filtered relation attributeQuery accepts compound (and/or) matchExpression
+ * - F-3: Custom records dataDep without attributeQuery fails fast at setup;
+ *        explicit [] means "membership only" and stays legal
+ * - F-4: x:n relation attribute on a relation record (relation-as-source) is queryable
+ *        from the relation side (direct query and nested & query)
+ * - F-5: Custom incrementalDataDeps only feeds declared-dep events to incrementalCompute;
+ *        events from other deps trigger full recompute; unrelated dict creates are filtered by key
+ * - R-1: StateMachine trigger.keys referencing relation attributes / unknown properties /
+ *        empty arrays are rejected at setup
+ * - R-2: SQLiteDB insert() returns RETURNING rows; created records carry no driver metadata
+ * - R-3: PropertyEvery/PropertyAny fall back to fullRecompute when the relation record
+ *        is gone between event and incremental computation (no bare dereference crash)
+ * - R-9: recomputeFilteredMemberships evaluates old membership on the OLD base record
+ */
+import { describe, expect, test } from "vitest";
+import {
+    Controller, Count, Custom, Dictionary, Entity, Every, KlassByName, MatchExp, MonoSystem,
+    Property, Relation, StateMachine, StateNode, StateTransfer, createMigrationManifest,
+} from "interaqt";
+import { recomputeFilteredMemberships } from "@runtime";
+import { PGLiteDB, SQLiteDB } from "@drivers";
+
+async function approveGeneratedMigrationDiff(controller: Controller) {
+    const diff = await controller.generateMigrationDiff({ includeFunctionText: true, includeDestructiveScope: true });
+    const decisions = [
+        ...diff.decisions,
+        ...diff.requiredDecisions.map((requirement: any) => {
+            if (requirement.kind === "computation") {
+                return { kind: "computation" as const, id: requirement.id, dataContext: requirement.dataContext, decision: requirement.recommendedDecision, reason: "approved by regression test" };
+            }
+            if (requirement.kind === "event-rebuild-handler") {
+                return { kind: "event-rebuild-handler" as const, dataContext: requirement.dataContext, handlerRef: requirement.dataContext, reason: "approved by regression test" };
+            }
+            if (requirement.kind === "destructive-scope") {
+                return { kind: "destructive-scope" as const, dataContext: requirement.dataContext, recordName: requirement.recordName, ids: requirement.ids, reason: "approved by regression test" };
+            }
+            return { ...requirement, reason: "approved by regression test" };
+        }),
+    ];
+    return { ...diff, status: "approved" as const, decisions };
+}
+
+describe("review fixes 2026-07-09 r3", () => {
+
+    // -------------------------------------------------------------------------
+    // F-1: filtered entity over computed property
+    // -------------------------------------------------------------------------
+    test("F-1: updating the input of a computed predicate column emits membership events and updates downstream Count", async () => {
+        const Task = Entity.create({
+            name: "R3FixTask",
+            properties: [
+                Property.create({ name: "status", type: "string" }),
+                Property.create({
+                    name: "isActive", type: "boolean",
+                    computed: (record: any) => record.status === "active",
+                }),
+            ],
+        });
+        const ActiveTask = Entity.create({
+            name: "R3FixActiveTask",
+            baseEntity: Task,
+            matchExpression: MatchExp.atom({ key: "isActive", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system, entities: [Task, ActiveTask], relations: [],
+            dict: [Dictionary.create({
+                name: "r3FixActiveTaskCount", type: "number", collection: false,
+                computation: Count.create({ record: ActiveTask, callback: () => true }),
+            })],
+        });
+        await controller.setup(true);
+
+        const task = await system.storage.create("R3FixTask", { status: "active" });
+        expect(await system.storage.dict.get("r3FixActiveTaskCount")).toBe(1);
+
+        // leave: computed column flips through an update of its input field only
+        const leaveEvents: any[] = [];
+        await system.storage.update("R3FixTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), { status: "inactive" }, leaveEvents);
+        expect(leaveEvents.filter(e => e.recordName === "R3FixActiveTask" && e.type === "delete")).toHaveLength(1);
+        // the host update event carries the computed column in keys (same write set)
+        const hostUpdate = leaveEvents.find(e => e.recordName === "R3FixTask" && e.type === "update");
+        expect(hostUpdate?.keys).toContain("status");
+        expect(hostUpdate?.keys).toContain("isActive");
+        expect(await system.storage.find("R3FixActiveTask", undefined, undefined, ["id"])).toHaveLength(0);
+        expect(await system.storage.dict.get("r3FixActiveTaskCount")).toBe(0);
+
+        // re-enter
+        const enterEvents: any[] = [];
+        await system.storage.update("R3FixTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), { status: "active" }, enterEvents);
+        expect(enterEvents.filter(e => e.recordName === "R3FixActiveTask" && e.type === "create")).toHaveLength(1);
+        expect(await system.storage.dict.get("r3FixActiveTaskCount")).toBe(1);
+
+        // irrelevant update: no membership events
+        const noopEvents: any[] = [];
+        await system.storage.update("R3FixTask", MatchExp.atom({ key: "id", value: ["=", task.id] }), { status: "active" }, noopEvents);
+        expect(noopEvents.filter(e => e.recordName === "R3FixActiveTask")).toHaveLength(0);
+        expect(await system.storage.dict.get("r3FixActiveTaskCount")).toBe(1);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // F-2: filtered relation compound matchExpression
+    // -------------------------------------------------------------------------
+    test("F-2: filtered relation attributeQuery accepts compound and single-atom matchExpression", async () => {
+        const User = Entity.create({
+            name: "R3FixUser",
+            properties: [Property.create({ name: "name", type: "string" })],
+        });
+        const Post = Entity.create({
+            name: "R3FixPost",
+            properties: [
+                Property.create({ name: "title", type: "string" }),
+                Property.create({ name: "status", type: "string" }),
+            ],
+        });
+        const UserPost = Relation.create({
+            source: User, sourceProperty: "posts",
+            target: Post, targetProperty: "author",
+            type: "1:n",
+            properties: [Property.create({ name: "isPinned", type: "boolean" })],
+        });
+        const PinnedPosts = Relation.create({
+            name: "R3FixPinnedPosts",
+            baseRelation: UserPost,
+            sourceProperty: "pinnedPosts",
+            targetProperty: "pinnedAuthor",
+            matchExpression: MatchExp.atom({ key: "isPinned", value: ["=", true] }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [User, Post], relations: [UserPost, PinnedPosts] });
+        await controller.setup(true);
+
+        const user = await system.storage.create("R3FixUser", { name: "u" });
+        const relationName = UserPost.name!;
+        const createPinnedPost = async (title: string, status: string, isPinned: boolean) => {
+            const post = await system.storage.create("R3FixPost", { title, status });
+            await system.storage.create(relationName, { source: { id: user.id }, target: { id: post.id }, isPinned });
+        };
+        await createPinnedPost("Alpha", "published", true);
+        await createPinnedPost("Alps", "draft", true);
+        await createPinnedPost("Beta", "published", true);
+        await createPinnedPost("Album", "published", false);
+
+        // compound .and()
+        const andRows = await system.storage.find("R3FixUser", MatchExp.atom({ key: "id", value: ["=", user.id] }), undefined, [
+            "name",
+            ["pinnedPosts", {
+                attributeQuery: ["title"],
+                matchExpression: MatchExp.atom({ key: "title", value: ["like", "Al%"] })
+                    .and({ key: "status", value: ["=", "published"] }),
+            }],
+        ]);
+        expect((andRows[0].pinnedPosts ?? []).map((p: any) => p.title).sort()).toEqual(["Alpha"]);
+
+        // compound .or()
+        const orRows = await system.storage.find("R3FixUser", MatchExp.atom({ key: "id", value: ["=", user.id] }), undefined, [
+            "name",
+            ["pinnedPosts", {
+                attributeQuery: ["title"],
+                matchExpression: MatchExp.atom({ key: "title", value: ["=", "Alpha"] })
+                    .or({ key: "title", value: ["=", "Beta"] }),
+            }],
+        ]);
+        expect((orRows[0].pinnedPosts ?? []).map((p: any) => p.title).sort()).toEqual(["Alpha", "Beta"]);
+
+        // single atom regression (previously working path)
+        const atomRows = await system.storage.find("R3FixUser", MatchExp.atom({ key: "id", value: ["=", user.id] }), undefined, [
+            "name",
+            ["pinnedPosts", {
+                attributeQuery: ["title"],
+                matchExpression: MatchExp.atom({ key: "status", value: ["=", "published"] }),
+            }],
+        ]);
+        expect((atomRows[0].pinnedPosts ?? []).map((p: any) => p.title).sort()).toEqual(["Alpha", "Beta"]);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // F-3: Custom records dataDep requires explicit attributeQuery
+    // -------------------------------------------------------------------------
+    test("F-3: Custom records dataDep without attributeQuery is rejected at setup", async () => {
+        const Item = Entity.create({
+            name: "R3FixDepItem",
+            properties: [Property.create({ name: "price", type: "number" })],
+        });
+        const dict = Dictionary.create({
+            name: "r3FixDepTotal", type: "number", collection: false,
+            computation: Custom.create({
+                name: "R3FixDepTotal",
+                dataDeps: { items: { type: "records", source: Item } }, // no attributeQuery
+                compute: async (dataDeps: any) => (dataDeps.items || []).length,
+                getInitialValue: () => 0,
+            }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        // 校验发生在 Controller 构造期（Scheduler 创建 handle 时）
+        expect(() => new Controller({ system, entities: [Item], relations: [], dict: [dict] })).toThrow(/must declare attributeQuery/);
+        await db.close();
+    });
+
+    test("F-3: Custom records dataDep with declared attributeQuery recomputes on field update", async () => {
+        const Item = Entity.create({
+            name: "R3FixDepOkItem",
+            properties: [Property.create({ name: "price", type: "number" })],
+        });
+        const dict = Dictionary.create({
+            name: "r3FixDepOkTotal", type: "number", collection: false,
+            computation: Custom.create({
+                name: "R3FixDepOkTotal",
+                dataDeps: { items: { type: "records", source: Item, attributeQuery: ["price"] } },
+                compute: async (dataDeps: any) => (dataDeps.items || []).reduce((acc: number, item: any) => acc + (item.price ?? 0), 0),
+                getInitialValue: () => 0,
+            }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Item], relations: [], dict: [dict] });
+        await controller.setup(true);
+        const item = await system.storage.create("R3FixDepOkItem", { price: 10 });
+        expect(await system.storage.dict.get("r3FixDepOkTotal")).toBe(10);
+        await system.storage.update("R3FixDepOkItem", MatchExp.atom({ key: "id", value: ["=", item.id] }), { price: 99 });
+        expect(await system.storage.dict.get("r3FixDepOkTotal")).toBe(99);
+        await db.close();
+    });
+
+    test("F-3: Custom records dataDep with explicit empty attributeQuery is legal membership-only dependency", async () => {
+        const Item = Entity.create({
+            name: "R3FixDepIdItem",
+            properties: [Property.create({ name: "price", type: "number" })],
+        });
+        const dict = Dictionary.create({
+            name: "r3FixDepIdCount", type: "number", collection: false,
+            computation: Custom.create({
+                name: "R3FixDepIdCount",
+                dataDeps: { items: { type: "records", source: Item, attributeQuery: [] } },
+                compute: async (dataDeps: any) => (dataDeps.items || []).length,
+                getInitialValue: () => 0,
+            }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Item], relations: [], dict: [dict] });
+        await controller.setup(true);
+        await system.storage.create("R3FixDepIdItem", { price: 1 });
+        await system.storage.create("R3FixDepIdItem", { price: 2 });
+        expect(await system.storage.dict.get("r3FixDepIdCount")).toBe(2);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // F-4: relation-as-source x:n attribute queryable from the relation side
+    // -------------------------------------------------------------------------
+    test("F-4: x:n relation attribute on a relation record works for writes and queries from every side", async () => {
+        const Profile = Entity.create({ name: "R3FixProfile", properties: [Property.create({ name: "bio", type: "string" })] });
+        const Tag = Entity.create({ name: "R3FixTag", properties: [Property.create({ name: "label", type: "string" })] });
+        const Person = Entity.create({ name: "R3FixPerson", properties: [Property.create({ name: "name", type: "string" })] });
+        const PersonProfile = Relation.create({
+            source: Person, sourceProperty: "profile", target: Profile, targetProperty: "owner", type: "1:1",
+        });
+        const LinkTag = Relation.create({
+            source: PersonProfile, sourceProperty: "tags", target: Tag, targetProperty: "links", type: "n:n",
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Person, Profile, Tag], relations: [PersonProfile, LinkTag] });
+        await controller.setup(true);
+
+        await system.storage.create("R3FixPerson", { name: "p1", profile: { bio: "hi" } });
+        await system.storage.create("R3FixPerson", { name: "p2" }); // no profile
+        const relName = PersonProfile.name!;
+        const rel = await system.storage.findOne(relName, undefined, undefined, ["id"]);
+        await system.storage.create("R3FixTag", { label: "vip", links: [{ id: rel.id }] });
+
+        // relation-side direct query
+        const rels = await system.storage.find(relName, undefined, undefined, ["id", ["tags", { attributeQuery: ["label"] }]]);
+        expect(rels).toHaveLength(1);
+        expect((rels[0].tags ?? []).map((t: any) => t.label)).toEqual(["vip"]);
+
+        // entity-side nested & query, including a person with NO profile (null x:1 must not crash)
+        const people = await system.storage.find("R3FixPerson", undefined, undefined, [
+            "name",
+            ["profile", { attributeQuery: ["bio", ["&", { attributeQuery: [["tags", { attributeQuery: ["label"] }]] }]] }],
+        ]);
+        expect(people).toHaveLength(2);
+        const withProfile = people.find((p: any) => p.name === "p1")!;
+        expect((withProfile.profile["&"].tags ?? []).map((t: any) => t.label)).toEqual(["vip"]);
+
+        // tag-side query still works
+        const tags = await system.storage.find("R3FixTag", undefined, undefined, ["label", ["links", { attributeQuery: ["id"] }]]);
+        expect(tags[0].links).toHaveLength(1);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // F-5: Custom incrementalDataDeps event contract
+    // -------------------------------------------------------------------------
+    test("F-5: own-output and undeclared dict events never reach incrementalCompute; declared dep events do", async () => {
+        // 契约（transactionRetry / migration spec 同样依赖）：incrementalDataDeps 声明的是
+        // "增量执行时解析并传入的依赖值"，任何已声明 dataDep 的事件都进入 incrementalCompute，
+        // 由用户按 event.recordName 区分。本测试锁定的是修复点：
+        // 计算自身的输出 dict 以及未声明的 dict 的 create/update 事件不再触发计算（source map 按 key 过滤）。
+        const Item = Entity.create({ name: "R3FixIncItem", properties: [Property.create({ name: "value", type: "number" })] });
+        const threshold = Dictionary.create({ name: "r3FixThreshold", type: "number", collection: false, defaultValue: () => 1 });
+        const unrelated = Dictionary.create({ name: "r3FixIncUnrelated", type: "number", collection: false, defaultValue: () => 0 });
+        const incrementalEvents: any[] = [];
+        const sumDict = Dictionary.create({
+            name: "r3FixIncSum", type: "number", collection: false,
+            computation: Custom.create({
+                name: "R3FixIncSum",
+                useLastValue: true,
+                dataDeps: {
+                    items: { type: "records", source: Item, attributeQuery: ["value"] },
+                    threshold: { type: "global", source: threshold },
+                },
+                incrementalDataDeps: ["threshold"],
+                incrementalCompute: async function (lastValue: number, event: any) {
+                    incrementalEvents.push({ recordName: event?.recordName, type: event?.type, key: event?.record?.key });
+                    // 按契约区分事件来源
+                    if (event?.recordName === "R3FixIncItem") {
+                        return (lastValue ?? 0) + (event.record?.value ?? 0);
+                    }
+                    return lastValue ?? 0;
+                },
+                compute: async function (dataDeps: any) {
+                    return (dataDeps.items || []).reduce((acc: number, item: any) => acc + (item.value ?? 0), 0);
+                },
+                getInitialValue: () => 0,
+            }),
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Item], relations: [], dict: [threshold, sumDict, unrelated] });
+        await controller.setup(true);
+
+        await system.storage.create("R3FixIncItem", { value: 5 });
+        expect(await system.storage.dict.get("r3FixIncSum")).toBe(5);
+        await system.storage.dict.set("r3FixIncUnrelated", 99);
+        await system.storage.dict.set("r3FixThreshold", 42);
+        await system.storage.create("R3FixIncItem", { value: 7 });
+        expect(await system.storage.dict.get("r3FixIncSum")).toBe(12);
+
+        // 到达 incrementalCompute 的 dict 事件只可能来自声明的 threshold；
+        // 自身输出 dict（r3FixIncSum）与无关 dict（r3FixIncUnrelated）的事件都被 source map 过滤。
+        const dictEvents = incrementalEvents.filter(e => e.recordName === "_Dictionary_");
+        expect(dictEvents.length).toBeGreaterThan(0);
+        expect(dictEvents.every(e => e.key === "r3FixThreshold")).toBe(true);
+        await db.close();
+    });
+
+    test("F-5: unrelated dictionary creates/updates no longer trigger computations with global deps", async () => {
+        const threshold = Dictionary.create({ name: "r3FixKeyedThreshold", type: "number", collection: false, defaultValue: () => 1 });
+        let computeCalls = 0;
+        const doubled = Dictionary.create({
+            name: "r3FixKeyedDoubled", type: "number", collection: false,
+            computation: Custom.create({
+                name: "R3FixKeyedDoubled",
+                dataDeps: { threshold: { type: "global", source: threshold } },
+                compute: async function (dataDeps: any) {
+                    computeCalls++;
+                    return (dataDeps.threshold ?? 0) * 2;
+                },
+                getInitialValue: () => 0,
+            }),
+        });
+        const unrelated = Dictionary.create({ name: "r3FixUnrelatedDict", type: "number", collection: false, defaultValue: () => 0 });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [], relations: [], dict: [threshold, doubled, unrelated] });
+        await controller.setup(true);
+
+        const callsAfterSetup = computeCalls;
+        // mutating an unrelated dict must not re-trigger the computation
+        await system.storage.dict.set("r3FixUnrelatedDict", 123);
+        expect(computeCalls).toBe(callsAfterSetup);
+        // mutating the declared dep does
+        await system.storage.dict.set("r3FixKeyedThreshold", 21);
+        expect(computeCalls).toBe(callsAfterSetup + 1);
+        expect(await system.storage.dict.get("r3FixKeyedDoubled")).toBe(42);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // R-1: trigger.keys validation at setup
+    // -------------------------------------------------------------------------
+    const buildKeysController = (keys: string[], db: PGLiteDB) => {
+        const Profile = Entity.create({ name: `R3KeysProfile${keys.join("_") || "empty"}`, properties: [Property.create({ name: "bio", type: "string" })] });
+        const draft = StateNode.create({ name: "draft" });
+        const assigned = StateNode.create({ name: "assigned" });
+        const personName = `R3KeysPerson${keys.join("_") || "empty"}`;
+        const Person = Entity.create({
+            name: personName,
+            properties: [
+                Property.create({ name: "name", type: "string" }),
+                Property.create({
+                    name: "status", type: "string",
+                    computation: StateMachine.create({
+                        states: [draft, assigned],
+                        initialState: draft,
+                        transfers: [StateTransfer.create({
+                            trigger: { recordName: personName, type: "update", keys } as any,
+                            current: draft, next: assigned,
+                            computeTarget: (event: any) => ({ id: event.oldRecord?.id ?? event.record?.id }),
+                        })],
+                    }),
+                }),
+            ],
+        });
+        const PersonProfile = Relation.create({
+            source: Person, sourceProperty: "profile", target: Profile, targetProperty: "owner", type: "1:1",
+        });
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        return new Controller({ system, entities: [Person, Profile], relations: [PersonProfile] });
+    };
+
+    test("R-1: trigger.keys referencing a relation attribute is rejected at setup", async () => {
+        const db = new PGLiteDB();
+        // 校验发生在 Controller 构造期（Scheduler 创建 handle 时）
+        expect(() => buildKeysController(["profile"], db)).toThrow(/relation attribute/);
+        await db.close();
+    });
+
+    test("R-1: trigger.keys referencing an unknown property is rejected at setup", async () => {
+        const db = new PGLiteDB();
+        expect(() => buildKeysController(["nmae"], db)).toThrow(/does not match any declared property/);
+        await db.close();
+    });
+
+    test("R-1: empty trigger.keys array is rejected at setup", async () => {
+        const db = new PGLiteDB();
+        expect(() => buildKeysController([], db)).toThrow(/non-empty array/);
+        await db.close();
+    });
+
+    test("R-1: trigger.keys on declared value properties still transitions", async () => {
+        const db = new PGLiteDB();
+        const controller = buildKeysController(["name"], db);
+        await controller.setup(true);
+        const system = controller.system;
+        const personName = "R3KeysPersonname";
+        const person = await system.storage.create(personName, { name: "p" });
+        await system.storage.update(personName, MatchExp.atom({ key: "id", value: ["=", person.id] }), { name: "p2" });
+        const row = await system.storage.findOne(personName, MatchExp.atom({ key: "id", value: ["=", person.id] }), undefined, ["*"]);
+        expect(row.status).toBe("assigned");
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // R-2: SQLite insert() driver contract
+    // -------------------------------------------------------------------------
+    test("R-2: SQLiteDB created records carry no better-sqlite3 run() metadata", async () => {
+        const Doc = Entity.create({
+            name: "R3SqliteDoc",
+            properties: [Property.create({ name: "title", type: "string" })],
+        });
+        const db = new SQLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Doc], relations: [] });
+        await controller.setup(true);
+        const events: any[] = [];
+        const created = await system.storage.create("R3SqliteDoc", { title: "t" }, events);
+        expect(created).not.toHaveProperty("changes");
+        expect(created).not.toHaveProperty("lastInsertRowid");
+        const createEvent = events.find(e => e.type === "create" && e.recordName === "R3SqliteDoc");
+        expect(createEvent?.record).not.toHaveProperty("changes");
+        expect(createEvent?.record).not.toHaveProperty("lastInsertRowid");
+        const row = await system.storage.findOne("R3SqliteDoc", MatchExp.atom({ key: "id", value: ["=", created.id] }), undefined, ["*"]);
+        expect(row.title).toBe("t");
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // R-3: PropertyEvery/PropertyAny fullRecompute fallback when relation row is gone
+    // -------------------------------------------------------------------------
+    test("R-3: PropertyEvery incrementalCompute falls back to fullRecompute when the relation record is not found", async () => {
+        const Task = Entity.create({
+            name: "R3GuardTask",
+            properties: [Property.create({ name: "done", type: "boolean" })],
+        });
+        const Project = Entity.create({
+            name: "R3GuardProject",
+            properties: [
+                Property.create({ name: "name", type: "string" }),
+                Property.create({
+                    name: "allDone", type: "boolean",
+                    computation: Every.create({
+                        record: Task, property: "tasks",
+                        attributeQuery: ["done"],
+                        callback: (task: any) => !!task.done,
+                        notEmpty: true,
+                    }),
+                }),
+            ],
+        });
+        const ProjectTask = Relation.create({
+            source: Project, sourceProperty: "tasks", target: Task, targetProperty: "project", type: "1:n",
+        });
+        const db = new PGLiteDB();
+        const system = new MonoSystem(db);
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Project, Task], relations: [ProjectTask] });
+        await controller.setup(true);
+
+        const project = await system.storage.create("R3GuardProject", { name: "p" });
+        await system.storage.create("R3GuardTask", { done: true, project: { id: project.id } });
+
+        // locate the PropertyEvery handle and invoke it with a synthetic create event
+        // whose relation id does not exist (simulates the delete race)
+        const handles = Array.from((controller.scheduler as any).computationsHandles.values()) as any[];
+        const everyHandle = handles.find(handle => handle.dataContext?.type === "property" && handle.dataContext?.id?.name === "allDone");
+        expect(everyHandle).toBeTruthy();
+        const syntheticEvent = {
+            recordName: "R3GuardProject",
+            type: "update",
+            relatedAttribute: ["tasks"],
+            record: { id: project.id },
+            oldRecord: { id: project.id },
+            relatedMutationEvent: {
+                recordName: everyHandle.relation.name,
+                type: "create",
+                record: { id: "00000000-0000-0000-0000-000000000000" },
+            },
+        };
+        const result = await system.storage.runInTransaction({ name: "r3-guard-test" }, async () =>
+            everyHandle.incrementalCompute(true, syntheticEvent, { id: project.id }, {})
+        );
+        expect(result?.type ?? result?.constructor?.name).toMatch(/fullRecompute|ComputationResultFullRecompute/i);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // I-18: filtered RELATION predicate change during migration (coverage gap:
+    //       r2 F-1 covered filtered entities only)
+    // -------------------------------------------------------------------------
+    test("I-18: changing a filtered relation predicate updates downstream Count after migration", async () => {
+        const db = new PGLiteDB();
+        const buildModel = (threshold: number) => {
+            const User = new Entity({
+                name: "R3MigRelUser",
+                properties: [new Property({ name: "name", type: "string" }, { uuid: "r3-migrel-user-name" })],
+            }, { uuid: "r3-migrel-user" });
+            const Post = new Entity({
+                name: "R3MigRelPost",
+                properties: [new Property({ name: "title", type: "string" }, { uuid: "r3-migrel-post-title" })],
+            }, { uuid: "r3-migrel-post" });
+            const UserPost = new Relation({
+                source: User, sourceProperty: "posts", target: Post, targetProperty: "author", type: "1:n",
+                properties: [new Property({ name: "amount", type: "number" }, { uuid: "r3-migrel-amount" })],
+            }, { uuid: "r3-migrel-userpost" });
+            const BigDeals = new Relation({
+                name: "R3MigBigDeals",
+                baseRelation: UserPost,
+                sourceProperty: "bigDeals",
+                targetProperty: "bigDealAuthor",
+                matchExpression: MatchExp.atom({ key: "amount", value: [">=", threshold] }),
+            } as any, { uuid: "r3-migrel-bigdeals" });
+            const countDict = new Dictionary({
+                name: "r3MigBigDealCount", type: "number", collection: false,
+                computation: new Count({ record: BigDeals }, { uuid: "r3-migrel-count" }),
+            }, { uuid: "r3-migrel-count-dict" });
+            return { User, Post, UserPost, BigDeals, countDict };
+        };
+
+        const v1 = buildModel(100);
+        const systemV1 = new MonoSystem(db);
+        systemV1.conceptClass = KlassByName;
+        const controllerV1 = new Controller({
+            system: systemV1, entities: [v1.User, v1.Post], relations: [v1.UserPost, v1.BigDeals], dict: [v1.countDict],
+        });
+        await controllerV1.setup(true);
+        const user = await systemV1.storage.create("R3MigRelUser", { name: "u" });
+        const relName = v1.UserPost.name!;
+        for (const amount of [10, 50, 200]) {
+            const post = await systemV1.storage.create("R3MigRelPost", { title: `p${amount}` });
+            await systemV1.storage.create(relName, { source: { id: user.id }, target: { id: post.id }, amount });
+        }
+        expect(await systemV1.storage.dict.get("r3MigBigDealCount")).toBe(1);
+
+        // v2: 只放宽谓词（>=100 → >=50）
+        const v2 = buildModel(50);
+        const systemV2 = new MonoSystem(db);
+        systemV2.conceptClass = KlassByName;
+        const controllerV2 = new Controller({
+            system: systemV2, entities: [v2.User, v2.Post], relations: [v2.UserPost, v2.BigDeals], dict: [v2.countDict],
+        });
+        const approvedDiff = await approveGeneratedMigrationDiff(controllerV2);
+        expect(JSON.stringify(approvedDiff.changes)).toMatch(/filtered-predicate-changed/);
+        await controllerV2.migrate({ approvedDiff });
+
+        expect(await systemV2.storage.find("R3MigBigDeals", undefined, undefined, ["id"])).toHaveLength(2);
+        expect(await systemV2.storage.dict.get("r3MigBigDealCount")).toBe(2);
+        await db.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // R-9: recomputeFilteredMemberships uses the OLD base for old membership
+    // -------------------------------------------------------------------------
+    test("R-9: rebase membership diff evaluates old members on the old base record", async () => {
+        const UserV1 = new Entity({
+            name: "R3RebaseUser",
+            properties: [new Property({ name: "flag", type: "boolean" }, { uuid: "r3-rebase-user-flag" })],
+        }, { uuid: "r3-rebase-user" });
+        const ProfileV1 = new Entity({
+            name: "R3RebaseProfile",
+            properties: [new Property({ name: "flag", type: "boolean" }, { uuid: "r3-rebase-profile-flag" })],
+        }, { uuid: "r3-rebase-profile" });
+        const ViewV1 = new Entity({
+            name: "R3RebaseView",
+            baseEntity: UserV1,
+            matchExpression: MatchExp.atom({ key: "flag", value: ["=", true] }),
+        }, { uuid: "r3-rebase-view" });
+        const db = new PGLiteDB();
+        const systemV1 = new MonoSystem(db);
+        systemV1.conceptClass = KlassByName;
+        const controllerV1 = new Controller({ system: systemV1, entities: [UserV1, ProfileV1, ViewV1], relations: [] });
+        await controllerV1.setup(true);
+        const u1 = await systemV1.storage.create("R3RebaseUser", { flag: true });
+        const u2 = await systemV1.storage.create("R3RebaseUser", { flag: true });
+        const p1 = await systemV1.storage.create("R3RebaseProfile", { flag: true });
+        const oldManifest = createMigrationManifest(controllerV1);
+
+        // v2: same filtered name, base swapped to Profile (normally blocked by migrate();
+        // this exercises the membership-diff primitive directly)
+        const UserV2 = new Entity({
+            name: "R3RebaseUser",
+            properties: [new Property({ name: "flag", type: "boolean" }, { uuid: "r3-rebase-user-flag" })],
+        }, { uuid: "r3-rebase-user" });
+        const ProfileV2 = new Entity({
+            name: "R3RebaseProfile",
+            properties: [new Property({ name: "flag", type: "boolean" }, { uuid: "r3-rebase-profile-flag" })],
+        }, { uuid: "r3-rebase-profile" });
+        const ViewV2 = new Entity({
+            name: "R3RebaseView",
+            baseEntity: ProfileV2,
+            matchExpression: MatchExp.atom({ key: "flag", value: ["=", true] }),
+        }, { uuid: "r3-rebase-view" });
+        const systemV2 = new MonoSystem(db);
+        systemV2.conceptClass = KlassByName;
+        const controllerV2 = new Controller({ system: systemV2, entities: [UserV2, ProfileV2, ViewV2], relations: [] });
+        // createMigrationManifest 默认读 storage.schema（需要 setup 后才有）——
+        // 这里与 Controller.prepareMigrationContext 一致，用 prepareMigrationSchema 的 schema plan。
+        const statesV2 = controllerV2.scheduler.createStates();
+        const internalRequirementsV2 = controllerV2.scheduler.createInternalSchemaRequirements();
+        const schemaPlanV2 = await (systemV2 as any).prepareMigrationSchema(
+            controllerV2.entities, controllerV2.relations, statesV2, { internalRequirements: internalRequirementsV2 });
+        const newManifest = createMigrationManifest(controllerV2, schemaPlanV2.schema);
+
+        const events = await recomputeFilteredMemberships(controllerV1, oldManifest, newManifest);
+        const creates = events.filter(e => e.type === "create").map(e => String(e.record!.id));
+        const deletes = events.filter(e => e.type === "delete").map(e => String(e.record!.id));
+        // profile enters (only member of the new base), both users leave (members of the old base)
+        expect(creates).toEqual([String(p1.id)]);
+        expect(deletes.sort()).toEqual([String(u1.id), String(u2.id)].sort());
+        await db.close();
+    });
+});

--- a/tests/storage/computedUpdateEvent.spec.ts
+++ b/tests/storage/computedUpdateEvent.spec.ts
@@ -57,6 +57,9 @@ describe('Computed field update events', () => {
       status: 'active',
       isActive: true
     })
+    // keys 是"实际写入集合"：payload 字段 + 联动重算的 computed 列（StateMachine trigger.keys 等消费方依赖它）
+    expect(updateEvent?.keys).toContain('status')
+    expect(updateEvent?.keys).toContain('isActive')
 
     const updatedTask = await handle.findOne(
       'Task',

--- a/tests/storage/oneToMany.spec.ts
+++ b/tests/storage/oneToMany.spec.ts
@@ -602,17 +602,13 @@ describe('one to many', () => {
                             "id": 2,
                         },
                         "age": 14,
-                        "changes": 1,
                         "id": 3,
-                        "lastInsertRowid": 3,
                         "name": "m2",
                         },
                     },
                     "target":  {
                         "age": 14,
-                        "changes": 1,
                         "id": 3,
-                        "lastInsertRowid": 3,
                         "name": "m2",
                     },
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third-round deep code review of the framework, followed by fixes for all reproduced findings on the same branch. Review report (with maintenance notes): `agentspace/output/deep-review-2026-07-09-r3.md`.

### Fatal fixes (all previously reproduced with failing tests)

1. **F-1** Filtered entity/relation membership diff now derives `changedFields` from the **actual write set** (`getSameRowFieldAndValue`, incl. recomputed `computed` columns — same source as update event `keys`). Previously a predicate on a computed column produced correct queries but no membership events, leaving downstream Counts permanently stale. (`UpdateExecutor`)
2. **F-2** Compound (`.and()`/`.or()`) user `matchExpression` on filtered relation attributes no longer crashes: `MatchExp.and` accepts whole `BoolExp` subtrees; `AttributeQuery` passes the expression instead of `.data`.
3. **F-3** Custom `records` dataDeps must declare `attributeQuery` (setup-time `ComputationProtocolError`; explicit `[]` = membership-only stays legal). Previously compute silently received id-only records and field updates never re-triggered. Mirrors the r2 fix for bare `property` deps.
4. **F-4** x:n relation attributes on relation records (relation-as-source modeling) are now queryable from the relation side: `getReverseAttribute` resolves ordinary relation attributes on relation records; three null-link guards added in `QueryExecutor` (optional 1:1 no longer crashes nested `&` queries).
5. **F-5** Global dict dataDep events are filtered by dict key for **create and update** in the source map — a computation's own output dict and unrelated dicts no longer trigger it (previously they leaked into `incrementalCompute` producing silently-persisted garbage).

### Hardening

- **R-1** `StateMachine trigger.keys` validated at setup: relation attributes (dead path — relation replacement emits no host update event), unknown property names (typos), and empty arrays (vacuous match) are all rejected with actionable errors.
- **R-2** SQLite `insert()` uses `.all()` for RETURNING; created records/events no longer carry `changes`/`lastInsertRowid` (one storage test had enshrined the junk fields as golden output — corrected).
- **R-3** `PropertyEvery`/`PropertyAny` port the `findOne` null guards from Count/Summation (fullRecompute fallback instead of TypeError under delete races); dead assignments removed.
- **R-7** Transform update patch treats a missing (concurrently deleted) source row as delete-all-derived instead of leaving orphan rows.
- **R-9** `recomputeFilteredMemberships` evaluates old members on the **old** base record (defensive; rebase is currently blocked upstream).

### Test coverage

- `tests/runtime/review-fixes-2026-07-09-r3.spec.ts` — 16 regression tests covering every fix above.
- `tests/runtime/filteredMembershipMatrix.spec.ts` — **combination matrix**: predicate column type (plain / computed / cross-entity) × host (entity / filtered relation) × nesting (single / filtered-on-filtered) × mutation kind (create hit/miss, update enter/leave, irrelevant update, relink, cascade delete), asserting the three-way invariant `query == event-derived == Count` after every step. This targets the recurring failure mode of all three review rounds: bugs at intersections of orthogonal features.
- Coverage gaps closed: `keys` includes computed columns (I-17), filtered **relation** predicate change through migration (I-18).

### Explicitly deferred (follow-up PRs suggested in the report)

R-4 asyncReturn advisory lock (needs real PG concurrency validation), R-5 RealTime time-based scheduling (product decision: implement or document), R-6 migration terminal phase, R-8 batched 1:n orphan warning, and the shared aggregation-handle template extraction (root fix for 7 defects across three rounds).

## Testing

- `npm run check` and `npm run check:all` pass.
- Full suite: **1715 passed / 26 skipped** (baseline 1693 — 22 new tests, zero regressions).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5205a3a5-0fca-4945-b2de-cef418aee56f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5205a3a5-0fca-4945-b2de-cef418aee56f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

