### PR TITLE
docs: fix fictional StateMachine/Activity APIs across the knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,14 +225,38 @@ Property.create({
 ### StateMachine
 
 ```typescript
+const pendingState = StateNode.create({ name: 'pending' });
+const approvedState = StateNode.create({ name: 'approved' });
+const rejectedState = StateNode.create({ name: 'rejected' });
+
 Property.create({
   name: 'status',
   computation: StateMachine.create({
-    states: ['pending', 'approved', 'rejected'],
-    default: 'pending',
-    transitions: [
-      { from: 'pending', to: 'approved', on: 'ApproveRequest' },
-      { from: 'pending', to: 'rejected', on: 'RejectRequest' }
+    states: [pendingState, approvedState, rejectedState],
+    initialState: pendingState,
+    transfers: [
+      StateTransfer.create({
+        current: pendingState,
+        next: approvedState,
+        // trigger is a RecordMutationEventPattern matched against mutation events
+        trigger: {
+          recordName: InteractionEventEntity.name,
+          type: 'create',
+          record: { interactionName: ApproveRequest.name }
+        },
+        // property-level state machines must locate the target record(s)
+        computeTarget: (event) => ({ id: event.record.payload.requestId })
+      }),
+      StateTransfer.create({
+        current: pendingState,
+        next: rejectedState,
+        trigger: {
+          recordName: InteractionEventEntity.name,
+          type: 'create',
+          record: { interactionName: RejectRequest.name }
+        },
+        computeTarget: (event) => ({ id: event.record.payload.requestId })
+      })
     ]
   })
 })

--- a/agent/agentspace/knowledge/generator/api-reference.md
+++ b/agent/agentspace/knowledge/generator/api-reference.md
@@ -225,7 +225,7 @@ const deletionStateMachine = StateMachine.create({
             current: NON_DELETED_STATE,
             next: DELETED_STATE,
             computeTarget: function(event) {
-                return { id: event.payload.userId }
+                return { id: event.record.payload.userId }
             }
         })
     ]
@@ -313,7 +313,7 @@ deletionProperty.computation = StateMachine.create({
             current: NON_DELETED_STATE,
             next: DELETED_STATE,
             computeTarget: function(event) {
-                return { id: event.payload.articleId }
+                return { id: event.record.payload.articleId }
             }
         })
     ]

--- a/agent/agentspace/knowledge/generator/computation-implementation.md
+++ b/agent/agentspace/knowledge/generator/computation-implementation.md
@@ -124,7 +124,11 @@ When using `InteractionEventEntity` as the Transform input source, understand th
      states: [updatedState],
      transfers: [
        StateTransfer.create({
-         trigger: UpdateStyleInteraction,
+         trigger: {
+           recordName: InteractionEventEntity.name,
+           type: 'create',
+           record: { interactionName: UpdateStyleInteraction.name }
+         },
          current: updatedState,
          next: updatedState,
          computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
@@ -142,7 +146,11 @@ When using `InteractionEventEntity` as the Transform input source, understand th
      initialState: activeState,  // StateMachine controls initial value
      transfers: [
        StateTransfer.create({
-         trigger: DeleteStyleInteraction,
+         trigger: {
+           recordName: InteractionEventEntity.name,
+           type: 'create',
+           record: { interactionName: DeleteStyleInteraction.name }
+         },
          current: activeState,
          next: deletedState,
          computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
@@ -336,19 +344,30 @@ Used for status changes and field updates.
 
 **🔴 IMPORTANT: StateTransfer Trigger Parameter**
 
-The `trigger` parameter in `StateTransfer.create()` must ALWAYS be an Interaction instance reference, NOT a string!
+The `trigger` parameter in `StateTransfer.create()` is a **RecordMutationEventPattern** — an object pattern matched against record mutation events (`{ recordName, type, keys?, record?, oldRecord? }`). It is NOT a string and NOT an Interaction instance. For interaction-triggered transitions, match the creation of the interaction's event record:
 
 ```typescript
-// ❌ WRONG: Using string as trigger
+// ❌ WRONG: Using a string as trigger
 StateTransfer.create({
-  trigger: 'PublishStyle',  // ERROR! Don't use string!
+  trigger: 'PublishStyle',  // ERROR! Never matches any event
   current: draftState,
   next: activeState
 })
 
-// ✅ CORRECT: Using Interaction instance reference
+// ❌ WRONG: Using an Interaction instance as trigger
 StateTransfer.create({
-  trigger: PublishStyle,  // Correct! Reference to Interaction instance
+  trigger: PublishStyle,  // ERROR! Never matches any event
+  current: draftState,
+  next: activeState
+})
+
+// ✅ CORRECT: Match the interaction's event record creation
+StateTransfer.create({
+  trigger: {
+    recordName: InteractionEventEntity.name,
+    type: 'create',
+    record: { interactionName: PublishStyle.name }
+  },
   current: draftState,
   next: activeState
 })
@@ -397,13 +416,21 @@ statusProperty.computation = StateMachine.create({
     StateTransfer.create({
       current: draftState,
       next: activeState,
-      trigger: PublishStyle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: PublishStyle.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     }),
     StateTransfer.create({
       current: activeState,
       next: offlineState,
-      trigger: DeleteStyle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: DeleteStyle.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     })
   ]
@@ -443,7 +470,11 @@ updatedAtProperty.computation = StateMachine.create({
     StateTransfer.create({
       current: updatedState,
       next: updatedState,  // Self-loop to same state
-      trigger: UpdateStyle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: UpdateStyle.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     })
   ]
@@ -506,7 +537,11 @@ modificationInfoProperty.computation = StateMachine.create({
     StateTransfer.create({
       current: modifiedState,
       next: modifiedState,
-      trigger: UpdateArticle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: UpdateArticle.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     })
   ]
@@ -869,7 +904,11 @@ updatedAtProperty.computation = StateMachine.create({
     StateTransfer.create({
       current: updatedState,
       next: updatedState,
-      trigger: UpdateStyle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: UpdateStyle.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     })
   ]
@@ -905,7 +944,11 @@ statusProperty.computation = StateMachine.create({
     StateTransfer.create({
       current: activeState,
       next: offlineState,
-      trigger: DeleteStyle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: DeleteStyle.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     })
   ]
@@ -977,7 +1020,11 @@ updatedAtProperty.computation = StateMachine.create({
     StateTransfer.create({
       current: updatedState,
       next: updatedState,
-      trigger: UpdateInteraction,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: UpdateInteraction.name }
+      },
       computeTarget: (mutationEvent) => ({ id: mutationEvent.record.payload.id })
     })
   ]

--- a/agent/agentspace/knowledge/usage/04-reactive-computations.md
+++ b/agent/agentspace/knowledge/usage/04-reactive-computations.md
@@ -1118,25 +1118,75 @@ StateMachine is used for state transition-based computations, particularly suita
 
 ### Basic State Machine
 
-```javascript
-import { StateMachine } from 'interaqt';
+A StateMachine is declared from three parts: `StateNode` instances (the states), `StateTransfer` instances (the transitions), and an `initialState`. States are always object references, never strings.
 
+Each `StateTransfer` declares:
+- `current` / `next`: the state nodes the transfer connects
+- `trigger`: a `RecordMutationEventPattern` (`{ recordName, type, keys?, record?, oldRecord? }`) matched against record mutation events — for interaction-triggered transitions, match the creation of the interaction's event record
+- `computeTarget` (required for property-level state machines): maps the matched event to the record(s) whose property should transition
+
+```javascript
+import { StateMachine, StateNode, StateTransfer, InteractionEventEntity } from 'interaqt';
+
+// 1. Declare state nodes
+const pendingState = StateNode.create({ name: 'pending' });
+const paidState = StateNode.create({ name: 'paid' });
+const shippedState = StateNode.create({ name: 'shipped' });
+const deliveredState = StateNode.create({ name: 'delivered' });
+const cancelledState = StateNode.create({ name: 'cancelled' });
+
+// 2. Declare the interactions that drive the transitions
+const PayOrder = Interaction.create({
+  name: 'PayOrder',
+  action: Action.create({ name: 'payOrder' }),
+  payload: Payload.create({
+    items: [PayloadItem.create({ name: 'orderId', type: 'string', required: true })]
+  })
+});
+// ... ShipOrder / ConfirmDelivery / CancelOrder declared the same way
+
+// 3. Wire them together on the property
 const Order = Entity.create({
   name: 'Order',
   properties: [
     Property.create({ name: 'orderNumber', type: 'string' }),
-    Property.create({ 
-      name: 'status', 
+    Property.create({
+      name: 'status',
       type: 'string',
-      computation: new StateMachine({
-        states: ['pending', 'paid', 'shipped', 'delivered', 'cancelled'],
-        initialState: 'pending',
-        transitions: [
-          { from: 'pending', to: 'paid', condition: 'payment_received' },
-          { from: 'paid', to: 'shipped', condition: 'order_shipped' },
-          { from: 'shipped', to: 'delivered', condition: 'delivery_confirmed' },
-          { from: 'pending', to: 'cancelled', condition: 'order_cancelled' },
-          { from: 'paid', to: 'cancelled', condition: 'order_cancelled' }
+      computation: StateMachine.create({
+        states: [pendingState, paidState, shippedState, deliveredState, cancelledState],
+        initialState: pendingState,
+        transfers: [
+          StateTransfer.create({
+            current: pendingState,
+            next: paidState,
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: PayOrder.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
+          }),
+          StateTransfer.create({
+            current: paidState,
+            next: shippedState,
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: ShipOrder.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
+          }),
+          StateTransfer.create({
+            current: pendingState,
+            next: cancelledState,
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: CancelOrder.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
+          })
         ]
       })
     })
@@ -1144,92 +1194,60 @@ const Order = Entity.create({
 });
 ```
 
-### Event-Based State Transitions
+### Data-Based State Transitions
+
+`trigger` matches **any** record mutation event, not just interaction events. This means state transitions can also be driven by data changes — for example, transition when a specific field of the host record is updated (`keys` uses subset semantics: the transfer fires when the update touched all the listed fields):
 
 ```javascript
-// Define state transition events
-const PaymentReceived = Interaction.create({
-  name: 'PaymentReceived',
-  action: Action.create({
-    name: 'recordPayment',
-    payload: Payload.create({
-      items: [
-        PayloadItem.create({ name: 'orderId', base: Order, isRef: true }),
-        PayloadItem.create({ name: 'amount' }),
-        PayloadItem.create({ name: 'paymentMethod' })
-      ]
-    })
+const draftState = StateNode.create({ name: 'draft' });
+const publishedState = StateNode.create({ name: 'published' });
+
+Property.create({
+  name: 'status',
+  type: 'string',
+  computation: StateMachine.create({
+    states: [draftState, publishedState],
+    initialState: draftState,
+    transfers: [
+      StateTransfer.create({
+        current: draftState,
+        next: publishedState,
+        // Fires when a Document update touches the `reviewed` field
+        trigger: { recordName: 'Document', type: 'update', keys: ['reviewed'] },
+        computeTarget: (event) => ({ id: event.oldRecord?.id ?? event.record?.id })
+      })
+    ]
   })
 });
-
-// State machine listens to these events and automatically transitions states
-const Order = Entity.create({
-  name: 'Order',
-  properties: [
-    Property.create({
-      name: 'status',
-      type: 'string',
-      computation: new StateMachine({
-        states: ['pending', 'paid', 'shipped', 'delivered'],
-        initialState: 'pending',
-        transitions: [
-          { 
-            from: 'pending', 
-            to: 'paid', 
-            on: 'PaymentReceived'  // Listen to interaction events
-          },
-          { 
-            from: 'paid', 
-            to: 'shipped', 
-            on: 'OrderShipped' 
-          }
-        ]
-      })
-    })
-  ]
-});
 ```
 
-### Conditional State Transitions
+Note: if several transfers share the same `current` state and their triggers match the same event but lead to different next states, the framework throws an "ambiguous transition" error — make the triggers mutually exclusive (e.g. via `record` / `keys` patterns).
+
+### Guarding Transitions
+
+There is no `condition` field on `StateTransfer`. Preconditions belong to the interaction layer (use `conditions` / `userAttributives` on the Interaction so unauthorized or invalid calls never produce an event), and fine-grained per-record filtering is expressed in `computeTarget` — return `null`/`undefined` (or an empty array) to skip the transition for records that should not transition:
 
 ```javascript
-const LeaveRequest = Entity.create({
-  name: 'LeaveRequest',
-  properties: [
-    Property.create({ name: 'employeeId', type: 'string' }),
-    Property.create({ name: 'startDate', type: 'string' }),
-    Property.create({ name: 'endDate', type: 'string' }),
-    Property.create({ name: 'reason', type: 'string' }),
-    Property.create({
-      name: 'status',
-      type: 'string',
-      computation: new StateMachine({
-        states: ['draft', 'submitted', 'approved', 'rejected', 'cancelled'],
-        initialState: 'draft',
-        transitions: [
-          {
-            from: 'draft',
-            to: 'submitted',
-            on: 'SubmitRequest',
-            condition: (record) => record.reason && record.startDate && record.endDate
-          },
-          {
-            from: 'submitted',
-            to: 'approved',
-            on: 'ApproveRequest',
-            condition: (record, context) => context.user.role === 'manager'
-          },
-          {
-            from: 'submitted',
-            to: 'rejected',
-            on: 'RejectRequest',
-            condition: (record, context) => context.user.role === 'manager'
-          }
-        ]
-      })
-    })
-  ]
-});
+StateTransfer.create({
+  current: submittedState,
+  next: approvedState,
+  trigger: {
+    recordName: InteractionEventEntity.name,
+    type: 'create',
+    record: { interactionName: ApproveRequest.name }
+  },
+  computeTarget: async function (event) {
+    // `this` is the Controller: you can query before deciding the target
+    const request = await this.system.storage.findOne(
+      'LeaveRequest',
+      MatchExp.atom({ key: 'id', value: ['=', event.record.payload.requestId] }),
+      undefined,
+      ['id', 'reason', 'startDate', 'endDate']
+    );
+    if (!request?.reason || !request?.startDate || !request?.endDate) return null;
+    return { id: request.id };
+  }
+})
 ```
 
 ### Dynamic Value Computation with StateNode
@@ -1263,8 +1281,12 @@ const EventEntity = Entity.create({
             // Self-transition: stays in the same state but triggers computeValue
             current: triggeredState,
             next: triggeredState,
-            trigger: TriggerEventInteraction,
-            computeTarget: (event) => ({ id: event.payload.eventId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: TriggerEventInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.eventId })
           })
         ],
         initialState: triggeredState
@@ -1308,14 +1330,22 @@ const CounterEntity = Entity.create({
           StateTransfer.create({
             current: idleState,
             next: incrementingState,
-            trigger: IncrementInteraction,
-            computeTarget: (event) => ({ id: event.payload.counterId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: IncrementInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.counterId })
           }),
           StateTransfer.create({
             current: incrementingState,
             next: idleState,
-            trigger: ResetInteraction,
-            computeTarget: (event) => ({ id: event.payload.counterId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: ResetInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.counterId })
           })
         ],
         initialState: idleState
@@ -1369,20 +1399,32 @@ const TaskEntity = Entity.create({
           StateTransfer.create({
             current: newState,
             next: inProgressState,
-            trigger: StartTaskInteraction,
-            computeTarget: (event) => ({ id: event.payload.taskId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: StartTaskInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.taskId })
           }),
           StateTransfer.create({
             current: inProgressState,
             next: completedState,
-            trigger: CompleteTaskInteraction,
-            computeTarget: (event) => ({ id: event.payload.taskId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: CompleteTaskInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.taskId })
           }),
           StateTransfer.create({
             current: inProgressState,
             next: cancelledState,
-            trigger: CancelTaskInteraction,
-            computeTarget: (event) => ({ id: event.payload.taskId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: CancelTaskInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.taskId })
           })
         ],
         initialState: newState

--- a/agent/agentspace/knowledge/usage/05-interactions.md
+++ b/agent/agentspace/knowledge/usage/05-interactions.md
@@ -629,8 +629,12 @@ const User = Entity.create({
           StateTransfer.create({
             current: NameUpdatedState,
             next: NameUpdatedState,
-            trigger: UpdateUserProfile,
-            computeTarget: (event) => ({ id: event.payload.userId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: UpdateUserProfile.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.userId })
           })
         ],
         initialState: NameUpdatedState
@@ -645,8 +649,12 @@ const User = Entity.create({
           StateTransfer.create({
             current: BioUpdatedState,
             next: BioUpdatedState,
-            trigger: UpdateUserProfile,
-            computeTarget: (event) => ({ id: event.payload.userId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: UpdateUserProfile.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.userId })
           })
         ],
         initialState: BioUpdatedState
@@ -704,20 +712,32 @@ const Post = Entity.create({
           StateTransfer.create({
             current: draftState,
             next: publishedState,
-            trigger: PublishPost,
-            computeTarget: (event) => ({ id: event.payload.postId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: PublishPost.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.postId })
           }),
           StateTransfer.create({
             current: publishedState,
             next: deletedState,
-            trigger: DeletePost,
-            computeTarget: (event) => ({ id: event.payload.postId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: DeletePost.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.postId })
           }),
           StateTransfer.create({
             current: draftState,
             next: deletedState,
-            trigger: DeletePost,
-            computeTarget: (event) => ({ id: event.payload.postId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: DeletePost.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.postId })
           })
         ]
       })
@@ -821,26 +841,42 @@ const Order = Entity.create({
           StateTransfer.create({
             current: pendingState,
             next: confirmedState,
-            trigger: ConfirmPayment,
-            computeTarget: (event) => ({ id: event.payload.orderId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: ConfirmPayment.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
           }),
           StateTransfer.create({
             current: confirmedState,
             next: shippedState,
-            trigger: ShipOrder,
-            computeTarget: (event) => ({ id: event.payload.orderId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: ShipOrder.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
           }),
           StateTransfer.create({
             current: shippedState,
             next: deliveredState,
-            trigger: ConfirmDelivery,
-            computeTarget: (event) => ({ id: event.payload.orderId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: ConfirmDelivery.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
           }),
           StateTransfer.create({
             current: pendingState,
             next: cancelledState,
-            trigger: CancelOrder,
-            computeTarget: (event) => ({ id: event.payload.orderId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: CancelOrder.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.orderId })
           })
         ]
       })
@@ -1130,14 +1166,22 @@ const OrderStateMachine = StateMachine.create({
     StateTransfer.create({
       current: PendingState,
       next: PaidState,
-      trigger: PayOrder,
-      computeTarget: (event) => ({ id: event.payload.orderId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: PayOrder.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.orderId })
     }),
     StateTransfer.create({
       current: PaidState,
       next: ShippedState,
-      trigger: ShipOrder,
-      computeTarget: (event) => ({ id: event.payload.orderId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: ShipOrder.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.orderId })
     })
   ]
 });

--- a/agent/agentspace/knowledge/usage/08-activities.md
+++ b/agent/agentspace/knowledge/usage/08-activities.md
@@ -1,5 +1,15 @@
 # How to Use Activities for Process Management
 
+> **⚠️ Maintenance note (2026-07-09)**: parts of this guide are outdated. The REAL Activity API is:
+> `Activity.create({ name, interactions, transfers, groups? })` with `Transfer.create({ name, source, target })`,
+> where `source`/`target` are Interaction / ActivityGroup instances. **There is no string-based
+> `Transfer.create({ from, to, interaction, condition })` form** — examples below using that shape are
+> historical sketches and do not run. Activities are dispatched through `ActivityManager`:
+> compile with `new ActivityManager(activities).getOutput()`, pass the output entities/relations/eventSources
+> to the Controller, then `controller.dispatch(controller.findEventSourceByName('ActivityName:interactionName'), { user, activityId? })`.
+> For a runnable end-to-end example see `agent/agentspace/knowledge/usage/13-testing.md` §12.2.2
+> and `tests/runtime/activity.spec.ts`. A full rewrite of this guide is tracked as follow-up work.
+
 Activities are the core mechanism in interaqt for managing complex business processes. They allow you to define multi-step, multi-role business processes and control the execution order and conditions of processes through a state machine model.
 
 ## Understanding Activity Concepts

--- a/agent/agentspace/knowledge/usage/13-testing.md
+++ b/agent/agentspace/knowledge/usage/13-testing.md
@@ -574,121 +574,72 @@ describe('User Interactions', () => {
 
 ### 12.2.2 Activity Testing
 
+An Activity is an ordered composition of Interactions (`Activity.create({ name, interactions, transfers })`, with `Transfer.create({ name, source, target })` connecting them — NOT StateNode/StateTransfer, which belong to StateMachine). Use `ActivityManager` to compile activities into dispatchable event sources named `activityName:interactionName`, and drive them through `controller.dispatch`:
+
 ```typescript
 // tests/activities/approvalProcess.spec.ts
+import {
+  Activity, ActivityManager, Transfer, Interaction, Action,
+  Controller, MonoSystem, KlassByName
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
 describe('Approval Process Activity', () => {
   test('should handle complete approval workflow', async () => {
     const system = new MonoSystem(new PGLiteDB());
-    
-    // Create request entity
-    const requestEntity = Entity.create({
-      name: 'Request',
-      properties: [
-        Property.create({ name: 'title', type: 'string' }),
-        Property.create({ name: 'status', type: 'string' }),
-        Property.create({ name: 'submitterId', type: 'string' })
-      ]
-    });
-    
-    // Create activity states
-    const submittedState = StateNode.create({ name: 'submitted' });
-    const reviewingState = StateNode.create({ name: 'reviewing' });
-    const approvedState = StateNode.create({ name: 'approved' });
-    const rejectedState = StateNode.create({ name: 'rejected' });
-    
-    // Create interactions
-    const submitInteraction = Interaction.create({
+    system.conceptClass = KlassByName;
+
+    // 1. Declare the interactions of the workflow
+    const submit = Interaction.create({
       name: 'submit',
       action: Action.create({ name: 'submit' })
     });
-    
-    const approveInteraction = Interaction.create({
+    const approve = Interaction.create({
       name: 'approve',
       action: Action.create({ name: 'approve' })
     });
-    
-    const rejectInteraction = Interaction.create({
-      name: 'reject',
-      action: Action.create({ name: 'reject' })
-    });
-    
-    // Create state transfers
-    const submitTransfer = StateTransfer.create({
-      trigger: submitInteraction,
-      current: submittedState,
-      next: reviewingState
-    });
-    
-    const approveTransfer = StateTransfer.create({
-      trigger: approveInteraction,
-      current: reviewingState,
-      next: approvedState
-    });
-    
-    const rejectTransfer = StateTransfer.create({
-      trigger: rejectInteraction,
-      current: reviewingState,
-      next: rejectedState
-    });
-    
-    // Create activity
+
+    // 2. Compose them into an activity: submit → approve
     const approvalActivity = Activity.create({
       name: 'ApprovalProcess',
-      states: [submittedState, reviewingState, approvedState, rejectedState],
-      transfers: [submitTransfer, approveTransfer, rejectTransfer],
-      initialState: submittedState
+      interactions: [submit, approve],
+      transfers: [
+        Transfer.create({ name: 'submitToApprove', source: submit, target: approve })
+      ]
     });
-    
+
+    // 3. ActivityManager compiles the activity into event sources / records
+    const activityManager = new ActivityManager([approvalActivity]);
+    const activityOutput = activityManager.getOutput();
+
     const controller = new Controller({
       system,
-      entities: [requestEntity],
-      relations: [],
-      activities: [approvalActivity],  // activities
-      interactions: [submitInteraction, approveInteraction, rejectInteraction],  // interactions
-      dict: []
+      entities: [...activityOutput.entities],
+      relations: [...activityOutput.relations],
+      eventSources: [...activityOutput.eventSources]
     });
     await controller.setup(true);
-    
-    // Create request
-    const request = await system.storage.create('Request', {
-      title: 'Test Request',
-      status: 'submitted',
-      submitterId: 'user123'
-    });
-    
-    // Execute submit interaction
-    await controller.callInteraction(submitInteraction.name, {
-      user: { id: 'user123' },  // Add user object
-      payload: {
-        requestId: request.id
-      }
-    });
-    
-    // Verify state transition
-    let updatedRequest = await system.storage.findOne(
-      'Request',
-      MatchExp.atom({ key: 'id', value: ['=', request.id] }),
-      undefined,
-      ['id', 'title', 'status', 'submitterId']  // Specify fields
-    );
-    expect(updatedRequest.status).toBe('reviewing');
-    
-    // Execute approve interaction
-    await controller.callInteraction(approveInteraction.name, {
-      user: { id: 'admin-user' },  // Add user object
-      payload: {
-        requestId: request.id
-      }
-    });
-    
-    // Verify final state
-    updatedRequest = await system.storage.findOne(
-      'Request',
-      MatchExp.atom({ key: 'id', value: ['=', request.id] }),
-      undefined,
-      ['id', 'title', 'status', 'submitterId']  // Specify fields
-    );
-    expect(updatedRequest.status).toBe('approved');
+
+    const submitES = controller.findEventSourceByName('ApprovalProcess:submit')!;
+    const approveES = controller.findEventSourceByName('ApprovalProcess:approve')!;
+
+    // 4. The head interaction creates the activity instance
+    const res1 = await controller.dispatch(submitES, { user: { id: 'user123' } });
+    expect(res1.error).toBeUndefined();
+    const activityId = res1.context!.activityId as string;
+
+    // 5. Subsequent interactions must carry the activityId
+    const res2 = await controller.dispatch(approveES, { user: { id: 'admin-user' }, activityId });
+    expect(res2.error).toBeUndefined();
+
+    // 6. The activity is complete: no further interaction is available
+    const res3 = await controller.dispatch(approveES, { user: { id: 'admin-user' }, activityId });
+    expect(res3.error).toBeDefined();
+
+    // 7. Verify the activity state directly
+    const activityCall = activityManager.getActivityCallByName('ApprovalProcess')!;
+    const state = await activityCall.getState(controller, activityId);
+    expect(state.current).toBeUndefined();  // undefined = completed
   });
 });
 ```

--- a/agent/agentspace/knowledge/usage/14-api-reference.md
+++ b/agent/agentspace/knowledge/usage/14-api-reference.md
@@ -621,7 +621,11 @@ const OrderStateMachine = StateMachine.create({
         StateTransfer.create({
             current: pendingState,
             next: confirmedState,
-            trigger: ConfirmOrderInteraction
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: ConfirmOrderInteraction.name }
+            }
         })
     ],
     initialState: pendingState
@@ -927,23 +931,31 @@ StateTransfer.create(config: StateTransferConfig): KlassInstance<typeof StateTra
 ```
 
 **Parameters**
-- `config.trigger` (any, required): Trigger for the state transfer (usually an Interaction)
+- `config.trigger` (RecordMutationEventPattern, required): Pattern matched against record mutation events: `{ recordName, type, keys?, record?, oldRecord? }`. For interaction-triggered transfers use `{ recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: SomeInteraction.name } }`. `keys` uses subset semantics (fires when the update touched all listed fields)
 - `config.current` (StateNode, required): Current state node
 - `config.next` (StateNode, required): Next state node
-- `config.computeTarget` (function, optional): Function to dynamically compute the target state
+- `config.computeTarget` (function, optional for global-level, **required for property-level** state machines): Maps a matched mutation event to the record(s) whose property should transition, e.g. `(event) => ({ id: event.record.payload.id })`
 
 **Examples**
 ```typescript
 // Simple state transfer
 const approveTransfer = StateTransfer.create({
-    trigger: ApproveInteraction,
+    trigger: {
+      recordName: InteractionEventEntity.name,
+      type: 'create',
+      record: { interactionName: ApproveInteraction.name }
+    },
     current: pendingState,
     next: approvedState
 });
 
 // State transfer with dynamic target computation
 const conditionalTransfer = StateTransfer.create({
-    trigger: ProcessInteraction,
+    trigger: {
+      recordName: InteractionEventEntity.name,
+      type: 'create',
+      record: { interactionName: ProcessInteraction.name }
+    },
     current: pendingState,
     next: approvedState, // Default next state
     computeTarget: (context) => {

--- a/agent/agentspace/knowledge/usage/15-entity-crud-patterns.md
+++ b/agent/agentspace/knowledge/usage/15-entity-crud-patterns.md
@@ -363,14 +363,22 @@ const ArticleStatusStateMachine = StateMachine.create({
     StateTransfer.create({
       current: ActiveState,
       next: DeletedState,
-      trigger: DeleteArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: DeleteArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     }),
     StateTransfer.create({
       current: DeletedState,
       next: ActiveState,
-      trigger: RestoreArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: RestoreArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     })
   ]
 });
@@ -418,14 +426,22 @@ const Article = Entity.create({
             StateTransfer.create({
               current: activeState,
               next: deletedState,
-              trigger: DeleteArticle,
-              computeTarget: (event) => ({ id: event.payload.articleId })
+              trigger: {
+                recordName: InteractionEventEntity.name,
+                type: 'create',
+                record: { interactionName: DeleteArticle.name }
+              },
+              computeTarget: (event) => ({ id: event.record.payload.articleId })
             }),
             StateTransfer.create({
               current: deletedState,
               next: activeState,
-              trigger: RestoreArticle,
-              computeTarget: (event) => ({ id: event.payload.articleId })
+              trigger: {
+                recordName: InteractionEventEntity.name,
+                type: 'create',
+                record: { interactionName: RestoreArticle.name }
+              },
+              computeTarget: (event) => ({ id: event.record.payload.articleId })
             })
           ],
           initialState: activeState
@@ -476,11 +492,15 @@ deletionProperty.computation = StateMachine.create({
   initialState: NON_DELETED_STATE,
   transfers: [
     StateTransfer.create({
-      trigger: DeleteArticle,
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: DeleteArticle.name }
+      },
       current: NON_DELETED_STATE,
       next: DELETED_STATE,
       computeTarget: function(event) {
-        return { id: event.payload.articleId };
+        return { id: event.record.payload.articleId };
       }
     })
   ]
@@ -611,14 +631,22 @@ const ArticlePublishStateMachine = StateMachine.create({
     StateTransfer.create({
       current: DraftState,
       next: PublishedState,
-      trigger: PublishArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: PublishArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     }),
     StateTransfer.create({
       current: PublishedState,
       next: DraftState,
-      trigger: UnpublishArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: UnpublishArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     })
   ]
 });
@@ -722,8 +750,12 @@ const TimestampStateMachine = StateMachine.create({
     StateTransfer.create({
       current: TimestampState,
       next: TimestampState,
-      trigger: RecordActivity,
-      computeTarget: (event) => ({ id: event.payload.entityId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: RecordActivity.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.entityId })
     })
   ]
 });
@@ -767,7 +799,11 @@ const User = Entity.create({
           StateTransfer.create({
             current: activeState,
             next: activeState,
-            trigger: UserActivityInteraction,
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: UserActivityInteraction.name }
+            },
             computeTarget: (event) => ({ id: event.user.id })
           })
         ],
@@ -801,8 +837,12 @@ const Article = Entity.create({
           StateTransfer.create({
             current: modifiedState,
             next: modifiedState,
-            trigger: UpdateArticleInteraction,
-            computeTarget: (event) => ({ id: event.payload.articleId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: UpdateArticleInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.articleId })
           })
         ],
         initialState: modifiedState
@@ -834,8 +874,12 @@ const Sensor = Entity.create({
           StateTransfer.create({
             current: triggeredState,
             next: triggeredState,
-            trigger: SensorTriggerInteraction,
-            computeTarget: (event) => ({ id: event.payload.sensorId })
+            trigger: {
+              recordName: InteractionEventEntity.name,
+              type: 'create',
+              record: { interactionName: SensorTriggerInteraction.name }
+            },
+            computeTarget: (event) => ({ id: event.record.payload.sensorId })
           })
         ],
         initialState: triggeredState
@@ -896,7 +940,11 @@ Property.create({
       StateTransfer.create({
         current: activeState,
         next: activeState,
-        trigger: UserActivityInteraction,
+        trigger: {
+          recordName: InteractionEventEntity.name,
+          type: 'create',
+          record: { interactionName: UserActivityInteraction.name }
+        },
         computeTarget: (event) => ({ id: event.user.id })
       })
     ]
@@ -1033,20 +1081,32 @@ const ArticleLifecycleStateMachine = StateMachine.create({
     StateTransfer.create({
       current: DraftState,
       next: PublishedState,
-      trigger: PublishArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: PublishArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     }),
     StateTransfer.create({
       current: PublishedState,
       next: DeletedState,
-      trigger: DeleteArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: DeleteArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     }),
     StateTransfer.create({
       current: DraftState,
       next: DeletedState,
-      trigger: DeleteArticle,
-      computeTarget: (event) => ({ id: event.payload.articleId })
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: DeleteArticle.name }
+      },
+      computeTarget: (event) => ({ id: event.record.payload.articleId })
     })
   ]
 });

--- a/agent/agentspace/knowledge/usage/19-common-anti-patterns.md
+++ b/agent/agentspace/knowledge/usage/19-common-anti-patterns.md
@@ -232,7 +232,11 @@ StateMachine.create({
     StateTransfer.create({
       current: 'active',  // Should be object reference!
       next: 'inactive',   // Should be object reference!
-      trigger: SomeInteraction
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: SomeInteraction.name }
+      }
     })
   ],
   initialState: 'active'  // Should be object reference!
@@ -248,7 +252,11 @@ StateMachine.create({
     StateTransfer.create({
       current: activeState,     // Object reference
       next: inactiveState,      // Object reference
-      trigger: SomeInteraction
+      trigger: {
+        recordName: InteractionEventEntity.name,
+        type: 'create',
+        record: { interactionName: SomeInteraction.name }
+      }
     })
   ],
   initialState: activeState     // Object reference

--- a/agentspace/challenge/02-external-system-integration.md
+++ b/agentspace/challenge/02-external-system-integration.md
@@ -1,5 +1,11 @@
 # 外部系统集成挑战
 
+> **维护说明（2026-07-09）**：本文是历史设计讨论，其中的代码块（`transitions/from/to/on`、`ExternalEvent`、`AsyncTransform` 等）是**当时的假设性 API 推演，均不是真实 API**。文中提出的核心挑战已由后续设计解决：
+> - `StateTransfer.trigger` 是 `RecordMutationEventPattern`，可以匹配**任意**记录的 mutation 事件（不限于用户 Interaction）——外部回调写入的同步记录可以直接触发状态转移；
+> - 异步计算已通过 task 记录 + `asyncReturn` 独立事务机制支持（见 `agentspace/knowledge/external-resource-sync-abstractions.md` 与 `tests/runtime/asyncComputed.spec.ts`）。
+>
+> 真实 API 的用法请以 `agent/agentspace/knowledge/usage/04-reactive-computations.md` 为准。
+
 ## 业务场景：支付与第三方服务集成
 
 ### 具体需求


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The knowledge base (and AGENTS.md) contained several **fictional APIs that never existed in the implementation**, most prominently around StateMachine and Activity. These docs feed both humans and code-generation agents, so they actively produce broken code. This PR aligns them with the real 2.0 API.

### What was wrong

- `AGENTS.md` and `usage/04-reactive-computations.md` showed `StateMachine.create({ states: ['pending', ...], default/initialState: 'pending', transitions: [{ from, to, on, condition }] })` — none of these fields exist. The real API is `states` (StateNode instances) / `initialState` / `transfers` (StateTransfer instances).
- 47 occurrences of `trigger: SomeInteraction` across 6 files — `StateTransfer.trigger` is a `RecordMutationEventPattern`, and an Interaction instance never matches any mutation event (silent no-op). `generator/computation-implementation.md` even had a "🔴 IMPORTANT" block *teaching* the Interaction-instance form as correct.
- 32 occurrences of `computeTarget: (event) => event.payload.x` — the payload of an interaction event lives at `event.record.payload`.
- `usage/14-api-reference.md` described `trigger` as "(any, usually an Interaction)" and missed that `computeTarget` is required for property-level machines.
- `usage/13-testing.md` §12.2.2 had an Activity test example built from whole-cloth APIs (`Activity.create({states, transfers, initialState})` with StateTransfers, `controller.callInteraction`, `activities:`/`interactions:` Controller options).

### Changes

- `AGENTS.md`: real StateMachine pattern (StateNode/StateTransfer, event-pattern trigger, `computeTarget`).
- `usage/04-reactive-computations.md`: rewrote the StateMachine section — basic usage, data-based transitions via `trigger.keys` (subset semantics, new in 2.0), ambiguity error note, and guarding via Interaction `conditions` + `computeTarget` returning null (there is no `condition` field on StateTransfer).
- Mechanical fixes across `usage/04/05/14/15/19` and `generator/computation-implementation.md`: `trigger: X` → `{ recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: X.name } }`; `event.payload` → `event.record.payload` inside computeTarget.
- `generator/computation-implementation.md`: the trigger teaching block now shows Interaction-instance triggers as ❌ wrong and the event-pattern as ✅ correct.
- `usage/14-api-reference.md`: corrected `StateTransfer.create()` parameter docs.
- `usage/13-testing.md`: replaced the fictional Activity test with a **runnable** `ActivityManager` + `controller.dispatch` example — verified by executing it as a vitest spec against 2.0 before committing.
- `usage/08-activities.md`: maintenance banner stating the real `Activity/Transfer.create({name, source, target})` API and pointing to runnable references; the file's 35+ `from/to/condition` sketches need a full rewrite (tracked as follow-up).
- `agentspace/challenge/02-external-system-integration.md`: maintenance note marking its code sketches as historical design speculation, and noting the challenges are now addressed (mutation-pattern triggers, async task mechanism).

### Verification

- ✅ The new Activity testing example was run as a real vitest spec (1 passed) before being committed to the doc.
- ✅ `rg` sweeps confirm no `transitions:`/`from/to/on` StateMachine sketches and no `trigger: <Interaction>` forms remain outside the explicitly-marked historical/❌-wrong blocks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53c08915-dd04-4422-aace-9d580822d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53c08915-dd04-4422-aace-9d580822d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

