### PR TITLE
fix: fourth-round deep review (r4) — fatal + important findings fixed with regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ import {
   Payload, PayloadItem, Controller, MonoSystem,
   Count, Transform, InteractionEventEntity
 } from 'interaqt'
+import { PGLiteDB } from 'interaqt/drivers'
 
 // --- Define your data model ---
 

--- a/agentspace/output/deep-review-2026-07-09-r4.md
+++ b/agentspace/output/deep-review-2026-07-09-r4.md
@@ -1,5 +1,16 @@
 # 全代码库深度 Review 报告（2026-07-09 第四轮）
 
+> **维护说明（2026-07-09 更新）**：本报告发现的问题已在同分支（`cursor/deep-code-review-r4-9580`）修复：
+>
+> - **致命 F-1 ~ F-3 全部修复**，回归测试见 `tests/runtime/review-fixes-2026-07-09-r4.spec.ts`（5 个用例）与 `tests/builtins/serialization-r4.spec.ts`（4 个用例）：
+>   - F-1：`ActivityCall.isActivityHead` 函数体改用递归参数 `head`（原来误读 `this.graph.head` 导致 group 起点无限递归）。group 起点的多分支创建语义维持与线性 activity 一致：「head interaction 无 activityId = 隐式创建新 activity」，第二个分支带 activityId 在同一 activity 内推进；回归测试覆盖 every group 双分支完成的全流程。
+>   - F-2 / I-7：builtins 序列化统一接入 core 管线——`Interaction.stringify` 改用 `stringifyInstance`（嵌套 Klass 编码为 `uuid::` 引用、函数编码为 `func::`）；全部 builtins 的 `parse` 与 core 对齐（`decodeFunctionValues` + 保持 uuid 身份）；`Transfer`/`ActivityGroup`/`Attributives` 注册进 `builtins/init.ts`。graph 级 round-trip（`createInstances`）现在可完整还原含 interactions/transfers/groups/conditions（含函数）的 Activity 图；standalone `parse` 的契约（`uuid::` 引用需 graph 管线）与 core 一致并在测试中固化。
+>   - F-3：新增 `interaqt/drivers` 子路径导出（`vite.prod.config.ts` 多 entry + `package.json` exports）；四个驱动改为从主入口 `"interaqt"` 导入共享单例（`asyncInteractionContext` 等），drivers bundle 对主包保持 external（包自引用）。已验证 `npm run build` 后 `import('interaqt/drivers')` 可获得全部四个驱动，并以发布包形态跑通最小 controller 冒烟测试。README 快速示例补上 `import { PGLiteDB } from 'interaqt/drivers'`（README 其他位置早已使用该路径——文档承诺的导入路径此前在包里并不存在）。
+> - **重要项修复**：R-1（`checkActivityState`/`completeInteractionState` 对不存在的 activityId 抛业务级 `activity ... not found` 错误）、R-2（`computeDirtyRecords` 归一化 computeTarget 四种返回形态：`{id}`/`{id}[]`/`{source,target}`/`[[s,t]]`，端点形态在 relation 宿主上按端点查询 relation 记录，entity 宿主上 fail-fast 抛 `ComputationProtocolError`）、R-3（source-map 对 `_self` 宿主 create 监听与业务 dataDep 已注册的宿主 create 监听去重，computeCalls 2→1，global dict 更新触发不受影响）、R-6.1（Property Average 负 count 守卫，与 PropertyCount 对齐）。
+> - **明确遗留（建议独立 PR）**：R-4（`program` ActivityGroup 完成语义的产品决策）、R-5（Global StateMachine `initialState.computeValue` 契约文档化）、R-6.2/6.3（聚合 handle recordName 校验对齐 + relation 属性 update 增量测试，随六 handle 模板抽取一并处理）、R-7（dictionary defaultValue 进 modelHash + stableStringify undefined 处理）、第四节全部改进项。
+>
+> 修复后全量测试 1725 passed / 26 skipped（基线 1716，新增 9 个用例，更新 10 个既有序列化用例以匹配「parse 保持 uuid 身份」的统一契约）；`npm run check` 与 `npm run build` 通过。下文正文保留 review 时的原始判定，作为问题背景与复现依据。
+
 - 日期：2026-07-09
 - 基线：`main` @ `b9ee8404`（PR #20 合入之后，前三轮 review 修复全部落地）
 - 范围：`src/core`、`src/runtime`（含 computations、migration）、`src/storage`、`src/builtins`（重点：Activity/序列化）、`src/drivers`、打包与发布配置（`package.json` / `vite.prod.config.ts`）

--- a/agentspace/output/deep-review-2026-07-09-r4.md
+++ b/agentspace/output/deep-review-2026-07-09-r4.md
@@ -1,0 +1,295 @@
+# 全代码库深度 Review 报告（2026-07-09 第四轮）
+
+- 日期：2026-07-09
+- 基线：`main` @ `b9ee8404`（PR #20 合入之后，前三轮 review 修复全部落地）
+- 范围：`src/core`、`src/runtime`（含 computations、migration）、`src/storage`、`src/builtins`（重点：Activity/序列化）、`src/drivers`、打包与发布配置（`package.json` / `vite.prod.config.ts`）
+- 方法：四个方向并行深度探查（storage 删除/对称关系/查询修饰符 / runtime dispatch 与 builtins / computations 增量语义 / core 序列化+drivers+migration+打包）→ 人工精读交叉验证 → **对每个致命候选编写最小复现测试并实际运行**（PGLiteDB / SQLiteDB）。只有「已运行复现确认」的问题列为致命；仅凭精读判定的问题单独分级并标注置信度。
+- 与既有报告的关系：前三轮（`full-codebase-review-2026-07.md`、`deep-review-2026-07-08-r2.md`、`deep-review-2026-07-09-r3.md`）的致命与重要项已全部修复并有回归测试；其「明确遗留」项（r3 的 R-4/R-5/R-6/R-8、六聚合 handle 模板抽取、I-1~I-16，r2 的驱动类型映射、级联深度、async task 清理、合表事件完整性、migration 运维项）仍然有效，本报告不重复展开。本报告发现均为**新增**。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1716 passed / 26 skipped，全部通过；`npm run build` 成功。
+
+---
+
+## 一、结论摘要
+
+前三轮把火力集中在 storage 读写路径、filtered entity、增量计算边界上，这些区域经三轮修复已明显收敛（本轮对 DELETE 级联、对称关系、查询修饰符、JSON 值处理、事务回滚边界的复查全部通过，见第五节）。本轮把纵深转向**此前零覆盖的区域**：Activity 图的非线性形态、builtins 的序列化 round-trip、以及**发布打包链路**——三处各查出一个已复现的致命问题。
+
+值得注意的规律：本轮致命问题全部集中在「**测试从未走过的公开 API 形态**」——group 起点的 Activity（现有测试只有线性 head→group）、含 interactions/conditions 的 Activity/Interaction 序列化（现有测试只 round-trip 空 Activity 和 name/action）、npm 消费者视角的驱动导入（测试全部走 `@drivers` 路径别名，从不走发布包入口）。测试矩阵的盲区即缺陷聚集区。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现） | 3 | group 起点 Activity 无限递归栈溢出、Activity/Interaction 序列化 round-trip 断裂、发布包无法获得任何数据库驱动 |
+| 重要（已复现） | 3 | 不存在的 activityId 抛裸 TypeError、StateMachine computeTarget 对象形式静默失效、global dataDep 触发同一计算双跑 |
+| 重要（精读，高置信度） | 5 | `program` ActivityGroup 永久卡死、Global StateMachine initialState.computeValue 无 event 契约、Property Average 负 count 无守卫、聚合 handle recordName 校验不对称、dictionary defaultValue 变更不进 modelHash |
+| 显著改进 | 若干 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认）
+
+### F-1 Activity 以 ActivityGroup 为起点：`isActivityHead` 无限递归，**构造期栈溢出**
+
+- 位置：`src/builtins/interaction/activity/ActivityCall.ts` L326–332：
+
+```ts
+isActivityHead(interaction: InteractionInstance, head: InteractionLikeNodeBase = this.graph.head): boolean {
+    if (ActivityGroup.is(this.graph.head.content)) {          // ← 应检查参数 head.content
+        return !!(this.graph.head as ActivityGroupNode)       // ← 应使用参数 head
+            .childSeqs?.some(seq => this.isActivityHead(interaction, seq.head))
+    } else {
+        return interaction === this.graph.head.content        // ← 应比较参数 head.content
+    }
+}
+```
+
+  方法签名接收 `head` 参数并在递归时传入 `seq.head`，但**函数体三处全部读取 `this.graph.head`**——当 graph 起点是 group 时，`ActivityGroup.is(this.graph.head.content)` 恒真，递归永不落到 else 分支。
+- 调用链：`new ActivityManager(activities)` → `buildActivityInteractionEventSource` L103 `activityCall.isActivityHead(interaction)` → 无限递归。
+- 复现（REPRO-7，实测输出）：`Activity.create({ interactions: [], groups: [everyGroup], ... })`（并行分支直接作为流程起点，合法建模形态）：
+
+```
+RangeError: Maximum call stack size exceeded
+  at ActivityCall.isActivityHead (ActivityCall.ts:326)  ← ActivityManager 构造期即崩 ❌
+```
+
+- 影响：任何以 group 为起点的 Activity（「多个并行分支组成的审批流」是常见建模）在 `new ActivityManager` 时就以裸 RangeError 崩溃，应用无法启动，错误信息与用户声明毫无关联。现有测试（`tests/runtime/data/activity/index.ts`）的图形态全部是「线性 head → group」，从未覆盖 group 即起点。
+- 修复方向：函数体统一改用参数 `head`（`head.content` / `(head as ActivityGroupNode).childSeqs`）。**注意修复递归后还有第二层问题**：group 起点意味着多个分支 head 都会被判定为 `isHeadInteraction`，`wrappedGuard`（`ActivityManager.ts` L106–111）对每个无 `activityId` 的 head dispatch 都会 `activityCall.create()` 新建一条 `_Activity_` 记录——两个分支各自 dispatch 会把同一业务流拆成两条互不关联的 activity。需要同时决策：group 起点场景下只允许第一个分支隐式创建，其余分支无 activityId 时抛明确错误（或都要求显式创建）。修复必须附带 group-起点 activity 的完整测试。
+
+### F-2 Activity 序列化 round-trip 断裂：`parse` 不还原 `uuid::` 引用，Transfer/ActivityGroup 未注册
+
+- 位置：
+  - `src/builtins/interaction/Activity.ts` L122–138（`stringify` 用 `stringifyAttribute` 把 interactions/transfers/groups/events 编码为 `"uuid::<id>"` 字符串）与 L162–165（`parse` 直接 `this.create(data.public)`，**不做任何 uuid 解码**）；`Transfer.parse`（L336–338）同构。
+  - `src/builtins/init.ts` L14–26：`Transfer`、`ActivityGroup` 未 `registerKlass`，即使走统一管线（`createInstancesFromString`）也无法按 displayName 还原。
+- 复现（REPRO-6，实测输出）：
+
+```
+const act = Activity.create({ name: 'R4Act', interactions: [a, b], transfers: [Transfer.create(...)] })
+const parsed = Activity.parse(Activity.stringify(act))
+parsed.interactions[0]  →  "uuid::id_87"（string）❌  应为 InteractionInstance
+parsed.transfers[0]     →  "uuid::id_90"（string）❌
+```
+
+- 影响：parse 产物在任何运行时消费点（`ActivityCall` 构图 / `forEachInteraction`）都会把字符串当 Klass 实例使用而崩溃或静默错行为。现有测试仅 round-trip **空** Activity（`tests/builtins/attributive.spec.ts` L172–182），从未覆盖含节点的图。
+- 修复方向：Activity/Transfer/ActivityGroup 的 parse 接入 core 的统一反序列化管线（uuid 引用需在 `KlassInstancesGraph` 上下文中解析，参考 `createInstancesFromString`），并把 Transfer/ActivityGroup 注册进 `init.ts`；或者明确这组 `stringify/parse` 不支持独立使用、从公开面移除并指向 `stringifyAllInstances`/`createInstancesFromString`。半可用的序列化 API 比没有更危险。
+
+### F-3 发布包无法获得任何数据库驱动：README 快速上手在 npm 消费者侧**不可运行**
+
+- 位置：
+  - `src/index.ts` L1–4：主入口只导出 `runtime/storage/core/builtins`，**不含 `drivers`**；
+  - `package.json` L49–62：`exports` 仅有 `"."`（`dist/index.js`），无 `./drivers` 子路径；
+  - `vite.prod.config.ts`：build entry 仅 `src/index.ts`，alias 里也没有 `@drivers`。
+- 复现（实测）：`npm run build` 成功后：
+
+```
+dist/drivers/ 只有 *.d.ts（类型声明），没有任何 .js 运行时产物
+node -e "import('./dist/index.js').then(m => console.log('PGLiteDB' in m))"  →  false ❌
+```
+
+- 影响：README 的 Quick Example（L171 `new MonoSystem(new PGLiteDB())`）对安装 `interaqt` 的 npm 用户**没有任何合法 import 路径可以成立**——四个驱动（SQLite/PG/PGLite/MySQL）全部不可达，框架开箱即不可用。仓库内测试全部走 `@drivers` 路径别名，所以 CI 永远发现不了。这是 v2.0.0 已发布版本的打包缺陷。
+- 修复方向：新增 `./drivers` 子路径导出（独立 entry 打包 `src/drivers/index.ts`，四个驱动依赖已在 rollup external 列表中），README 补 `import { PGLiteDB } from 'interaqt/drivers'`；不建议并入主入口（会把 better-sqlite3/pg/mysql2 变成主包的隐式可选依赖解析负担）。修复后应加一个「以发布包形态 import」的冒烟测试（pack + 从 tarball import）。
+
+---
+
+## 三、重要问题
+
+### R-1 不存在的 `activityId`：guard 阶段抛裸 `TypeError`（已复现）
+
+- 位置：`src/builtins/interaction/activity/ActivityCall.ts` L289–291（`getState` 对不存在的 activity 返回 `undefined`）→ L334–338（`checkActivityState` 直接 `new ActivityState(undefined, ...)`）→ `ActivitySeqState.create` 读 `undefined.current`。`completeInteractionState`（L349–351）同族。
+- 复现（REPRO-2/2b，实测输出）：
+
+```
+dispatch(es, { activityId: '01890a5d-…'(合法 uuid 格式、不存在) })
+  → error: TypeError :: Cannot read properties of undefined (reading 'current') ❌
+dispatch(es, { activityId: 'non-existent-id'(非 uuid 格式) })
+  → error: invalid input syntax for type uuid（PGLite 裸 DB 错误）❌
+```
+
+- 影响：API 边界输入（客户端传来的 activityId）导致内部 TypeError / 裸数据库错误，与相邻路径已有的受控错误（`activityId must be provided ...`）风格断裂，`forceThrowDispatchError` 场景下极难诊断。
+- 修复方向：`checkActivityState` / `completeInteractionState` 入口 fail-closed：`getActivity` 为空时抛 `activity ${activityId} not found` 的业务级错误。
+
+### R-2 PropertyStateMachine `computeTarget` 返回 `{source, target}` 对象：转移静默失效（已复现）
+
+- 位置：`src/runtime/computations/StateMachine.ts` L73–76 声明了 `ComputeRelationTargetResult = SourceTargetPair | {source, target} | undefined` 等类型（**死类型，无任何实现消费**）；`computeDirtyRecords` L183–197 对返回值只做 `.flat().filter(Boolean)`——`{source, target}` 对象整个保留，`record.id === undefined`，`lock(dirtyRecord)` 失败后 `ComputationResult.skip()`（L202–203），无错误无日志。
+- 复现（REPRO-1，实测输出）：Follow 关系 create 触发 User.status 转移，`computeTarget: e => ({source: {id}, target: {id}})`：
+
+```
+create Follow 后：users = [{status:'pending'}, {status:'pending'}] ❌（应为 'linked'，且无任何报错）
+```
+
+- 影响：类型层面像是承诺过的返回形态（且 `[[s,t],…]` 数组对形式恰好能被 `.flat()` 展开而工作），对象形式静默 no-op。与 r2 F-3（trigger.keys 死 API）同族——「类型系统允许的声明静默失效」。
+- 修复方向：`computeDirtyRecords` 统一归一化 `{id}` / `{id}[]` / `[[s,t]]` / `{source,target}` 四种形态；无法归一化的形态抛 `ComputationProtocolError`。同时删掉或真正实现那组死类型。顺带：`lock` 失败（stale id）建议加 debug 日志，消除静默 skip 的排查黑洞。
+
+### R-3 property 计算声明 global dataDep 时：宿主 create 触发同一计算**两次**（已复现）
+
+- 位置：`src/runtime/ComputationSourceMap.ts` L116–124——存在 global dataDep 时额外注册 `_self` 的宿主 create 监听（初始化用），但与该计算其余 dataDep 自身的宿主 create 监听**不去重**；`Scheduler.ts` L388–404 的 listener 对同一 (computation, event) 无去重。
+- 复现（REPRO-4，实测输出）：`dataDeps: { _current: property, threshold: global }`：
+
+```
+create Item 后：computeCalls = 2 ❌（值正确，但完整 compute 执行了两遍）
+```
+
+- 影响：值正确（两次都是全量求值），但对昂贵计算 / async 计算（会创建两条 async task）/ 含外部副作用的 Custom 是实打实的双跑。宿主实体高频创建的场景计算量翻倍。
+- 修复方向：在 source-map 初始化时对「同 computation × 同 recordName × 同事件类型」的监听去重（`_self` 与业务 dataDep 合并）；或在 Scheduler 的单事件分发循环内按 computation 去重。
+
+### R-4 `program` ActivityGroup：注册了类型但无完成语义，activity 永久卡死（精读，高置信度）
+
+- 位置：`src/builtins/interaction/activity/ActivityCall.ts` L458–460——`ProgrammaticActivityStateNode` 空类注册进 `GroupStateNodeType`，无 `onChange`、无人调用 `complete()`。声明 `ActivityGroup.create({type: 'program'})` 合法、运行时永远无法越过该 group。
+- 修复方向：实现完成语义（暴露程序化 complete 入口）或从类型注册表移除并在声明期拒绝。
+
+### R-5 Global StateMachine `initialState.computeValue` 在 setup 期收到 `event === undefined`：契约未声明（已实测行为，语义分级）
+
+- 位置：`StateMachine.ts` L108–110（Global 的 `getInitialValue` 把 `event` 透传给 `computeValue`，setup 调用链 `Scheduler.setupGlobalComputationDefaultValue` L356–364 不传 event）。对照 Property 路径（L164–177）有显式 assert 与分支。
+- 实测（REPRO-10）：`computeValue: (last, event) => event?.record?.reason ?? 'unknown-reason'` 在 setup 后 dict 值为 `'unknown-reason'`——回调必须自己防御 undefined，框架无任何提示。若用户直接解构 `event.record` 则 setup 崩溃且栈指向用户代码。
+- 修复方向：文档化「initialState.computeValue 的 event 恒为 undefined」，或与 Property 路径对齐加保护性错误消息。
+
+### R-6 计算层三处漂移（精读，高置信度，与六 handle 模板抽取同根）
+
+1. **Property Average 无负 count 守卫**：`Average.ts` L308–311 返回 `count > 0 ? sum/count : 0`，count 被减成负数时静默产出错误比例；对照 `Count.ts` L287 有 `count < 0 throw`。
+2. **update 分支 recordName 校验不对称**：`Every.ts` L252 / `Any.ts` 在 relation 属性 update 分支显式校验 `relatedMutationEvent.recordName`，`Count/Summation/Average/WeightedSummation` 不校验——当前路由下正确，路由扩展时是漂移温床。
+3. **relation 属性 update 的增量路径测试缺口**：`count.spec.ts`/`summation.spec.ts` 对 relation 侧 `& field` 只覆盖 create，update 增量无回归。
+
+### R-7 migration：dictionary `defaultValue` 变更不进 modelHash / diff（精读，高置信度）
+
+- 位置：`migration.ts` L929–938 / L1547–1566——manifest 对 dictionary 只收集 `type/collection/computed`；函数型 defaultValue 变更完全不可见，`setup(false)` 直接放行。与已修复的 r2 R-8（bound-state defaultValue 进签名）同族漏项。
+- 修复方向：复用 `serializeState` 的函数文本哈希模式（L722–730）收集 dictionary defaultValue。同族顺带：`stableStringify`（L542–551）对值为 `undefined` 的字段产出 `"key":` 空片段，应显式省略键或序列化为 null，保证 hash 输入恒为合法 JSON 文本。
+
+---
+
+## 四、显著值得改进的地方
+
+### 4.1 storage / 查询语义（本轮实测确认的两项语义陷阱）
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | 查询结果丢弃 SQL NULL（实测确认） | `QueryExecutor.ts` L119–121 `if (value !== null) setByPath(...)` | `create({subtitle: null})` 后 find 返回的对象**没有 subtitle 键**（REPRO-12 实测）。与写侧 `['=', null]` 语义不对齐，下游 `record.field === null` 恒 false。至少在 USAGE_GUIDE 文档化「NULL = 键缺失」，或改为保留 null（行为变更需评审） |
+| I-2 | `!=` 对 NULL 行的三值逻辑（实测确认） | `MatchExp.ts` L211–231 | `category != 'news'` 不命中 category 为 NULL 的行（REPRO-14 实测返回 []）。标准 SQL 语义但对 JS 用户是陷阱；文档化或提供 `['is distinct from', v]` 算子 |
+| I-3 | `like` 无 ESCAPE / 通配符转义 | `MatchExp.getFinalFieldValue` L211 | 用户数据里的 `%`/`_` 被当通配符；提供转义 helper 或 ESCAPE 子句 |
+| I-4 | 写路径 boolean 归一化只在 driver 层 | `SQLBuilder.prepareFieldValue` L562–567 只处理 json | SQLite/MySQL 靠各 driver 的 `true→1` 兜底；应上提到 SQLBuilder 统一（读侧 `structureRawReturns` 已归一化） |
+| I-5 | 合表部分删除发 `delete` 事件但物理行保留 | `DeletionExecutor.ts` L139–151 | 事件语义上区分 hardDelete 与 rowEviction，或文档说明 |
+| I-6 | 后分页（x:n 剥离 LIMIT）缺根级 orderBy 重排 | `QueryExecutor.ts` L229–234 | 常规路径实测正确（REPRO-13），但按 x:n 关联字段排序时 tie-order 取决于 JOIN 顺序，非确定；dedupe 后按 modifier 重排根记录更稳 |
+
+### 4.2 runtime / builtins
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-7 | Interaction 序列化未走统一 Klass 管线：函数丢失（实测确认） | `Interaction.ts` L169–217 | REPRO-11 实测：含 `Conditions` 的 Interaction round-trip 后 Condition 的 `content` 函数**丢失**（`stringify` 对嵌套 Klass 直接 JSON.stringify、`parse` 无 `decodeFunctionValues`）。简单字段（action/payload）表面存活（REPRO-5），但 guard 能力静默损毁。与 F-2 一并统一到 core 管线 |
+| I-8 | `setup(true)` 不执行 entity/relation 级计算的 getInitialValue | `Scheduler.ts` L356–365（相关分支被注释） | 纯 entity/relation 级计算空库 install 后为 null 直到首次 mutation；文档化或补一次性 full compute |
+| I-9 | 非 isRef 的 Entity/Relation payload 校验过弱 | `Interaction.ts` L517–519 | 任意 `{}` 通过 guard（r2 I-14 的延续）；`type: 'object'` 的 primitive 检查也接受数组，应排除 `Array.isArray` |
+| I-10 | `saveUserRefs` 的 refs 合并不在 stateVersion CAS 保护内 | `ActivityCall.ts` L375–396 | 既有遗留 I-12 的再确认：refs 是无版本 read-modify-write，修 F-1 的多分支并行时优先级上升 |
+| I-11 | records dataDep 的 DELETE 事件无 source-map 级预过滤 | `Scheduler.ts` L669–717 兜底 | 功能正确、大删除量时多余触发；可与 update 的 membership 预检对称 |
+
+### 4.3 computations / core / drivers
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-12 | MathResolver：Inequality.solve 忽略运算符方向、二次方程丢负根、多变量 throw | `MathResolver.ts` L315–367、L425–430 | RealTime 用作「翻转时刻」尚可，语义应文档化；实现 R-5（时间调度器）前还需 clamp 过去时间戳（`RealTime.ts` L14–47） |
+| I-13 | RealTime property 初始值 `0` vs global `null` | `RealTime.ts` L78–79、L139–140 | boolean RealTime property 类型不一致 |
+| I-14 | RefContainer.updateSpecificReferences 不遍历 computation 引用 | `RefContainer.ts` L309–350 | replace 后其他实体 `Property.computation.record` 仍指向旧对象；当前主线未消费该路径，防御性修复 + 测试 |
+| I-15 | relation `type` 变更（1:n→n:n）缺 storage blocking 显式兜底 | `migration.ts` L1517–1531 vs `getStorageBlockingChanges` L2265–2346 | 中置信度：布局不变时可能仅逻辑层 changed 而 DDL 放行；补 relation type 专项测试确认 |
+| I-16 | MySQL `LAST_INSERT_ID` 可能返回 bigint | `Mysql.ts` L137–139 | `Number()` 归一化并写入驱动契约 |
+| I-17 | 对称 n:n 不阻止 (A,B)+(B,A) 双向重复边 | `CreationExecutor.ts` L417–427 | 现有测试有意允许；若语义是「无向边唯一」则 Count 会 double-count——需要产品决策后文档化 |
+| I-18 | `BoolExp.find` 的 context 类型 `unknown[]` 实际按 `string[]` 使用 | `BoolExp.ts` L365–377 | 类型/语义不一致 |
+
+### 4.4 测试矩阵缺口（本轮致命项的共同根因）
+
+| 场景 | 现状 |
+|------|------|
+| group 为起点的 Activity（构图 + 多分支 dispatch） | **零覆盖** → F-1 |
+| 含 interactions/transfers/conditions 的 Activity/Interaction 序列化 round-trip + 还原后 dispatch | 仅空 Activity / 仅 name+action → F-2、I-7 |
+| 以发布包形态（pack + import tarball）的冒烟测试 | 零覆盖（全部走 `@drivers` alias）→ F-3 |
+| computeTarget 四种返回形态矩阵 | 仅 `{id}`/`undefined` → R-2 |
+| 无效 activityId | 零覆盖 → R-1 |
+| global dataDep + 宿主 create 的调用次数断言 | 零覆盖 → R-3 |
+| relation 属性 update 的 Count/Summation/Average 增量 | 仅 create → R-6.3 |
+
+### 4.5 既有报告遗留项（仍有效）
+
+r3 的 R-4（asyncReturn advisory lock）、R-5（RealTime 时间调度器）、R-6（迁移终态 phase）、R-8（批量 1:n 孤儿告警）、I-1~I-16；r2 的驱动类型映射统一、级联深度上限、async task 清理、合表事件完整性（本轮 storage 复查确认 `flashOutCombinedRecordsAndMergedLinks`/`relocateCombinedRecordDataForLink` 的内部 `deleteRecordSameRowData`/`insertSameRowData` 仍不传 events——该路径当前仅显式 mergeLinks 配置可达，维持「先决策 mergeLinks 去留」的结论）；六聚合 handle 共享模板抽取（本轮 R-6 又见三处漂移，四轮累计 10 个具体缺陷，优先级应再次上调）。
+
+---
+
+## 五、本轮复查确认健康的区域
+
+| 区域 | 结论 |
+|------|------|
+| dispatch 事务回滚 / guard 失败无部分事件 / retry 不重复 effects | `Controller.ts` L669–708 顺序正确；`transactionRetry.spec.ts` 覆盖 |
+| 主 DELETE 路径 filtered membership（含级联 reliance 树快照） | `DeletionExecutor` + `FilteredEntityManager.collectDeletionMemberships` 在物理删除前快照 |
+| 对称 n:n 的 match OR 双路径 / x:n 查询 / `&` 数据 | `MatchExp.buildFieldMatchExpression` L347–389 + 既有测试 |
+| JSON/collection 字段 UPDATE round-trip（PGLite/SQLite 实测） | REPRO-8/8b 通过（SQLBuilder 不做 stringify，但各 driver 的对象参数兜底成立；上提归一化列为 I-4） |
+| x:n 谓词 + limit/offset 的后分页去重（常规 SELECT） | REPRO-13 实测分页正确 |
+| r3 修复的持久性：global dict key 过滤、records dataDep fail-fast、Transform lockRecord miss 清理、成员资格 changedFields | 复查 + 既有回归测试均在位 |
+| ScopedSequence 并发 / 回滚 / gap 语义 | PG 100×2 并发测试在位；删除不回收为 by-design |
+| isRef payload 存在性校验、嵌套 dispatch 拦截 | `checkPayload` L456–474 fail-fast |
+
+---
+
+## 六、修复优先级建议
+
+**P0（应用无法启动 / 公开 API 断裂 / 发布包不可用，全部有复现）：**
+1. F-3 驱动子路径导出（影响所有 npm 消费者，v2.0.0 已带病发布）+ 发布包冒烟测试
+2. F-1 `isActivityHead` 递归修复 + group 起点多分支创建语义决策 + 测试
+3. F-2 / I-7 builtins 序列化统一接入 core 管线（Interaction/Activity/Transfer/ActivityGroup/Conditions），注册缺失 Klass；或从公开面收缩
+
+**P1（错误契约 / 静默失效 / 双跑）：**
+R-1 activityId fail-closed、R-2 computeTarget 归一化 + 死类型清理、R-3 source-map 触发去重、R-4 program group 决策、R-6.1 Average 负 count 守卫。
+
+**P2（契约文档化与防御）：**
+R-5 initialState.computeValue 契约、R-7 dictionary defaultValue 进 modelHash + stableStringify undefined、I-1/I-2 NULL 语义文档化、I-3~I-18、测试矩阵缺口补齐（4.4 节）。
+
+---
+
+## 附录：复现测试代码（验证用，未提交为正式测试）
+
+以下测试在 `b9ee8404` 上以 PGLiteDB/SQLiteDB 运行，结果如注释所示。修复时可改造为回归测试（断言改为正确语义）。
+
+```ts
+// F-1 (REPRO-7)：group 起点 Activity 构造期栈溢出
+const group = ActivityGroup.create({ type: 'every', activities: [
+  Activity.create({ name: 'seqA', interactions: [a] }),
+  Activity.create({ name: 'seqB', interactions: [b] }),
+]})
+const act = Activity.create({ name: 'R4Parallel', interactions: [], groups: [group] })
+new ActivityManager([act])
+// RangeError: Maximum call stack size exceeded @ ActivityCall.isActivityHead:326 ❌
+
+// F-2 (REPRO-6)：Activity round-trip 不还原 uuid 引用
+const act2 = Activity.create({ name: 'R4Act', interactions: [a, b],
+  transfers: [Transfer.create({ name: 't', source: a, target: b })] })
+const parsed = Activity.parse(Activity.stringify(act2))
+parsed.interactions[0]  // "uuid::id_87"（string）❌
+parsed.transfers[0]     // "uuid::id_90"（string）❌
+
+// F-3：发布包无驱动（npm run build 后）
+// dist/drivers/ 只有 *.d.ts；package.json exports 仅 "."
+import('./dist/index.js').then(m => 'PGLiteDB' in m)  // false ❌
+
+// R-1 (REPRO-2b)：不存在的 activityId
+await controller.dispatch(nonHeadES, { user, payload: {}, activityId: '01890a5d-…' })
+// error: TypeError :: Cannot read properties of undefined (reading 'current') ❌
+
+// R-2 (REPRO-1)：computeTarget 对象形式静默失效
+StateTransfer.create({ trigger: { recordName: Follow.name, type: 'create' },
+  current: pending, next: linked,
+  computeTarget: e => ({ source: {id: e.record.source.id}, target: {id: e.record.target.id} }) })
+// create Follow 后 status 仍为 'pending'，无报错 ❌
+
+// R-3 (REPRO-4)：global dataDep 双触发
+Custom.create({ dataDeps: { _current: {type:'property',attributeQuery:['value']},
+                            threshold: {type:'global',source:thresholdDict} }, compute })
+await storage.create('R4dItem', { value: 10 })
+// computeCalls === 2 ❌（应为 1）
+
+// I-7 (REPRO-11)：Interaction round-trip 丢失 condition 函数
+const ix = Interaction.create({ name: 'R4CondIx', action,
+  conditions: Conditions.create({ content: BoolExp.atom(Condition.create({ name:'c', content: async () => true })) }) })
+const p = Interaction.parse(Interaction.stringify(ix))
+// p.conditions.content.data = {_type:'Condition', name:'c'} —— content 函数丢失 ❌
+
+// I-1 (REPRO-12)：NULL 值从查询结果中消失
+await storage.create('R4nDoc', { title: 't', subtitle: null })
+const found = await storage.findOne('R4nDoc', matchId, undefined, ['*'])
+// 'subtitle' in found === false ❌（键整体缺失）
+
+// I-2 (REPRO-14)：!= 不命中 NULL 行
+// rows: {category:'news'}, {category:null}
+await storage.find('R4tDoc', MatchExp.atom({key:'category',value:['!=','news']}), undefined, ['title'])
+// → []（NULL 行被三值逻辑排除）
+```

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./drivers": {
+      "import": "./dist/drivers.js",
+      "types": "./dist/drivers/index.d.ts"
     }
   },
   "type": "module",

--- a/src/builtins/init.ts
+++ b/src/builtins/init.ts
@@ -1,7 +1,7 @@
 import { registerKlass } from '@core';
 import { Interaction } from './interaction/Interaction.js';
-import { Activity } from './interaction/Activity.js';
-import { Attributive } from './interaction/Attributive.js';
+import { Activity, ActivityGroup, Transfer } from './interaction/Activity.js';
+import { Attributive, Attributives } from './interaction/Attributive.js';
 import { Condition } from './interaction/Condition.js';
 import { DataPolicy } from './interaction/Data.js';
 import { Action } from './interaction/Action.js';
@@ -14,7 +14,13 @@ import { Conditions } from './interaction/Conditions.js';
 const klassesToRegister = [
   Interaction,
   Activity,
+  // CAUTION Transfer/ActivityGroup/Attributives 必须注册：
+  //  Activity.stringify 把 transfers/groups 编码为 `uuid::` 引用，
+  //  未注册的类型在 createInstancesFromString（graph 级反序列化）中无法还原。
+  ActivityGroup,
+  Transfer,
   Attributive,
+  Attributives,
   Condition,
   DataPolicy,
   Action,

--- a/src/builtins/interaction/Action.ts
+++ b/src/builtins/interaction/Action.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
 
 // Action 实例接口
 export interface ActionInstance extends IInstance {
@@ -76,7 +76,7 @@ export class Action implements ActionInstance {
 
   static parse(json: string): ActionInstance {
     const data: SerializedData<ActionCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 

--- a/src/builtins/interaction/Activity.ts
+++ b/src/builtins/interaction/Activity.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, stringifyAttribute } from '@core';
+import { IInstance, SerializedData, generateUUID, stringifyAttribute, decodeFunctionValues } from '@core';
 import { InteractionInstance } from './Interaction.js';
 import { GatewayInstance } from './Gateway.js';
 import { EventInstance } from './Event.js';
@@ -159,9 +159,12 @@ export class Activity implements ActivityInstance {
     return data !== null && typeof data === 'object' && typeof (data as IInstance).uuid === 'string';
   }
   
+  // 与 core（Entity.parse 等）对齐：还原 `func::` 函数并保持 uuid 身份。
+  // interactions/transfers/groups 等 `uuid::` 引用需要完整实例集合才能解析——
+  // graph 级反序列化请使用 createInstancesFromString（Transfer/ActivityGroup 已注册 Klass）。
   static parse(json: string): ActivityInstance {
     const data: SerializedData<ActivityCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 
@@ -247,7 +250,7 @@ export class ActivityGroup implements ActivityGroupInstance {
   
   static parse(json: string): ActivityGroupInstance {
     const data: SerializedData<ActivityGroupCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 
@@ -335,7 +338,7 @@ export class Transfer implements TransferInstance {
   
   static parse(json: string): TransferInstance {
     const data: SerializedData<TransferCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 

--- a/src/builtins/interaction/Attributive.ts
+++ b/src/builtins/interaction/Attributive.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, stringifyAttribute, BoolAtomDataInstance, BoolExpressionDataInstance } from '@core';
+import { IInstance, SerializedData, generateUUID, stringifyAttribute, decodeFunctionValues, BoolAtomDataInstance, BoolExpressionDataInstance } from '@core';
 
 // Attributive
 export interface AttributiveInstance extends IInstance {
@@ -106,14 +106,7 @@ export class Attributive implements AttributiveInstance {
   
   static parse(json: string): AttributiveInstance {
     const data: SerializedData<AttributiveCreateArgs> = JSON.parse(json);
-    const args = data.public;
-    
-    const raw = args as unknown as Record<string, unknown>;
-    if (typeof raw.content === 'string' && raw.content.startsWith('func::')) {
-      args.content = new Function('return ' + raw.content.substring(6))();
-    }
-    
-    return this.create(args, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 
@@ -194,7 +187,7 @@ export class Attributives implements AttributivesInstance {
   
   static parse(json: string): AttributivesInstance {
     const data: SerializedData<AttributivesCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 

--- a/src/builtins/interaction/Condition.ts
+++ b/src/builtins/interaction/Condition.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, stringifyAttribute, BoolExp, BoolAtomData, BoolExpressionData, type BoolExpressionRawData } from '@core';
+import { IInstance, SerializedData, generateUUID, stringifyAttribute, decodeFunctionValues, BoolExp, BoolAtomData, BoolExpressionData, type BoolExpressionRawData } from '@core';
 import { Conditions } from './Conditions.js';
 
 export interface ConditionInstance extends IInstance {
@@ -88,13 +88,6 @@ export class Condition implements ConditionInstance {
   
   static parse(json: string): ConditionInstance {
     const data: SerializedData<ConditionCreateArgs> = JSON.parse(json);
-    const args = data.public;
-    
-    const raw = args as unknown as Record<string, unknown>;
-    if (typeof raw.content === 'string' && raw.content.startsWith('func::')) {
-      args.content = new Function('return ' + raw.content.substring(6))();
-    }
-    
-    return this.create(args, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 } 

--- a/src/builtins/interaction/Conditions.ts
+++ b/src/builtins/interaction/Conditions.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, stringifyAttribute, BoolAtomDataInstance, BoolExpressionDataInstance, BoolExp, BoolAtomData, BoolExpressionData } from '@core';
+import { IInstance, SerializedData, generateUUID, stringifyAttribute, decodeFunctionValues, BoolAtomDataInstance, BoolExpressionDataInstance, BoolExp, BoolAtomData, BoolExpressionData } from '@core';
 
 export interface ConditionsInstance extends IInstance {
   content?: BoolExpressionDataInstance | BoolAtomDataInstance;
@@ -101,6 +101,6 @@ export class Conditions implements ConditionsInstance {
   
   static parse(json: string): ConditionsInstance {
     const data: SerializedData<ConditionsCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 } 

--- a/src/builtins/interaction/Data.ts
+++ b/src/builtins/interaction/Data.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
 
 // DataPolicy - defines fixed constraints for data fetching in interactions
 export interface DataPolicyInstance extends IInstance {
@@ -99,6 +99,6 @@ export class DataPolicy implements DataPolicyInstance {
   
   static parse(json: string): DataPolicyInstance {
     const data: SerializedData<DataPolicyCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }

--- a/src/builtins/interaction/Event.ts
+++ b/src/builtins/interaction/Event.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
 
 // Event 实例接口
 export interface EventInstance extends IInstance {
@@ -76,6 +76,6 @@ export class Event implements EventInstance {
 
   static parse(json: string): EventInstance {
     const data: SerializedData<EventCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 } 

--- a/src/builtins/interaction/Gateway.ts
+++ b/src/builtins/interaction/Gateway.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
 
 // Gateway 实例接口
 export interface GatewayInstance extends IInstance {
@@ -76,6 +76,6 @@ export class Gateway implements GatewayInstance {
 
   static parse(json: string): GatewayInstance {
     const data: SerializedData<GatewayCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 } 

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -1,7 +1,8 @@
 import {
     IInstance, SerializedData, generateUUID, Concept, ConceptAlias, ConceptInstance, DerivedConcept,
     EntityInstance, Entity, RelationInstance, Relation, Property,
-    BoolExp, ExpressionData, BoolExpressionRawData, EventSourceInstance
+    BoolExp, ExpressionData, BoolExpressionRawData, EventSourceInstance,
+    stringifyInstance, decodeFunctionValues
 } from '@core';
 import type { Controller } from '@runtime';
 import { ActionInstance, GetAction } from './Action.js';
@@ -166,26 +167,12 @@ export class Interaction implements InteractionInstance {
     return instance;
   }
   
+  // CAUTION 必须走统一的 stringifyInstance 管线：嵌套的 Klass 实例（Action/Conditions/Payload/Entity 等）
+  //  会被编码为 `uuid::` 引用、函数编码为 `func::`。此前手写的 JSON.stringify 会把嵌套实例内联成
+  //  plain object（函数直接丢失、Klass 身份丢失），graph 级 round-trip（stringifyAllInstances →
+  //  createInstancesFromString）产出损毁的 Interaction。
   static stringify(instance: InteractionInstance): string {
-    const args: InteractionCreateArgs = {
-      name: instance.name,
-      action: instance.action
-    };
-    if (instance.conditions !== undefined) args.conditions = instance.conditions;
-    if (instance.userAttributives !== undefined) args.userAttributives = instance.userAttributives;
-    if (instance.userRef !== undefined) args.userRef = instance.userRef;
-    if (instance.payload !== undefined) args.payload = instance.payload;
-
-    if (instance.data !== undefined) args.data = instance.data;
-    if (instance.dataPolicy !== undefined) args.dataPolicy = instance.dataPolicy;
-    
-    const data: SerializedData<InteractionCreateArgs> = {
-      type: 'Interaction',
-      options: instance._options,
-      uuid: instance.uuid,
-      public: args
-    };
-    return JSON.stringify(data);
+    return stringifyInstance(this, instance as unknown as IInstance);
   }
   
   static clone(instance: InteractionInstance, deep: boolean): InteractionInstance {
@@ -212,9 +199,11 @@ export class Interaction implements InteractionInstance {
     return data !== null && typeof data === 'object' && typeof (data as IInstance).uuid === 'string';
   }
   
+  // 与 core（Entity.parse 等）对齐：还原 `func::` 函数并保持 uuid 身份。
+  // `uuid::` 引用需要完整实例集合才能解析——graph 级反序列化请使用 createInstancesFromString。
   static parse(json: string): InteractionInstance {
     const data: SerializedData<InteractionCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }
 

--- a/src/builtins/interaction/Payload.ts
+++ b/src/builtins/interaction/Payload.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
 import { PayloadItemInstance } from './PayloadItem.js';
 
 export interface PayloadInstance extends IInstance {
@@ -76,6 +76,6 @@ export class Payload implements PayloadInstance {
   
   static parse(json: string): PayloadInstance {
     const data: SerializedData<PayloadCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 } 

--- a/src/builtins/interaction/PayloadItem.ts
+++ b/src/builtins/interaction/PayloadItem.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, EntityInstance } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues, EntityInstance } from '@core';
 import { AttributiveInstance, AttributivesInstance } from './Attributive.js';
 
 export interface PayloadItemInstance extends IInstance {
@@ -146,6 +146,6 @@ export class PayloadItem implements PayloadItemInstance {
   
   static parse(json: string): PayloadItemInstance {
     const data: SerializedData<PayloadItemCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 } 

--- a/src/builtins/interaction/activity/ActivityCall.ts
+++ b/src/builtins/interaction/activity/ActivityCall.ts
@@ -324,15 +324,24 @@ export class ActivityCall {
     }
 
     isActivityHead(interaction: InteractionInstance, head: InteractionLikeNodeBase = this.graph.head): boolean {
-        if (ActivityGroup.is(this.graph.head.content)) {
-            return !!(this.graph.head as ActivityGroupNode).childSeqs?.some(seq => this.isActivityHead(interaction, seq.head))
+        // CAUTION 必须使用参数 head（递归时传入的是子序列的 head），
+        //  误用 this.graph.head 会在「group 作为流程起点」时无限递归（构造期栈溢出）。
+        const headNode = head as InteractionNode | ActivityGroupNode
+        if (ActivityGroup.is(headNode.content)) {
+            return !!(headNode as ActivityGroupNode).childSeqs?.some(seq => this.isActivityHead(interaction, seq.head))
         } else {
-            return interaction === this.graph.head.content
+            return interaction === headNode.content
         }
     }
 
     async checkActivityState(storage: StorageAccess, activityId: string, interactionUuid: string) {
-        const state = new ActivityState(await this.getState(storage, activityId), this)
+        // fail-closed：activityId 是 API 边界输入，查不到记录必须给出业务级错误，
+        //  否则 new ActivityState(undefined) 会在深处抛 "Cannot read properties of undefined" 的裸 TypeError。
+        const stateData = await this.getState(storage, activityId)
+        if (!stateData) {
+            throw new Error(`activity ${activityId} not found for activity "${this.activity.name}"`)
+        }
+        const state = new ActivityState(stateData, this)
         if (!state.isInteractionAvailable(interactionUuid)) {
             throw new Error(`interaction ${interactionUuid} not available`)
         }
@@ -348,6 +357,9 @@ export class ActivityCall {
 
     async completeInteractionState(storage: StorageAccess, activityId: string, interactionUuid: string) {
         const activity = await this.getActivity(storage, activityId)
+        if (!activity) {
+            throw new Error(`activity ${activityId} not found for activity "${this.activity.name}"`)
+        }
         const state = new ActivityState(activity.state, this)
         state.completeInteraction(interactionUuid)
         const nextState = state.toJSON()

--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -1,6 +1,5 @@
-import {Database, DatabaseLogger, EntityIdRef, asyncInteractionContext, InteractionContext, dbConsoleLogger, TransactionCapability} from "interaqt";
+import {Database, DatabaseLogger, EntityIdRef, asyncInteractionContext, InteractionContext, dbConsoleLogger, TransactionCapability, defaultEncodeLiteral} from "interaqt";
 import mysql, {type Connection, type ConnectionOptions, RowDataPacket} from 'mysql2/promise'
-import { defaultEncodeLiteral } from "@storage";
 
 class IDSystem {
     constructor(public db: Database) {}

--- a/src/drivers/PGLite.ts
+++ b/src/drivers/PGLite.ts
@@ -1,7 +1,6 @@
-import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionContext, InteractionContext, dbConsoleLogger, TransactionCapability} from "interaqt";
+import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionContext, InteractionContext, dbConsoleLogger, TransactionCapability, defaultEncodeLiteral} from "interaqt";
 import { PGlite} from '@electric-sql/pglite'
 import { uuidv7 } from "@interaqt/uuidv7";
-import { defaultEncodeLiteral } from "@storage";
 
 class IDSystem {
     constructor(public db: Database) {}

--- a/src/drivers/PostgreSQL.ts
+++ b/src/drivers/PostgreSQL.ts
@@ -1,8 +1,7 @@
-import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionContext, InteractionContext, dbConsoleLogger, RequireSerializableRetry, TransactionCapability, TransactionOptions} from "interaqt";
+import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionContext, InteractionContext, dbConsoleLogger, RequireSerializableRetry, TransactionCapability, TransactionOptions, defaultEncodeLiteral} from "interaqt";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
 import pg, { type ClientConfig, type PoolClient} from 'pg'
-import { defaultEncodeLiteral } from "@storage";
 
 const { Client, Pool } = pg
 

--- a/src/drivers/SQLite.ts
+++ b/src/drivers/SQLite.ts
@@ -1,6 +1,7 @@
 import SQLite from "better-sqlite3";
-import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionContext, InteractionContext, dbConsoleLogger, TransactionCapability} from "interaqt";
-import { sqliteEncodeLiteral } from "@storage";
+// CAUTION drivers 是发布包的独立子入口（interaqt/drivers），只能从主入口 "interaqt" 导入：
+//  路径别名（@storage 等）在消费者环境不存在，且共享单例（asyncInteractionContext）必须与主包同源。
+import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionContext, InteractionContext, dbConsoleLogger, TransactionCapability, sqliteEncodeLiteral} from "interaqt";
 
 class IDSystem {
     constructor(public db: Database) {}

--- a/src/runtime/ComputationSourceMap.ts
+++ b/src/runtime/ComputationSourceMap.ts
@@ -104,24 +104,33 @@ export class ComputationSourceMapManager {
                     })
                 }
 
+                const computationSources: EntityEventSourceMap[][] = [[], [], []]
                 Object.entries(computation.dataDeps).forEach(([dataDepName, dataDep]) => {
                     const sources = this.convertDataDepToERMutationEventsSourceMap(dataDepName, dataDep, computation)
-                    sortedERMutationEventSources[dataDep.phase || PHASE_NORMAL].push(...sources)
+                    computationSources[dataDep.phase || PHASE_NORMAL].push(...sources)
                 })
 
-                // ERMutationEventSources.push(
-                //     ...Object.entries(computation.dataDeps).map(([dataDepName, dataDep]) => this.convertDataDepToERMutationEventsSourceMap(dataDepName, dataDep, computation)).flat()
-                // )
-
                 // 2. 监听自身 record 的 create 事件，可能一开始创建就要执行一遍 computation. 如果依赖了已有的 global dict。
+                // CAUTION 必须与业务 dataDeps 已注册的宿主 create 监听去重：
+                //  property dataDep 本身就会注册宿主 create（convertAttrsToERMutationEventsSourceMap includeCreate），
+                //  再叠加 _self 会让同一个 create 事件触发同一计算两次（昂贵计算/async 计算实打实双跑）。
                 if (computation.dataContext.type === 'property' && Object.values(computation.dataDeps).some(dataDep => dataDep.type === 'global')) {
-                    const selfDataDep: RecordsDataDep = {
-                        type: 'records',
-                        source: computation.dataContext.host,
+                    const hostName = computation.dataContext.host.name
+                    const alreadyListensHostCreate = computationSources.some(sources =>
+                        sources.some(source => source.type === 'create' && source.recordName === hostName)
+                    )
+                    if (!alreadyListensHostCreate) {
+                        const selfDataDep: RecordsDataDep = {
+                            type: 'records',
+                            source: computation.dataContext.host,
+                        }
+                        computationSources[PHASE_NORMAL].push(...this.convertDataDepToERMutationEventsSourceMap('_self', selfDataDep, computation, 'create'))
                     }
-                    sortedERMutationEventSources[PHASE_NORMAL].push(...this.convertDataDepToERMutationEventsSourceMap('_self', selfDataDep, computation, 'create'))
-                    // ERMutationEventSources.push(...this.convertDataDepToERMutationEventsSourceMap('_self', selfDataDep, computation, 'create'))
                 }
+
+                computationSources.forEach((sources, phase) => {
+                    sortedERMutationEventSources[phase].push(...sources)
+                })
             } else {
                 // const recordDataDep: RecordsDataDep = {
                 //     type: 'records',

--- a/src/runtime/computations/Average.ts
+++ b/src/runtime/computations/Average.ts
@@ -307,7 +307,8 @@ export class PropertyAverageHandle implements DataBasedComputation {
 
         const sum = await this.state.sum.increment(mutationEvent.record, sumDelta);
         const count = await this.state.count.increment(mutationEvent.record, countDelta);
-        
+        // 与 PropertyCount 的负值守卫对齐：count 为负说明事件序与绑定状态已不一致，静默返回比例是错误数据。
+        if (count < 0) throw new Error(`PropertyAverage count became negative for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
         return count > 0 ? sum / count : 0;
     }
 }

--- a/src/runtime/computations/StateMachine.ts
+++ b/src/runtime/computations/StateMachine.ts
@@ -1,4 +1,4 @@
-import { StateMachine, StateMachineInstance, StateNode, StateNodeInstance } from "@core";
+import { BoolExp, StateMachine, StateMachineInstance, StateNode, StateNodeInstance } from "@core";
 import { Controller } from "../Controller.js";
 import { EntityIdRef, RecordMutationEvent } from '../System.js';
 import { DataContext, PropertyDataContext } from "./Computation.js";
@@ -74,6 +74,56 @@ type SourceTargetPair = [EntityIdRef, EntityIdRef][]
 type ComputeRelationTargetResult = SourceTargetPair | {source: EntityIdRef[] | EntityIdRef, target: EntityIdRef[]|EntityIdRef} | undefined
 type EntityTargetResult = EntityIdRef|EntityIdRef[]|undefined
 type ComputeSourceResult = ComputeRelationTargetResult| EntityTargetResult
+
+/**
+ * 归一化 computeTarget 的返回值为 `{id}[]`。
+ * 支持的形态：`{id}`、`{id}[]`、`undefined/null`（skip）；
+ * 宿主为 relation 时额外支持按端点定位：`{source, target}`（source/target 为 `{id}` 或 `{id}[]`，取笛卡尔积）
+ * 与 `[[source, target], ...]` 数组对形式——这两种形态会查询 relation 记录并解析为 `{id}[]`。
+ * 其他无法识别的形态一律 fail-fast：静默 skip 会让转移无声失效，极难排查。
+ */
+async function normalizeComputeTargetResult(
+    controller: Controller,
+    result: ComputeSourceResult,
+    dataContext: PropertyDataContext,
+    describeTransfer: () => string
+): Promise<EntityIdRef[]> {
+    if (result === undefined || result === null) return []
+    const items = Array.isArray(result) ? result : [result]
+    const hostIsRelation = controller.relations.some(r => r.name === dataContext.host.name)
+    const normalized: EntityIdRef[] = []
+    for (const item of items) {
+        if (item === undefined || item === null) continue
+        if (Array.isArray(item) || (typeof item === 'object' && 'source' in item && 'target' in item && !('id' in item))) {
+            // 端点形态：[source, target] 数组对，或 {source, target} 对象
+            if (!hostIsRelation) {
+                throw new ComputationProtocolError(
+                    `StateMachine computation of property "${dataContext.host.name}.${dataContext.id.name}" ${describeTransfer()}: computeTarget returned a {source, target} endpoint form, but the host is not a relation. Return {id} (or an array of {id}) identifying the ${dataContext.host.name} record(s) to transition.`,
+                    { handleName: 'StateMachine', computationPhase: 'compute-dirty-records' }
+                )
+            }
+            const sources = Array.isArray(item) ? [item[0]].flat() : [item.source].flat()
+            const targets = Array.isArray(item) ? [item[1]].flat() : [item.target].flat()
+            for (const source of sources) {
+                for (const target of targets) {
+                    if (!source?.id || !target?.id) continue
+                    const match = BoolExp.atom({ key: 'source.id', value: ['=', source.id] })
+                        .and({ key: 'target.id', value: ['=', target.id] })
+                    const relationRecords = await controller.system.storage.find(dataContext.host.name!, match, undefined, ['id'])
+                    normalized.push(...relationRecords)
+                }
+            }
+        } else if (typeof item === 'object' && (item as EntityIdRef).id !== undefined) {
+            normalized.push(item as EntityIdRef)
+        } else {
+            throw new ComputationProtocolError(
+                `StateMachine computation of property "${dataContext.host.name}.${dataContext.id.name}" ${describeTransfer()}: computeTarget returned an unrecognized value ${JSON.stringify(item)}. Supported forms: {id}, {id}[], undefined${hostIsRelation ? ', {source, target}, [[source, target], ...]' : ''}.`,
+                { handleName: 'StateMachine', computationPhase: 'compute-dirty-records' }
+            )
+        }
+    }
+    return normalized
+}
 
 export class GlobalStateMachineHandle implements EventBasedComputation {
     static computationType = StateMachine
@@ -179,10 +229,16 @@ Or if you want to use state name as value, you should not set ${this.dataContext
     async computeDirtyRecords(mutationEvent: RecordMutationEvent) {
         // Now directly use mutationEvent for matching
         const transfers = this.transitionFinder.findTransfers(mutationEvent)
-        // CAUTION 不能返回有 null 的节点，所以加上 filter。
-        const allRecords = (await Promise.all(transfers.map(transfer => {
-            return transfer.computeTarget!.call(this.controller, mutationEvent)
-        }))).flat().filter(Boolean)
+        // CAUTION computeTarget 的返回形态必须归一化为 {id}[]：
+        //  {source, target} / [[source, target]] 端点形态（relation 宿主）需要解析成 relation 记录，
+        //  直接 .flat() 会把整个对象保留下来（record.id === undefined），lock 失败后静默 skip——转移无声失效。
+        const allRecords = (await Promise.all(transfers.map(async transfer => {
+            const raw = await transfer.computeTarget!.call(this.controller, mutationEvent) as ComputeSourceResult
+            return normalizeComputeTargetResult(
+                this.controller, raw, this.dataContext,
+                () => `(transfer "${transfer.current.name}" -> "${transfer.next.name}", trigger: ${transfer.trigger.recordName} ${transfer.trigger.type})`
+            )
+        }))).flat()
         
         // 按 id 去重，确保每个 record 在同一个事件周期内只被处理一次。
         // 这是为了防止当多个 transfers 有相同的 trigger 但不同的 current state 时，

--- a/tests/builtins/serialization-r4.spec.ts
+++ b/tests/builtins/serialization-r4.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for the 2026-07-09 r4 review serialization fixes (F-2 / I-7).
+ *
+ * - Activity/Transfer/ActivityGroup are registered Klasses and survive the
+ *   graph-level round trip (createInstances resolves `uuid::` references).
+ * - Interaction.stringify goes through the unified stringifyInstance pipeline,
+ *   so nested Klass instances keep their identity and functions survive.
+ * - Standalone parse restores `func::` functions and preserves uuid identity
+ *   (uuid:: references still require the graph pipeline — documented contract).
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import { clearAllInstances, createInstances, KlassByName, BoolExp, BoolAtomData, BoolExpressionData } from '@core';
+import { Interaction, InteractionInstance } from '../../src/builtins/interaction/Interaction.js';
+import { Activity, ActivityGroup, Transfer, ActivityInstance, TransferInstance } from '../../src/builtins/interaction/Activity.js';
+import { Action, ActionInstance } from '../../src/builtins/interaction/Action.js';
+import { Payload } from '../../src/builtins/interaction/Payload.js';
+import { PayloadItem } from '../../src/builtins/interaction/PayloadItem.js';
+import { Condition, ConditionInstance } from '../../src/builtins/interaction/Condition.js';
+import { Conditions, ConditionsInstance } from '../../src/builtins/interaction/Conditions.js';
+import '../../src/builtins/init.js';
+
+beforeEach(() => {
+    clearAllInstances(
+        Interaction, Activity, ActivityGroup, Transfer, Action,
+        Payload, PayloadItem, Condition, Conditions,
+        BoolAtomData, BoolExpressionData,
+    );
+});
+
+function roundTrip(jsons: string[]) {
+    const serialized = `[${jsons.join(',')}]`;
+    clearAllInstances(
+        Interaction, Activity, ActivityGroup, Transfer, Action,
+        Payload, PayloadItem, Condition, Conditions,
+        BoolAtomData, BoolExpressionData,
+    );
+    return createInstances(JSON.parse(serialized));
+}
+
+describe('r4 serialization fixes', () => {
+    test('Transfer and ActivityGroup are registered Klasses', () => {
+        expect(KlassByName.get('Transfer')).toBe(Transfer);
+        expect(KlassByName.get('ActivityGroup')).toBe(ActivityGroup);
+    });
+
+    test('F-2: activity graph round-trips through the graph pipeline', () => {
+        const actionA = Action.create({ name: 'doA' });
+        const actionB = Action.create({ name: 'doB' });
+        const a = Interaction.create({ name: 'StepA', action: actionA });
+        const b = Interaction.create({ name: 'StepB', action: actionB });
+        const t = Transfer.create({ name: 't1', source: a, target: b });
+        const group = ActivityGroup.create({
+            type: 'every',
+            activities: [Activity.create({ name: 'SubSeq', interactions: [] })],
+        });
+        const act = Activity.create({ name: 'Flow', interactions: [a, b], transfers: [t], groups: [group] });
+
+        const jsons = [
+            Action.stringify(actionA), Action.stringify(actionB),
+            Interaction.stringify(a), Interaction.stringify(b),
+            Transfer.stringify(t), ActivityGroup.stringify(group),
+            Activity.stringify(Activity.instances.find(i => i.name === 'SubSeq')!),
+            Activity.stringify(act),
+        ];
+        const instances = roundTrip(jsons);
+
+        const parsedAct = instances.get(act.uuid) as ActivityInstance;
+        expect(parsedAct).toBeDefined();
+        expect(parsedAct.name).toBe('Flow');
+        // 修复前：interactions/transfers 是 "uuid::..." 字符串
+        expect(parsedAct.interactions).toHaveLength(2);
+        expect(Interaction.is(parsedAct.interactions[0])).toBe(true);
+        expect(parsedAct.interactions.map(i => i.name).sort()).toEqual(['StepA', 'StepB']);
+
+        expect(parsedAct.transfers).toHaveLength(1);
+        const parsedTransfer = parsedAct.transfers[0] as TransferInstance;
+        expect(Transfer.is(parsedTransfer)).toBe(true);
+        expect(Interaction.is(parsedTransfer.source)).toBe(true);
+        expect((parsedTransfer.source as InteractionInstance).name).toBe('StepA');
+        expect((parsedTransfer.target as InteractionInstance).name).toBe('StepB');
+
+        expect(parsedAct.groups).toHaveLength(1);
+        expect(ActivityGroup.is(parsedAct.groups[0])).toBe(true);
+        expect(parsedAct.groups[0].activities![0].name).toBe('SubSeq');
+
+        // action 保持 Klass 身份（修复前 Interaction.stringify 会把它内联成 plain object）
+        const parsedA = instances.get(a.uuid) as InteractionInstance;
+        expect(Action.is(parsedA.action)).toBe(true);
+        expect((parsedA.action as ActionInstance).name).toBe('doA');
+    });
+
+    test('I-7: interaction with function-bearing conditions round-trips', () => {
+        const cond = Condition.create({ name: 'isAllowed', content: async function () { return true } });
+        const conditions = Conditions.create({ content: BoolExp.atom(cond) });
+        const ix = Interaction.create({
+            name: 'GuardedIx',
+            action: Action.create({ name: 'doGuarded' }),
+            conditions,
+        });
+
+        const jsons = [
+            Condition.stringify(cond),
+            // BoolExp.atom(cond) 产生的 BoolAtomData 实例也是图的一部分
+            ...BoolAtomData.instances.map(i => BoolAtomData.stringify(i as InstanceType<typeof BoolAtomData>)),
+            Conditions.stringify(conditions),
+            Action.stringify(Action.instances.find(i => i.name === 'doGuarded')!),
+            Interaction.stringify(ix),
+        ];
+        const instances = roundTrip(jsons);
+
+        const parsedIx = instances.get(ix.uuid) as InteractionInstance;
+        expect(Conditions.is(parsedIx.conditions)).toBe(true);
+        const content = (parsedIx.conditions as ConditionsInstance).content!;
+        expect(BoolAtomData.is(content)).toBe(true);
+        const parsedCond = (content as InstanceType<typeof BoolAtomData>).data as unknown as ConditionInstance;
+        expect(Condition.is(parsedCond)).toBe(true);
+        // 修复前：condition 的 content 函数在 Interaction 手写序列化中静默丢失
+        expect(typeof parsedCond.content).toBe('function');
+    });
+
+    test('standalone parse restores functions and preserves uuid identity', () => {
+        const cond = Condition.create({ name: 'standalone', content: async function () { return false } });
+        const json = Condition.stringify(cond);
+        clearAllInstances(Condition);
+        const parsed = Condition.parse(json);
+        expect(parsed.uuid).toBe(cond.uuid);
+        expect(typeof parsed.content).toBe('function');
+
+        const a = Interaction.create({ name: 'SoloIx', action: Action.create({ name: 'soloAct' }) });
+        const ixJson = Interaction.stringify(a);
+        clearAllInstances(Interaction);
+        const parsedIx = Interaction.parse(ixJson);
+        expect(parsedIx.uuid).toBe(a.uuid);
+        expect(parsedIx.name).toBe('SoloIx');
+        // 标注的契约：uuid:: 引用需要 graph 管线才能解析，standalone parse 保留编码字符串
+        expect(parsedIx.action).toBe(`uuid::${(a.action as ActionInstance).uuid}`);
+    });
+});

--- a/tests/core/action-refactored.spec.ts
+++ b/tests/core/action-refactored.spec.ts
@@ -36,11 +36,13 @@ describe("Action Refactored - compatibility test", () => {
   test("should parse stringified action", () => {
     const original = Action.create({ name: "parseTest" });
     const stringified = Action.stringify(original);
+    // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+    Action.instances.length = 0;
     const parsed = Action.parse(stringified);
 
     expect(parsed.name).toBe("parseTest");
     expect(parsed._type).toBe("Action");
-    expect(parsed.uuid).toBeDefined();
+    expect(parsed.uuid).toBe(original.uuid);
   });
 
   test("should clone action", () => {

--- a/tests/core/bool-attributive-refactored.spec.ts
+++ b/tests/core/bool-attributive-refactored.spec.ts
@@ -123,6 +123,8 @@ describe("Bool and Attributive Classes Refactored", () => {
       });
       
       const stringified = Attributive.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      Attributive.instances.length = 0;
       const parsed = Attributive.parse(stringified);
 
       expect(parsed.name).toBe("TestAttr");

--- a/tests/core/core-domain-refactored.spec.ts
+++ b/tests/core/core-domain-refactored.spec.ts
@@ -227,10 +227,14 @@ describe("Core Domain Classes Refactored", () => {
       });
       
       const stringified = Interaction.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      Interaction.instances.length = 0;
       const parsed = Interaction.parse(stringified);
 
       expect(parsed.name).toBe("UpdateProfile");
-      expect(parsed.action).toBeDefined();
+      expect(parsed.uuid).toBe(original.uuid);
+      // 统一管线：嵌套 Klass 实例编码为 uuid:: 引用，graph 级解析见 createInstancesFromString
+      expect(parsed.action).toBe(`uuid::${action.uuid}`);
     });
   });
 

--- a/tests/core/data-activity-refactored.spec.ts
+++ b/tests/core/data-activity-refactored.spec.ts
@@ -56,6 +56,8 @@ describe("Data and Activity Classes Refactored", () => {
         });
         
         const stringified = DataPolicy.stringify(original);
+        // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+        DataPolicy.instances.length = 0;
         const parsed = DataPolicy.parse(stringified);
 
         expect(parsed.match).toEqual(original.match);
@@ -207,6 +209,8 @@ describe("Data and Activity Classes Refactored", () => {
         });
         
         const stringified = Transfer.stringify(original);
+        // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+        Transfer.instances.length = 0;
         const parsed = Transfer.parse(stringified);
 
         expect(parsed.name).toBe("testFlow");

--- a/tests/core/simple-refactored.spec.ts
+++ b/tests/core/simple-refactored.spec.ts
@@ -25,6 +25,8 @@ describe("Simple Objects Refactored - compatibility test", () => {
     test("should stringify and parse gateway", () => {
       const original = Gateway.create({ name: "TestGateway" });
       const stringified = Gateway.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      Gateway.instances.length = 0;
       const parsed = Gateway.parse(stringified);
 
       expect(parsed.name).toBe("TestGateway");
@@ -53,6 +55,8 @@ describe("Simple Objects Refactored - compatibility test", () => {
     test("should stringify and parse event", () => {
       const original = Event.create({ name: "TestEvent" });
       const stringified = Event.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      Event.instances.length = 0;
       const parsed = Event.parse(stringified);
 
       expect(parsed.name).toBe("TestEvent");

--- a/tests/core/support-classes-refactored.spec.ts
+++ b/tests/core/support-classes-refactored.spec.ts
@@ -45,6 +45,8 @@ describe("Support Classes Refactored", () => {
       });
       
       const stringified = Condition.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      Condition.instances.length = 0;
       const parsed = Condition.parse(stringified);
 
       expect(parsed.name).toBe("AlwaysTrue");
@@ -150,6 +152,8 @@ describe("Support Classes Refactored", () => {
       });
       
       const stringified = PayloadItem.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      PayloadItem.instances.length = 0;
       const parsed = PayloadItem.parse(stringified);
 
       expect(parsed.name).toBe("email");
@@ -203,6 +207,8 @@ describe("Support Classes Refactored", () => {
       });
       
       const stringified = Payload.stringify(original);
+      // Clear instances before parsing: parse preserves the uuid (identity round-trip)
+      Payload.instances.length = 0;
       const parsed = Payload.parse(stringified);
 
       expect(parsed.items).toHaveLength(1);

--- a/tests/runtime/review-fixes-2026-07-09-r4.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r4.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression tests for the 2026-07-09 r4 deep review fixes.
+ * See agentspace/output/deep-review-2026-07-09-r4.md
+ *
+ * - F-1: group-head activity no longer stack-overflows; full flow works
+ * - R-1: non-existent activityId yields a clear business error, not a TypeError
+ * - R-2: computeTarget {source, target} endpoint form works on relation-hosted
+ *        properties and fails fast on entity-hosted properties
+ * - R-3: property computation with global + property dataDeps runs exactly once per host create
+ */
+import { describe, expect, test } from "vitest";
+import {
+    Controller, MonoSystem, Entity, Property, Relation, Dictionary,
+    StateMachine, StateNode, StateTransfer, Interaction, InteractionEventEntity,
+    Action, Payload, PayloadItem, Custom, Activity, ActivityGroup, Transfer, ActivityManager,
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+describe('review fixes 2026-07-09 r4', () => {
+
+    // ============ F-1: activity graph with a group as its head ============
+    test('F-1: activity with group head sets up and completes both branches', async () => {
+        const a = Interaction.create({ name: 'r4fBranchA', action: Action.create({ name: 'r4fBranchA' }) })
+        const b = Interaction.create({ name: 'r4fBranchB', action: Action.create({ name: 'r4fBranchB' }) })
+        const group = ActivityGroup.create({
+            type: 'every', activities: [
+                Activity.create({ name: 'r4fSeqA', interactions: [a] }),
+                Activity.create({ name: 'r4fSeqB', interactions: [b] }),
+            ]
+        })
+        const act = Activity.create({ name: 'R4FParallel', interactions: [], groups: [group], transfers: [] })
+        const system = new MonoSystem(new PGLiteDB())
+        const User = Entity.create({ name: 'R4fUser', properties: [Property.create({ name: 'name', type: 'string' })] })
+
+        // 修复前：new ActivityManager 在 isActivityHead 中无限递归（RangeError: Maximum call stack size exceeded）
+        const activityManager = new ActivityManager([act])
+        const out = activityManager.getOutput()
+        const controller = new Controller({ system, entities: [User, ...out.entities], relations: out.relations, eventSources: out.eventSources })
+        await controller.setup(true)
+        const user = await system.storage.create('R4fUser', { name: 'u' })
+
+        const esA = controller.findEventSourceByName('R4FParallel:r4fBranchA')!
+        const esB = controller.findEventSourceByName('R4FParallel:r4fBranchB')!
+        expect(esA).toBeDefined()
+        expect(esB).toBeDefined()
+
+        // 分支 A 作为 head、无 activityId：隐式创建 activity
+        const r1 = await controller.dispatch(esA, { user, payload: {} } as any)
+        expect(r1.error).toBeUndefined()
+        const activityId = (r1 as any).context?.activityId as string
+        expect(activityId).toBeDefined()
+
+        // 分支 B 带同一个 activityId：在同一 activity 内完成，不再新建
+        const r2 = await controller.dispatch(esB, { user, payload: {}, activityId } as any)
+        expect(r2.error).toBeUndefined()
+
+        const activities = await system.storage.find('_Activity_', undefined, undefined, ['*'])
+        expect(activities).toHaveLength(1)
+
+        // every group：两个分支都完成后整个 activity 完成（state.current 为空）
+        const activityCall = activityManager.getActivityCallByName('R4FParallel')!
+        const state = await activityCall.getState(controller, activityId)
+        expect(state.current).toBeUndefined()
+    })
+
+    // ============ R-1: non-existent activityId ============
+    test('R-1: dispatching with a non-existent activityId returns a clear error', async () => {
+        const i1 = Interaction.create({ name: 'r4gStep1', action: Action.create({ name: 'r4gStep1' }) })
+        const i2 = Interaction.create({ name: 'r4gStep2', action: Action.create({ name: 'r4gStep2' }) })
+        const act = Activity.create({
+            name: 'R4GFlow',
+            interactions: [i1, i2],
+            transfers: [Transfer.create({ name: 't1', source: i1, target: i2 })]
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        const User = Entity.create({ name: 'R4gUser2', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const activityManager = new ActivityManager([act])
+        const out = activityManager.getOutput()
+        const controller = new Controller({ system, entities: [User, ...out.entities], relations: out.relations, eventSources: out.eventSources })
+        await controller.setup(true)
+        const user = await system.storage.create('R4gUser2', { name: 'u' })
+
+        const es = controller.findEventSourceByName('R4GFlow:r4gStep2')!
+        // 合法 uuid 格式但不存在的 activityId：修复前抛裸 TypeError（reading 'current'）
+        const res = await controller.dispatch(es, { user, payload: {}, activityId: '01890a5d-ac96-774b-bcce-b302099a8057' } as any)
+        expect(res.error).toBeDefined()
+        expect(String((res.error as any).message ?? res.error)).toContain('not found')
+    })
+
+    // ============ R-2: computeTarget endpoint forms ============
+    test('R-2: computeTarget {source, target} transitions a relation-hosted property', async () => {
+        const User = Entity.create({ name: 'R4hUser', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Item = Entity.create({ name: 'R4hItem', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const Own = Relation.create({ source: User, sourceProperty: 'items', target: Item, targetProperty: 'owner', type: '1:n', properties: [] })
+        const markIx = Interaction.create({
+            name: 'r4hMark',
+            action: Action.create({ name: 'r4hMark' }),
+            payload: Payload.create({
+                items: [
+                    PayloadItem.create({ name: 'userId', type: 'string' }),
+                    PayloadItem.create({ name: 'itemId', type: 'string' }),
+                ]
+            })
+        })
+
+        const normal = StateNode.create({ name: 'normal' })
+        const marked = StateNode.create({ name: 'marked' })
+        Own.properties!.push(Property.create({
+            name: 'flag', type: 'string',
+            computation: StateMachine.create({
+                states: [normal, marked],
+                initialState: normal,
+                transfers: [StateTransfer.create({
+                    current: normal, next: marked,
+                    trigger: { recordName: InteractionEventEntity.name, type: 'create', record: { interactionName: 'r4hMark' } },
+                    // 端点形态：由 {source, target} 定位要转移的 relation 记录
+                    computeTarget: (event: any) => ({
+                        source: { id: event.record.payload.userId },
+                        target: { id: event.record.payload.itemId },
+                    })
+                })]
+            })
+        }))
+
+        const system = new MonoSystem(new PGLiteDB())
+        const controller = new Controller({ system, entities: [User, Item], relations: [Own], eventSources: [markIx] })
+        await controller.setup(true)
+        const u = await system.storage.create('R4hUser', { name: 'u' })
+        const i1 = await system.storage.create('R4hItem', { title: 'i1', owner: { id: u.id } })
+        const i2 = await system.storage.create('R4hItem', { title: 'i2', owner: { id: u.id } })
+
+        const res = await controller.dispatch(markIx, { user: { id: u.id }, payload: { userId: u.id, itemId: i1.id } } as any)
+        expect(res.error).toBeUndefined()
+
+        const relations = await system.storage.find(Own.name!, undefined, undefined, ['*', ['source', { attributeQuery: ['id'] }], ['target', { attributeQuery: ['id'] }]])
+        const rel1 = relations.find((r: any) => r.target.id === i1.id)!
+        const rel2 = relations.find((r: any) => r.target.id === i2.id)!
+        expect(rel1.flag).toBe('marked')   // 修复前：{source,target} 对象整体保留、lock 失败、静默 skip
+        expect(rel2.flag).toBe('normal')
+    })
+
+    test('R-2: computeTarget {source, target} on an entity-hosted property fails fast', async () => {
+        const User = Entity.create({ name: 'R4iUser', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Follow = Relation.create({ source: User, sourceProperty: 'following', target: User, targetProperty: 'followers', type: 'n:n', properties: [] })
+        const pending = StateNode.create({ name: 'pending' })
+        const linked = StateNode.create({ name: 'linked' })
+        User.properties.push(Property.create({
+            name: 'status', type: 'string',
+            computation: StateMachine.create({
+                states: [pending, linked],
+                initialState: pending,
+                transfers: [StateTransfer.create({
+                    current: pending, next: linked,
+                    trigger: { recordName: Follow.name!, type: 'create' },
+                    computeTarget: (event: any) => ({ source: { id: event.record.source.id }, target: { id: event.record.target.id } })
+                })]
+            })
+        }))
+        const system = new MonoSystem(new PGLiteDB())
+        const controller = new Controller({ system, entities: [User], relations: [Follow], eventSources: [] })
+        await controller.setup(true)
+        const u1 = await system.storage.create('R4iUser', { name: 'a' })
+        const u2 = await system.storage.create('R4iUser', { name: 'b' })
+        // 宿主是 entity，端点形态无意义：必须 fail-fast 而不是静默 skip
+        await expect(
+            system.storage.create(Follow.name!, { source: { id: u1.id }, target: { id: u2.id } })
+        ).rejects.toThrowError(/computeTarget returned a \{source, target\} endpoint form/)
+    })
+
+    // ============ R-3: no double trigger with global + property dataDeps ============
+    test('R-3: host create triggers the computation exactly once', async () => {
+        const threshold = Dictionary.create({ name: 'r4jThreshold', type: 'number', collection: false, defaultValue: () => 5 })
+        let computeCalls = 0
+        const Item = Entity.create({
+            name: 'R4jItem', properties: [
+                Property.create({ name: 'value', type: 'number' }),
+            ]
+        })
+        Item.properties.push(Property.create({
+            name: 'aboveThreshold', type: 'boolean',
+            computation: Custom.create({
+                name: 'r4jAbove',
+                dataDeps: {
+                    _current: { type: 'property', attributeQuery: ['value'] },
+                    threshold: { type: 'global', source: threshold },
+                },
+                compute: async function (this: any, deps: any) {
+                    computeCalls++
+                    return (deps._current?.value ?? 0) > (deps.threshold ?? 0)
+                },
+                getInitialValue: () => false,
+            })
+        }))
+        const system = new MonoSystem(new PGLiteDB())
+        const controller = new Controller({ system, entities: [Item], relations: [], eventSources: [], dict: [threshold] })
+        await controller.setup(true)
+        computeCalls = 0
+        await system.storage.create('R4jItem', { value: 10 })
+        expect(computeCalls).toBe(1)   // 修复前：_self 与 property dataDep 的宿主 create 监听叠加 → 2
+
+        const items = await system.storage.find('R4jItem', undefined, undefined, ['*'])
+        expect(items[0].aboveThreshold).toBe(true)
+
+        // global dict 更新仍然触发重算（去重不能误伤 global 监听）
+        computeCalls = 0
+        await system.storage.dict.set('r4jThreshold', 100)
+        expect(computeCalls).toBe(1)
+        const items2 = await system.storage.find('R4jItem', undefined, undefined, ['*'])
+        expect(items2[0].aboveThreshold).toBe(false)
+    })
+})

--- a/vite.prod.config.ts
+++ b/vite.prod.config.ts
@@ -11,9 +11,13 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      // drivers 是独立子入口（interaqt/drivers）：驱动依赖（better-sqlite3/pg/mysql2/pglite）
+      // 不应成为主入口的解析负担，消费者按需引入。
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        drivers: resolve(__dirname, 'src/drivers/index.ts')
+      },
       name: 'interaqt',
-      fileName: 'index',
       formats: ['es']
     },
     target: 'esnext',
@@ -21,6 +25,9 @@ export default defineConfig({
     rollupOptions: {
       // 确保外部依赖不被打包
       external: [
+        // drivers 子入口通过包自引用导入主入口（共享 asyncInteractionContext 等单例），
+        // 必须保持 external，否则会打进第二份运行时副本。
+        'interaqt',
         // Node.js 内置模块
         'async_hooks',
         'fs',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

第四轮全代码库深度 review（基线 `main` @ `b9ee8404`）+ **同分支修复全部已复现的致命与重要问题**。报告（含维护说明与修复映射）见 `agentspace/output/deep-review-2026-07-09-r4.md`。

## 致命问题修复（均有运行复现 → 回归测试）

| ID | 问题 | 修复 |
|----|------|------|
| F-1 | Activity 以 ActivityGroup 为起点：`isActivityHead` 误读 `this.graph.head` 而非递归参数 → 构造期无限递归栈溢出 | 函数体改用参数 `head`；group 起点语义与线性 activity 一致（head 无 activityId = 隐式创建），回归测试覆盖 every group 双分支完成全流程 |
| F-2 | Activity/Interaction 序列化 round-trip 断裂（`uuid::` 引用不还原、嵌套 Klass 内联丢函数、Transfer/ActivityGroup 未注册） | builtins 序列化统一接入 core 管线：`Interaction.stringify` 走 `stringifyInstance`；全部 builtins `parse` 对齐 `decodeFunctionValues` + uuid 身份保持；注册 `Transfer`/`ActivityGroup`/`Attributives`。graph 级 round-trip 可完整还原含 conditions（函数）的 Activity 图 |
| F-3 | 发布包无法获得任何数据库驱动（`dist/drivers/` 只有 `.d.ts`，exports 无子路径）——README 已承诺的 `interaqt/drivers` 路径实际不存在 | vite 多 entry 构建 `dist/drivers.js` + `package.json` 增加 `./drivers` 导出；驱动改从主入口导入共享单例（`asyncInteractionContext` 等）；已用构建产物跑通最小 controller 冒烟 |

## 重要问题修复

- **R-1**：不存在的 `activityId` 现在抛业务级 `activity ... not found`（原为裸 `TypeError: reading 'current'`）
- **R-2**：`computeTarget` 返回值归一化为 `{id}[]`——`{source,target}`/`[[s,t]]` 端点形态在 relation 宿主上解析为 relation 记录，entity 宿主上 fail-fast（原为静默 skip，转移无声失效）
- **R-3**：source-map 对 `_self` 宿主 create 监听与 dataDep 已注册监听去重——global+property dataDeps 的计算不再双跑（computeCalls 2→1）
- **R-6.1**：PropertyAverage 负 count 守卫（与 PropertyCount 对齐）

## 明确遗留（建议独立 PR）

R-4（`program` group 完成语义决策）、R-5（Global StateMachine `initialState.computeValue` 契约文档化）、R-7（dictionary defaultValue 进 modelHash）、报告第四节改进项（NULL 语义文档化、`!=` 三值逻辑、六 handle 模板抽取等）。

## 验证

- ✅ `npm run check`（无 TS 错误）
- ✅ `npm test`：**1725 passed / 26 skipped**（基线 1716；新增 9 个回归用例：`tests/runtime/review-fixes-2026-07-09-r4.spec.ts` + `tests/builtins/serialization-r4.spec.ts`；更新 10 个既有序列化用例以匹配「parse 保持 uuid 身份」的统一契约）
- ✅ `npm run build` + 发布包形态冒烟：`import('interaqt/drivers')` 四驱动齐全，PGLiteDB 端到端建表/写入成功
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa53f9f0-4867-40fc-a6e3-f6e75c999580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa53f9f0-4867-40fc-a6e3-f6e75c999580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

