### PR TITLE
Fifth-round review + combinatorial matrix + fixes for all 7 fatal bugs (35 matrix cells → 0)

### DIFF
--- a/agentspace/output/deep-review-2026-07-09-r5.md
+++ b/agentspace/output/deep-review-2026-07-09-r5.md
@@ -1,0 +1,288 @@
+# 全代码库深度 Review 报告（2026-07-09 第五轮）
+
+- 日期：2026-07-09
+- 基线：`main` @ `1f848596`（PR #22 合入之后，前四轮 review 修复全部落地）
+- 范围：`src/core`、`src/runtime`（Controller/Scheduler/ComputationSourceMap/computations/transaction）、`src/storage`（mutation executors / SQL 构造 / filtered entity）、`src/builtins`（dispatch 守卫链 / data API）、`src/drivers`、`agent/agentspace/knowledge/`（知识库与代码事实的一致性）
+- 方法：五个方向并行深度探查（dispatch 守卫链与 data API / runtime 编排与事务 / SQL 构造与查询 / 计算引擎增量语义 / storage 写路径与 filtered entity）→ 人工精读交叉验证 → **对每个致命候选编写最小复现测试并实际运行**（PGLiteDB / SQLiteDB）。只有「已运行复现确认」的问题列为致命；仅凭精读判定的问题单独分级并标注置信度。两个子报告候选经复现被**证伪**（见第五节），未计入。
+- 与既有报告的关系：前四轮（r1–r4）的致命与重要项已全部修复并有回归测试；其「明确遗留」项（r4 的 R-4/R-5/R-6.2/R-6.3/R-7、六聚合 handle 模板抽取、I-1~I-18，r3 的 R-4/R-5/R-6/R-8，r2 的驱动类型映射、级联深度、async task 清理、合表事件完整性）仍然有效，本报告不重复展开。本报告发现均为**新增**。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1725 passed / 26 skipped，全部通过。
+
+---
+
+## 一、结论摘要
+
+前四轮把 storage 读写路径、增量计算边界、Activity/序列化、打包链路修到明显收敛。本轮纵深转向**声明组合的正交盲区**：filtered entity × 聚合计算的增量触发、data API 的字段投影策略、update 路径 × 关系属性（`&`）、`computed` 属性 × 关系数据。四处各查出一个已复现的致命问题。
+
+延续前几轮的规律：本轮致命问题依然全部落在「**测试矩阵从未走过的合法声明组合**」——filtered 聚合只测过 membership 驱动的 Count（成员字段更新零覆盖）、`dataPolicy.attributeQuery` 的所有测试都同时传了 caller 侧 attributeQuery、`&` 关系属性只测过 create、`computed` 只测过同行字段输入。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现） | 4 | filtered 实体上的聚合对成员字段更新永久失明、dataPolicy.attributeQuery 零生效（字段投影可被调用方绕过）、update 丢弃 `&` 关系属性、computed 属性引用关系数据在 update 时静默翻转 |
+| 重要（已复现） | 3 | 大 IN 列表超占位符上限崩溃、n:n update 重复 ref 内部断言崩溃、`contains` 用于非数组 JSON 裸 DB 错误 |
+| 重要（精读，高置信度） | 5 | Scheduler.setup 失败留下零监听系统、setup(true) 半途失败进死角、dispatch retry 共享嵌套 payload、同名 side effect 结果覆盖、知识库 `getValue` API 不存在（代码生成管线级污染） |
+| 显著改进 | 若干 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认）
+
+### F-1 建立在 filtered entity/relation 上的聚合计算：**成员字段更新永不触发**，聚合值永久陈旧
+
+- 位置：
+  - `src/runtime/ComputationSourceMap.ts` L322–331——records dataDep 的 update 监听注册在 `dataDep.source.name`（即 **filtered 视图名**，如 `ActiveUser`）；
+  - 对照 storage 侧：update 事件的 `recordName` 是**base 实体名**（`CreationExecutor.ts` L199–206，`recordName: newEntityData.recordName`）；filtered 名下只发 membership 的 create/delete（`FilteredEntityManager.settleMembershipChecks`），成员**留在集合内**的字段变化不产生任何 filtered 名下的事件。
+  - `rg 'baseEntity|filtered' src/runtime/ComputationSourceMap.ts src/runtime/Scheduler.ts` **零命中**——runtime 计算层完全不知道 filtered 与 base 的映射关系。
+- 复现（REPRO-A / REPRO-L，实测输出）：
+
+```
+// Summation({record: ActiveUser, attributeQuery: ['salary']}) 挂 dict
+create User{isActive:true, salary:100} → sum = 100 ✓（membership create 驱动）
+update User.salary → 200（仍是成员，无 membership 事件）
+  → sum = 100 ❌（应为 200，无任何报错）
+
+// Count({record: ActiveTask, attributeQuery:['score'], callback: r => r.score > 10})
+create Task{isActive:true, score:5} → count = 0 ✓
+update Task.score → 20 → count = 0 ❌（应为 1）
+```
+
+- 影响：文档明确承诺该模式（`agent/agentspace/knowledge/usage/09-filtered-entities.md` L12「Supports computations: Can perform reactive computations on filtered data」，L374 直接给出 filtered + WeightedSummation 示例）。凡是「视图 + 按字段聚合」的建模（活跃用户薪资总额、已支付订单金额、高分任务计数……）在成员字段更新后全部静默陈旧——**查询侧正确、聚合侧永久错误、无告警**，与 r3 F-1 同为最危险的失效形态。纯 membership 驱动的 Count（无 attributeQuery/callback 读字段）不受影响，这正是现有测试矩阵（`filteredMembershipMatrix.spec.ts` 只断言 Count）没发现它的原因。
+- 修复方向：source-map 构建时对 `dataDep.source` 携带 `baseEntity`/`baseRelation` 的情况，把 update 监听注册到**resolved base 链**上（穿透嵌套 filtered），并在事件到达时用 filtered 谓词做成员资格预检（可复用 storage 侧 `FilteredEntityManager.analyzeDependencies` 已有的依赖分析）；增量分支中 oldRecord/newRecord 的成员资格组合（留在集合内 / 进入 / 退出）要与 membership 事件去重，避免双计。测试矩阵需补：filtered source × {Summation, Average, WeightedSummation, Count+callback} × 成员字段 update。
+
+### F-2 `dataPolicy.attributeQuery` 从未生效：Get 交互的字段投影完全由调用方决定
+
+- 位置：`src/builtins/interaction/Interaction.ts` L552–553：
+
+```ts
+const modifier = { ...(eventArgs.query?.modifier || {}), ...(fixedModifier || {}) };  // policy 覆盖 caller ✓
+const attributeQuery = eventArgs.query?.attributeQuery || [];                        // ← policy.attributeQuery 无人消费 ❌
+```
+
+  `retrieveData` 只读取了 `dataPolicy.match` 与 `dataPolicy.modifier`；`rg 'dataPolicy' src/` 确认 `attributeQuery` 在整个 src 中零消费。`DataPolicy.public` 却把它声明为一等字段（`Data.ts` L48–52）。
+- 复现（REPRO-B，实测输出）：
+
+```ts
+const GetSecrets = Interaction.create({ action: GetAction, data: Secret,
+  dataPolicy: DataPolicy.create({ attributeQuery: ['id', 'title'] }) })  // 作者意图：固定投影
+await controller.dispatch(GetSecrets, { user, query: { attributeQuery: ['id', 'title', 'ssn'] } })
+// → [{"id":"…","title":"t","ssn":"123-45-6789"}] ❌  ssn 全量返回，policy 零效果
+```
+
+- 影响：这是**权限/数据暴露级**问题——交互作者以为 `dataPolicy.attributeQuery` 限定了可见列（`queryDataInteraction.spec.ts` L857–861 的测试也这么写），实际上任何调用方都可以请求任意字段（含 `['*']`）。match/modifier 都是「policy 覆盖/合并 caller」，唯独 attributeQuery 是「caller 全权」，同一 API 内三个字段两种语义。现有测试全部在 query 里同时传了合法 attributeQuery，所以从未暴露。
+- 修复方向：policy 存在时以 policy 为上限（取交集，或直接 policy-wins，与 modifier 的合并方向一致）；并补「caller 无法越权拓宽字段」的负向测试。半可用的策略字段比没有更危险——建议按显式控制原则，policy 声明了就必须生效。
+
+### F-3 update 替换关系时 `&` 关系属性被静默丢弃
+
+- 位置：`src/storage/erstorage/UpdateExecutor.ts` L219——`handleUpdateReliance` 重建关系时调用 `addLinkFromRecord(..., /* attributes */ undefined, events)`，link 数据参数**恒为 undefined**；对照 create 路径（`CreationExecutor.ts` L337–343）正确使用 `record.linkRecordData?.getData()`。
+- 复现（REPRO-E，实测输出）：
+
+```ts
+await storage.create('User', { teams: [{ id: t1.id, '&': { role: 'member' } }] })
+// link: [{"role":"member","team":"t1"}] ✓
+await storage.update('User', matchU, { teams: [{ id: t2.id, '&': { role: 'lead' } }] })
+// link: [{"team":"t2"}] ❌  role 丢失（应为 'lead'），无报错
+```
+
+- 影响：`&` 是文档化的一等语法（`update relation with & payload` 是合法建模），create 可用、update 静默丢数据——又一处「半可用 API」。关系属性上挂了 filtered relation 谓词或聚合计算时，错误会进一步向下游传导。现有 `relationAttributes.spec.ts` 只覆盖 create 与 null-delete。
+- 修复方向：`handleUpdateReliance` 把 `newRelatedEntityData.linkRecordData?.getData()` 传入 `addLinkFromRecord`；同族检查 `updateSameRowData` 路径上 merged link 的 `&` 数据（`NewRecordData.getSameRowFieldAndValue` L242 起对 mergedLinkTargetRecordIdRefs 有处理，isolated/differentTableMerged 没有）。补 update-with-`&` 的回归测试（含事件断言）。
+
+### F-4 `computed` 属性引用关系数据：create 时"可用"，任意后续 update **静默翻转**
+
+- 位置：
+  - `src/storage/erstorage/UpdateExecutor.ts` L46–52——update 前置查询按 `newEntityData.getData()` 的键裁剪，**isolated/差表关系永远不在** `fullAttributeQuery`（`AttributeQuery.getAttributeQueryDataForRecord` 不含 differentTableRecordAttributes）；
+  - `src/storage/erstorage/NewRecordData.ts` L216–230——update 时**无条件重算全部** computed 列，`newRecord = {...oldRecord, ...rawData}` 中关系路径缺失，`r.team?.type` 求值为 undefined 并落库。
+- 复现（REPRO-D2，实测输出）：
+
+```ts
+// User.inTech = computed(r => r.team?.type === 'tech')，User–Team n:1
+await storage.create('User', { name: 'A', team: { type: 'tech' } })   // 嵌套 payload
+// inTech = true ✓（create 时 rawData 里恰好有 team.type）
+await storage.update('User', matchU, { name: 'A2' })                  // 与 team 无关的更新
+// inTech = false ❌  静默翻转并持久化
+```
+
+  （用 ref 形式 `team: {id}` 创建时，inTech 从 create 起就是 false——同一声明两种建立方式产生不同值。）
+- 影响：`computed` 的契约（同行字段派生）从未在声明期强制——引用关系数据的写法**创建时表面可用**，诱导用户依赖它，然后在任意一次无关 update 时静默腐蚀数据。若 filtered entity 谓词建立在这样的 computed 列上，还会连带产生错误的 membership 事件（r4 F-1 修复让 computed 列进了 changedFields，此处翻转会触发假的成员退出）。
+- 修复方向（二选一，不能维持现状）：
+  1. **声明期拒绝**（推荐，符合显式控制）：`computed` 函数无法静态分析依赖，但可以在运行 computed 时传入仅含同行 value 字段的 record 代理，访问关系属性即抛出明确错误——把契约变成可执行的；文档同步写明「computed 只能引用同行字段，跨记录派生用 computation」。
+  2. 支持关系输入：update 前置查询不裁剪 computed 所需的关系子图（需要 computed 声明依赖，等于引入新 API）。成本高，不建议。
+
+---
+
+## 三、重要问题
+
+### R-1 用户侧大 `IN` 列表超数据库占位符上限：崩溃（已复现）
+
+- 位置：`src/storage/erstorage/MatchExp.ts` L254–257——`IN (${value[1].map(() => p()).join(',')})`，每元素一个占位符，无分片无上限。框架内部批量路径有 `BATCH_SIZE = 500`（`QueryExecutor.ts` L386–414），用户 matchExpression 不在保护内。
+- 复现（REPRO-G，实测输出）：SQLite 上 `['in', 40000 个值]` → `too many SQL variables`（SQLite 默认上限 999/32766，PG 65535）。
+- 修复方向：MatchExp 编译期对超阈值 IN 自动分片为 OR 链，或在 QueryExecutor 侧拆查询合并结果；至少给出带建议的受控错误。
+
+### R-2 n:n update payload 含重复 ref：内部断言崩溃（已复现）
+
+- 位置：`src/storage/erstorage/CreationExecutor.ts` L416–427 `assert(!existRecord, 'link already exist')`，经 `UpdateExecutor.handleUpdateReliance` L202–219 逐元素 addLink，无去重。
+- 复现（REPRO-H，实测输出）：`update('User', …, { teams: [{id: t1}, {id: t1}] })` → `Error: cannot create User_teams_members_Team for <id> <id>, link already exist`。
+- 影响：update 语义是 replace（先 unlink 再重建），payload 内部重复是调用方数据不洁的常见形态；崩溃点是内部断言，信息与用户写法脱节。修复方向：handleUpdateReliance 对 (attribute, targetId) 去重（幂等），或在入口给出指向 payload 的明确错误。
+
+### R-3 `contains` 用于非数组 JSON 字段：裸数据库错误（已复现）
+
+- 位置：`src/drivers/PGLite.ts` L206 / `PostgreSQL.ts` L349——`json_array_elements_text` 假定列值是 JSON 数组。
+- 复现（REPRO-I，实测输出）：`type: 'object'` 属性 + `['contains', 'key']` → `cannot call json_array_elements_text on a non-array`。
+- 修复方向：对非 collection 列使用 `contains` 时给出声明期/编译期错误，或驱动侧兼容对象语义并文档化跨驱动差异（MySQL `JSON_CONTAINS` / SQLite `json_each` 语义本就不完全一致，见 4.1 I-5）。
+
+### R-4 `Scheduler.setup` 失败序：先注销后注册，中途抛出留下**零监听**的静默系统（精读，高置信度）
+
+- 位置：`src/runtime/Scheduler.ts` L1238–1243——`removeRegisteredMutationListeners()` 最先执行；随后 `addMutationComputationListeners()` 内的 `sourceMapManager.initialize()` 有多条抛出路径（如 `ComputationProtocolError`）。抛出后旧监听已全部移除、新监听未注册完成，错误向上抛但**没有恢复逻辑**。调用方（尤其 migrate 后的 resume 场景）若捕获错误继续使用 controller，事实写入照常、所有增量计算冻结，无任何后续报错——与 r3 R-6（migration succeeded 先于 scheduler.setup）同族的「静默失效框架」，但这里连 migration log 的线索都没有。
+- 修复方向：注册-后-切换（先构建新 listener 集合，全部成功后原子替换），或失败时显式进入「不可用」状态让后续 dispatch fail-fast。
+
+### R-5 `setup(true)` 半途失败：有表无 manifest，后续 `setup(false)` 死于 `MigrationBaselineError`（精读，高置信度）
+
+- 位置：`src/runtime/Controller.ts` L269–274——`system.setup`（建表）成功后才执行 `scheduler.setup(install)`，manifest 在**最后**写入。scheduler.setup 抛出（坏的 dict 初始值 / R-4 的任何 initialize 错误）时：表已建、`hasExistingData()` 为真、无 manifest → 下次 `setup(false)` 命中 L262–264 的 baseline 检查，只能走 `createMigrationBaseline()` 恢复，错误信息不指向真实原因。
+- 修复方向：install 失败时回滚 schema（或至少在错误里附带「首次安装未完成，可 forceDrop 重装」的恢复指引）；或把 manifest 写入提前到 system.setup 之后、scheduler.setup 之前（manifest 描述的是 schema，与 scheduler 无关）。
+
+### R-6 dispatch retry 的 `cloneDispatchArgs` 是浅拷贝：嵌套 payload 跨尝试共享（精读，高置信度）
+
+- 位置：`src/runtime/Controller.ts` L616–626——只 spread 了顶层与 payload/user 第一层。`guard`/`resolve`/`afterDispatch` 对嵌套对象的原地修改在 retryable 错误（40001/40P01）后**泄漏进下一次尝试**，重试不再等价于干净重放。`transactionRetry.spec.ts` 只验证了顶层语义。
+- 修复方向：对 payload/user 深拷贝（structuredClone，注意函数字段），或冻结输入并文档化「dispatch 输入不可变」。
+
+### R-7 知识库 `getValue` API 不存在：**代码生成管线级**的文档污染（已实测确认）
+
+- 位置：`agent/agentspace/knowledge/usage/` 五个指南（02/04/14/15/19）+ `agent/agentspace/knowledge/generator/` 两个指南反复推荐 `Property.create({ getValue: (record) => … })` 作为「同实体简单派生」的正解（02 L204–248 有整节教程，04 L685 起「CRITICAL: When to Use Transform vs getValue」，19 L195 把它标成 ✅ CORRECT）。但 `src/core/Property.ts` **没有 `getValue`**（实际 API 是 `computed`），实测 `Property.create({..., getValue})` **静默丢弃**该参数——生成的属性是一个永远为 null 的普通列，无任何报错。
+- 影响：这套知识库是 agent 代码生成工作流（`agent/CLAUDE.md`）的直接输入——按文档生成的应用会批量产出静默失效的派生属性。另外文档还宣称 computed 属性「not stored in the database but calculated dynamically at query time」（02 L253），而实际实现是**写时持久化列**（`NewRecordData.getSameRowFieldAndValue`，读路径无动态求值）——两个方向都与代码事实相反。`agent/skill/interaqt-reference.md` L44 的「NOT persisted」同错。
+- 修复方向：全量替换文档中的 `getValue` → `computed`，改正持久化语义描述；顺带在 Klass 工厂对未声明的 create 参数告警/抛错（displayName + 未知键），把这类漂移从「静默」变「fail-fast」——这对框架所有 Klass 都是一次性收益。
+
+### R-8 `RecordMutationSideEffect` 同名结果覆盖：一次 dispatch 多事件命中同一注册时只保留最后一次（精读，高置信度）
+
+- 位置：`src/runtime/Controller.ts` L756–783——`result.sideEffects![sideEffect.name] = {...}` 以 name 为键，批量创建 / membership 连锁产生多事件时前面的 result/error 被覆盖。副作用本身都执行了，但 `DispatchResponse` 丢失了前面的结果（含 **error**——失败可能被后续成功掩盖）。
+- 修复方向：按 name 聚合为数组，或 key 加事件序号；error 至少不能被覆盖。
+
+---
+
+## 四、显著值得改进的地方
+
+### 4.1 storage / drivers
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | `between` 无参数形态校验 | `MatchExp.ts` L273–283 | `['between', 25]` 直接 TypeError；对照 `'in'` 有 Array.isArray 检查。补 arity 校验 |
+| I-2 | 操作符大小写不一致 | `MatchExp.ts` L208–209 | `in/not in/between/is null` 走 toLowerCase，`like`/`!=` 必须小写，`['LIKE', …]` 落到 `unknown value expression` 断言。统一在一处 normalize |
+| I-3 | `IN`/`NOT IN` 列表含 null 的三值逻辑陷阱 | `MatchExp.ts` L256–271 | `NOT IN (…, NULL)` 恒空集；文档化或过滤 null 并给告警 |
+| I-4 | `mergeAttributeQueryData` 合并重复关系键时丢 matchExpression/modifier/onlyRelationData | `AttributeQuery.ts` L29–36 | 只保留 attributeQuery，两分支元数据冲突时静默丢弃；低频但语义错 |
+| I-5 | 跨驱动 `contains` 语义漂移 | PG `json_array_elements_text` / MySQL `JSON_CONTAINS` / SQLite `json_each` | 无跨驱动 parity 测试；与 R-3 一并处理 |
+| I-6 | `parentById` Map 键 string/number 混用 | `QueryExecutor.ts` L392–395 | SQLite 数值 id 与字符串化路径若混用会静默丢子行（既有「批量 1:n 孤儿」的类型学根因）；统一 String() 归一化 |
+| I-7 | IDSystem 表名字符串插值 | `SQLite.ts` L12–16 / `Mysql.ts` L10–14 | 实体名 setup 期已有正则校验，风险低；defense-in-depth 改占位符 |
+| I-8 | `EntityQueryHandle` 入口对 matchExpression 形态零校验 | `EntityQueryHandle.ts` L29–42 | modifier 有校验（F8 修复），match 没有；畸形 match 深入到 SQL 构建才崩 |
+| I-9 | `handleUpdateReliance` 消费 `newEntityData` 而非 `newEntityDataWithDep` | `UpdateExecutor.ts` L80–84 | 与既有「updateRecord 返回值遗漏 dependency」同源，修 F-3 时顺带对齐 |
+
+### 4.2 runtime / builtins
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-10 | Attributive/Condition 返回非 boolean 非 string 的 truthy（1/{}）被当放行 | `BoolExp.ts` L442–444 | undefined 已拒、string 当错误信息，1/{} 静默 pass；与「必须显式返回 boolean」的既有契约不齐，`typeof result !== 'boolean'` 应统一拒绝 |
+| I-11 | `createUserRoleAttributive({name: ''})` 得到恒真 attributive | `User.ts` L24–26 | 无 name 的「anyone」是有意设计（`createUserRoleAttributive({})` 全测试在用），但空字符串同样落进 anyone 分支是纯 footgun；`name === ''` 应抛声明期错误 |
+| I-12 | `checkConceptAttributive` 把 BoolExp 失败折叠成泛化字符串 | `Interaction.ts` L486–487 | per-atom 错误信息被丢，payload 概念检查只报 `attributives check failed`；DX |
+| I-13 | `getActivityCall(activityId)` 以定义 uuid 为键，参数名却暗示运行期 activity 记录 id | `ActivityManager.ts` L75–77, L188–190 | 用运行期 id 调用恒得 undefined；改名或双索引 |
+| I-14 | `core/SideEffect` 与 `RecordMutationSideEffect` 双轨并存，前者 runtime 零消费 | `src/core/SideEffect.ts` | 两套「副作用」概念增加集成错误率；收敛或文档化分工 |
+| I-15 | `asyncReturn` 调用只传 2 参，宿主 record 参数恒 undefined | `Scheduler.ts` L947, L1113 | Custom 包装器签名期望 (result, dataDeps, record)；对齐 arity 或修类型 |
+| I-16 | `computeOldRecord` 对关联实体脏行返回 `{...newRecord}` 假冒 oldRecord | `Scheduler.ts` L457–462 | 已有 FIXME；消费方若读 oldRecord 拿到的是现值。文档化或置 undefined |
+| I-17 | 全局 dataDep 扇出的批处理一错全断 | `Scheduler.ts` L548–562 | 单条 host 记录计算失败阻断同批其余 host 更新；fail-fast 可以，但爆炸半径应文档化 |
+| I-18 | `trigger.oldRecord` 模式对 delete 事件永不匹配 | `ComputationSourceMap.ts` L248–252 | delete 事件通常只有 record；声明期校验或文档化 |
+| I-19 | GlobalEvery/GlobalAverage 负计数守卫缺失 | `Every.ts` L110–111 / `Average.ts` L132–135 | r4 R-6.1 只修了 Property Average；六 handle 模板抽取（四轮遗留）应一并收编 |
+| I-20 | property 聚合对 `relatedAttribute.length > 3` 一律 fullRecompute | `Count.ts` L205–214 等六处 | 深嵌套 attributeQuery 的增量路径直接放弃，SERIALIZABLE 下退化为全量重算/重试风暴；功能缺口非正确性问题 |
+| I-21 | `finishMigration` 只存 `error.message`；`FrameworkError.causedBy` 未接 `Error.cause` | `MonoSystem.ts` L1461 / `FrameworkError.ts` L21 | 排障信息损耗 |
+
+### 4.3 文档 / 测试矩阵缺口（本轮致命项的共同根因）
+
+| 场景 | 现状 |
+|------|------|
+| filtered source × {Summation/Average/WeightedSummation/Count+callback} × 成员字段 update | **零覆盖** → F-1 |
+| `dataPolicy.attributeQuery` 单独生效（caller 不传/传更宽） | 所有测试都同时传 caller attributeQuery → F-2 |
+| update payload 携带 `&` 关系属性 | 仅 create 覆盖 → F-3 |
+| `computed` 引用关系数据（create ref 形式 / update 无关字段） | 零覆盖 → F-4 |
+| 大 IN / 畸形 between / 重复 ref / contains 非数组 | 零覆盖 → R-1/I-1/R-2/R-3 |
+| 知识库示例代码 vs 真实 API 的 CI 级校验 | 无（`getValue` 漂移存活于 7 个指南）→ R-7 |
+| filtered entity OR 谓词的 membership diff | 代码已实现（`FilteredEntityManager` L169–175 递归 OR），零测试 |
+| `agentspace/knowledge/filtered-entity-cross-entity-limitation.md` | 声称不支持 cross-entity，实际已支持且有测试——文档过时 |
+
+### 4.4 既有报告遗留项（仍有效）
+
+r4 的 R-4（program group 语义）、R-5（initialState.computeValue 契约）、R-6.2/6.3、R-7（dictionary defaultValue 进 modelHash）、I-1~I-18；r3 的 R-4（asyncReturn advisory lock）、R-5（RealTime 时间调度器）、R-6（迁移终态 phase）、R-8；r2 的驱动类型映射、级联深度、async task 清理、合表事件完整性（本轮 storage 复查再次确认 `flashOutCombinedRecordsAndMergedLinks` / `relocateCombinedRecordDataForLink` 的内部行删除/插入不传 events——维持「先决策 mergeLinks 去留」）。**六聚合 handle 共享模板抽取**：本轮 I-19/I-20 又见两处漂移，五轮累计 12 个具体缺陷，这是全部遗留项中投入产出比最高的一项。
+
+---
+
+## 五、本轮证伪的候选与复查确认健康的区域
+
+| 候选/区域 | 结论 |
+|------|------|
+| 「SQLite JSON contains 缺 `IS` 导致 SQL 语法错误」 | **证伪**：SQLite 语法接受 `expr NOT NULL` 后缀形态，`JSONfield.spec.ts` 在位且通过 |
+| 「StateMachine delete 触发器静默失效」 | **证伪**（对关联记录删除的常规形态）：REPRO-F 实测 owner 删除后 pet.status 正确转移；宿主自身 delete 触发的 lock-miss skip 语义上合理（记录已不存在），仅建议文档化 |
+| Attributive 返回 truthy **字符串** | 实测**被正确拒绝**（string 按错误信息处理，fail-closed）；仅 1/{} 形态漏网（I-10） |
+| 守卫链 async BoolExp / 异常 fail-closed / not 反转安全 | `evaluateAsync` + 错误字符串语义健壮；`BoolExp.evaluate` 对 Promise 有显式拒绝 |
+| dispatch 事务重试边界（effects 重置 / post-commit 门控 / listener 不叠加） | `transactionRetry.spec.ts` 覆盖，结构正确（除 R-6 的深拷贝缺口） |
+| 空 IN / EXIST 占位符次序 / x:n fan-out 去重 / 长别名 | 既有回归测试在位 |
+| filtered membership（computed 列 / 嵌套 / 级联 relation delete） | r3/r4 修复与矩阵测试在位；本轮 F-1 是 runtime 监听注册层的问题，storage 事件层健康 |
+| 嵌套创建事件完整性 / 默认值 falsy（0/false/''）处理 | `preprocessSameRowData` 每嵌套记录发事件；defaultValue 用 `=== undefined` 判断，无 `\|\|` 陷阱 |
+
+---
+
+## 六、修复优先级建议
+
+**P0（静默错误数据 / 权限失效，全部有复现可转回归）：**
+1. F-1 filtered 聚合的 base 链监听注册——「文档承诺的模式 + 查询正确 + 聚合永久错」组合，影响面最大
+2. F-2 `dataPolicy.attributeQuery` 生效（policy 上限语义）——数据暴露级
+3. F-3 update 传递 `&` link 数据——静默数据丢失
+4. F-4 `computed` 关系输入的声明期拒绝（可执行契约）
+
+**P1（崩溃与运维死角）：**
+R-1 IN 分片、R-2 重复 ref 幂等/明确错误、R-3 contains 类型防护、R-4 Scheduler.setup 原子切换、R-5 install 半途失败恢复路径、R-6 dispatch 深拷贝、R-8 sideEffects 结果聚合。
+
+**P2（管线与契约）：**
+R-7 知识库 `getValue` 全量修正 + Klass 未知参数 fail-fast（一次性根治此类漂移）、I-1~I-21、4.3 测试矩阵缺口补齐。
+
+---
+
+## 附录：复现测试代码（验证用，未提交为正式测试）
+
+以下测试在 `1f848596` 上以 PGLiteDB/SQLiteDB 运行，结果如注释所示。修复时可改造为回归测试（断言改为正确语义）。
+
+```ts
+// F-1 (REPRO-A)：filtered Summation 对成员字段更新失明
+const ActiveUser = Entity.create({ name: 'ActiveUser', baseEntity: User,
+  matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }) })
+Dictionary.create({ name: 'activeSalarySum',
+  computation: Summation.create({ record: ActiveUser, attributeQuery: ['salary'] }) })
+await storage.create('User', { isActive: true, salary: 100 })   // sum = 100 ✓
+await storage.update('User', matchU, { salary: 200 })
+// sum = 100 ❌（应为 200）；Count+callback 变体（REPRO-L）同样失明
+
+// F-2 (REPRO-B)：dataPolicy.attributeQuery 零生效
+const GetSecrets = Interaction.create({ action: GetAction, data: Secret,
+  dataPolicy: DataPolicy.create({ attributeQuery: ['id', 'title'] }) })
+await controller.dispatch(GetSecrets, { user, query: { attributeQuery: ['id','title','ssn'] } })
+// → [{id, title, ssn: '123-45-6789'}] ❌
+
+// F-3 (REPRO-E)：update 丢 & 关系属性
+await storage.create('User', { teams: [{ id: t1.id, '&': { role: 'member' } }] })  // role ✓
+await storage.update('User', matchU, { teams: [{ id: t2.id, '&': { role: 'lead' } }] })
+// link 上 role 为空 ❌
+
+// F-4 (REPRO-D2)：computed 关系输入静默翻转
+Property.create({ name: 'inTech', type: 'boolean', computed: r => r.team?.type === 'tech' })
+await storage.create('User', { name: 'A', team: { type: 'tech' } })  // inTech = true
+await storage.update('User', matchU, { name: 'A2' })                 // 与 team 无关
+// inTech = false ❌（静默持久化）
+
+// R-1 (REPRO-G)：大 IN 崩溃
+await storage.find('Item', MatchExp.atom({ key: 'n', value: ['in', Array.from({length: 40000}, (_,i)=>i)] }), undefined, ['id'])
+// SQLite: "too many SQL variables" ❌
+
+// R-2 (REPRO-H)：重复 ref 崩溃
+await storage.update('User', matchU, { teams: [{ id: t1.id }, { id: t1.id }] })
+// Error: cannot create ... link already exist ❌
+
+// R-3 (REPRO-I)：contains 非数组 JSON
+await storage.find('Doc', MatchExp.atom({ key: 'meta', value: ['contains', 'key'] }), undefined, ['id'])
+// PG: cannot call json_array_elements_text on a non-array ❌
+
+// R-7：getValue 静默丢弃（实测）
+const p = Property.create({ name: 'fullName', type: 'string', getValue: r => r.a } as any)
+// 'getValue' in p === false，p.computed === undefined —— 属性恒为 null，无报错
+```

--- a/agentspace/output/deep-review-2026-07-09-r5.md
+++ b/agentspace/output/deep-review-2026-07-09-r5.md
@@ -1,5 +1,15 @@
 # 全代码库深度 Review 报告（2026-07-09 第五轮）
 
+> **维护说明（2026-07-09 更新）**：本报告的致命项已在同分支（`cursor/deep-code-review-r5-06e2`）修复：
+>
+> - **F-1**：`ComputationSourceMap` 把 filtered 源的 update 监听注册到物理 base 记录名（携带 `filteredRecordName`）；`Scheduler.resolveFilteredUpdateEvent` 做同批次成员资格事件去重 + 当前成员资格查询守卫，并把事件名改写回 filtered 名。回归网：`tests/runtime/aggregationConsistencyMatrix.spec.ts`（25 个原破损格子全部转绿）。
+> - **F-2**：`retrieveData` 中 `dataPolicy.attributeQuery` 声明即生效（policy wins，调用方不可拓宽投影），与 modifier 的合并方向一致；`queryDataInteraction.spec.ts` 新增「调用方无法越权取隐藏字段」回归用例，并修正了原先断言越权行为的既有用例。
+> - **F-3**：`UpdateExecutor.handleUpdateReliance` 把 `linkRecordData` 透传给 `addLinkFromRecord`，update 替换关系不再丢 `&` 属性（矩阵 parity 格子转绿）。
+> - **F-4**：`NewRecordData.getSameRowFieldAndValue` 用 Proxy 把「computed 只能引用同行 value 字段」变成可执行契约——computed 访问关系属性立即抛出明确错误，不再静默腐蚀；回归测试 `tests/storage/computedRelationGuard.spec.ts`。
+> - 重要项（R-1~R-8）与改进项为**明确遗留**，建议独立 PR 处理。
+>
+> 修复后全量测试 1733 passed / 26 skipped；`npm run check` 通过。下文正文保留 review 时的原始判定，作为问题背景与复现依据。
+
 - 日期：2026-07-09
 - 基线：`main` @ `1f848596`（PR #22 合入之后，前四轮 review 修复全部落地）
 - 范围：`src/core`、`src/runtime`（Controller/Scheduler/ComputationSourceMap/computations/transaction）、`src/storage`（mutation executors / SQL 构造 / filtered entity）、`src/builtins`（dispatch 守卫链 / data API）、`src/drivers`、`agent/agentspace/knowledge/`（知识库与代码事实的一致性）

--- a/agentspace/output/deep-review-2026-07-09-r6-matrix.md
+++ b/agentspace/output/deep-review-2026-07-09-r6-matrix.md
@@ -1,0 +1,134 @@
+# 组合空间矩阵化探索报告（2026-07-09 第六轮）
+
+- 日期：2026-07-09
+- 基线：`cursor/deep-code-review-r5-06e2`（r5 报告之后，代码与 `main` @ `1f848596` 一致）
+- 方法：**不变式预言机（oracle）驱动的组合矩阵**——不再逐例人工写期望值，而是用两条自校验不变式让每个格子的断言零成本：
+  1. **增量一致性**：任何变更之后，增量维护的聚合值 == 从 storage 查询全量重算的值（JS ground truth）；
+  2. **create/update 对偶性**：通过 update 到达的状态 == 直接 create 声明出的同一状态。
+- 载体：`tests/runtime/aggregationConsistencyMatrix.spec.ts`（已提交为常驻回归设施，见「机制」一节）
+- 一次运行覆盖：**7 种数据源形态 × 7 种聚合 × 15 种变更操作 + 3 种关系类型 × 4 种载荷形态 × create/update 两路** ≈ 700+ 个断言点
+
+---
+
+## 一、回答「能否一次性找到所有类似问题」
+
+**对「聚合增量一致性」和「create/update 对偶性」这两族问题：能，本轮已做到全矩阵覆盖**。一次运行给出完整的破损清单（35 个破损格子 / 144 次不一致事件），其中包含 **3 个 r5 没有发现的新致命缺陷**。
+
+但要明确边界：矩阵方法只对「**有自校验预言机的问题族**」有效。五轮 review 的致命 bug 分四类，本轮矩阵覆盖了前两类：
+
+| 问题族 | 预言机 | 本轮状态 |
+|--------|--------|---------|
+| 聚合增量一致性 | 增量值 == 全量重算 | ✅ 全矩阵覆盖 |
+| 写路径语义对偶 | update 终态 == create 终态 | ✅ 全矩阵覆盖（n:n / 1:1 / 1:n × 4 种载荷形态） |
+| 「声明被接受但无实现」（dataPolicy.attributeQuery、getValue、死类型） | 无通用预言机，需逐 API 对账 | ❌ 需要静态手段（Klass 未知参数 fail-fast + public 字段消费审计） |
+| 流程型（Activity 图形态、序列化 round-trip、打包、迁移） | 各自需要专用 harness | ❌ 各需独立矩阵（round-trip 等价性是现成预言机，可仿此模式扩展） |
+
+---
+
+## 二、矩阵结果全景
+
+运行输出：35 个破损格子 / 144 次不一致事件（完整输出见测试运行日志）。按根因聚类为 **4 个缺陷家族**，其中 2 个是 r5 已知问题的完整边界测绘，**3 个是新发现**（家族 3、4 内的三种崩溃）。
+
+### 家族 1：filtered 源上的聚合对成员字段更新失明（r5 F-1 的完整测绘，25 个格子）
+
+r5 只复现了 global Summation / Count+callback 两个点。矩阵证明**整个家族全灭**：
+
+| 源形态 \ 聚合 | countCb | sum | avg | weighted | every | any |
+|---|---|---|---|---|---|---|
+| filtered entity（普通谓词） | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| filtered entity（computed 谓词） | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| 嵌套 filtered（filtered 上再 filtered） | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| filtered relation | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| property 宿主 × filtered relation × 链接字段 | — | ❌（`prop/sumLinkF`） | — | — | — | — |
+
+- 对照组全部健康：非 filtered 的 entity/relation 源 × 全部 7 种聚合、纯 membership 驱动的 `count`（无字段读取）、property 宿主 × 非 filtered relation（含链接字段与 target 字段）。
+- 失明的精确形态：只有「成员**留在集合内**的字段更新」丢失；create/enter/exit/delete/级联删除全部正确（membership 事件驱动）。`every`/`any` 需要纯字段更新翻转结果才能暴露（矩阵的 s14/s15 步骤专门构造了这个形态）。
+- 根因（r5 已定位）：`ComputationSourceMap.ts` L322–331 把 update 监听注册在 filtered 视图名上，而 storage 的 update 事件用 base 名。**一处修复应清空全部 25 个格子**，矩阵将直接验证这一点。
+
+### 家族 2：update 丢弃 `&` 关系属性（r5 F-3 的完整测绘 + 波及 1:n）
+
+| 格子 | 现象 |
+|------|------|
+| `parity/n:n/ref+&` | create 得 `role:'lead'`，update 得 `role:null` |
+| `parity/n:n/nested+&` | 同上 |
+| `parity/1:n/nested+&` | create 得 `note:'n2'`，update 得 `note:null` |
+
+根因同 r5 F-3（`UpdateExecutor.handleUpdateReliance` L219 不传 linkRecordData）。
+
+### 家族 3（**新发现**）：1:1 关系的 `&` 载荷在 create/update 双路**全部崩溃**
+
+```
+storage.create('User', { profile: { id: p.id, '&': { since: '2020' } } })
+→ TypeError: Converting circular structure to JSON
+   at CreationExecutor.preprocessSameRowData (CreationExecutor.ts:255)
+```
+
+- 位置：`CreationExecutor.ts` L232–236 构造 link 事件记录时把宿主与关联记录互相引用（`linkRecord.source`/`linkRecord.target` 与 `&` 数据形成环），L255 的**日志字符串模板**对含环数据 `JSON.stringify` 直接抛 TypeError。
+- 影响：1:1 + `&` 关系属性（如 `profile` 关系上的 `since`）在 **create 和 update 两路都不可用**——比家族 2 更严重（不是丢数据而是硬崩），且崩溃点是日志插值，错误信息与用户写法完全无关。nested / ref 两种形态同崩。现有 `relationAttributes.spec.ts` 只测了 n:n 和 1:n（从 target 侧），1:1 + `&` 零覆盖。
+- 复现格子：`parity/1:1/ref+&/{create,update}`、`parity/1:1/nested+&/{create,update}`（4 个）。
+
+### 家族 4（**新发现**）：1:n 关系从 source 侧（拥有多端的一侧）的两种崩溃
+
+**4a. `ref+&` 形态 create 崩溃：**
+
+```
+storage.create('User', { orders: [{ id: o.id, '&': { note: 'n' } }] })
+→ Error: entity undefined not found
+   at EntityToTableMap.groupAttributes (EntityToTableMap.ts:433)
+   at CreationExecutor.handleCreationReliance (CreationExecutor.ts:315)
+```
+
+对照：同一关系 `nested+&`（新建记录 + `&`）create 正常、`ref` 无 `&` 正常——只有「引用已有记录 + `&`」这一组合崩，说明 `handleCreationReliance` L315 构造 link 的 NewRecordData 时 recordName 传了 undefined。
+
+**4b. update 抢夺已链接目标时崩溃（与 `&` 无关）：**
+
+```
+// order 已链接到 owner，把它 update 到另一个 user：
+storage.update('User', matchU2, { orders: [{ id: takenOrder.id }] })
+→ error: column "v7o_buy_…" specified more than once
+```
+
+隔离实验：链接**未被占用**的目标 → 正常；**幂等重连**（目标已链接到自己）→ 正常；**抢夺**（目标已链接到别人）→ SQL 列重复崩溃。1:n 的「转移所有权」是完全常规的业务操作（订单转移、任务改派），目前不可用。复现格子：`parity/1:n/ref/update`、`parity/1:n/ref+&/update`。
+
+---
+
+## 三、本轮矩阵确认健康的区域（对照组价值）
+
+| 区域 | 结论 |
+|------|------|
+| 非 filtered 源 × 全部 7 种聚合 × 全部 15 种变更（含同时改字段+退出、级联删除端点、边界值 0/负数） | 全部一致 ✅ |
+| filtered 源的 membership 驱动路径（create 命中/不命中、enter、exit、delete、级联） | 全部一致 ✅（r3/r4 修复扎实） |
+| property 宿主 × 非 filtered relation（count / sum 链接字段 / sum target 字段 / every / any，含 target 实体字段更新触发） | 全部一致 ✅ |
+| 纯 membership Count over filtered（无字段读取） | 全部一致 ✅（解释了为何既有矩阵测试没发现家族 1） |
+| n:n / 1:n 的 `ref`、`nested+&` create 路；1:1 的无 `&` 全路径；relation 记录直接 update `&` 字段 | 对偶性成立 ✅ |
+
+---
+
+## 四、机制沉淀：矩阵作为常驻回归设施
+
+`tests/runtime/aggregationConsistencyMatrix.spec.ts` 已提交，设计为**自带缺陷清单的守护测试**：
+
+- 最后一个用例把「实际破损格子集合」与 `KNOWN_BROKEN_CELLS`（35 项，每项对应本报告的一个已确认缺陷）做**双向 diff**：
+  - 出现**新格子** → 回归，测试失败并点名；
+  - 已知格子**消失** → 说明修复生效，测试失败并提示从清单移除——修复被永久锁定。
+- 这样矩阵在 CI 中保持绿色，同时把「已知债务」显式化为代码内清单，修复进度可直接度量（清单长度单调递减）。
+
+### 扩展路线（按预言机可得性排序）
+
+1. **序列化 round-trip 矩阵**：`parse(stringify(x)) ≍ x` 是现成预言机，可对全部 Klass × 嵌套形态程序化生成（r4 F-2 一族的根治性覆盖）。
+2. **StateMachine 触发矩阵**：trigger 形态（recordName × type × keys × record pattern）× 宿主（global/property/relation）——预言机是「事件序列重放后的期望终态」，半自动。
+3. **「声明即实现」静态审计**：Klass 工厂拒绝未知 create 参数 + 对每个 `static public` 字段做消费点 grep 审计——这覆盖矩阵方法够不到的第三类问题族。
+
+---
+
+## 五、缺陷清单增量（相对 r5）
+
+| 编号 | 级别 | 内容 | 状态 |
+|------|------|------|------|
+| r6-F1 | 致命（已复现） | 1:1 + `&` 载荷 create/update 双路崩溃（日志插值 `JSON.stringify` 环引用） | **新增** |
+| r6-F2 | 致命（已复现） | 1:n source 侧 `ref+&` create 崩溃（`entity undefined not found`） | **新增** |
+| r6-F3 | 致命（已复现） | 1:n update 抢夺已链接目标崩溃（SQL 列重复） | **新增** |
+| r5-F1 完整边界 | 致命 | filtered 聚合失明：25 个格子的完整测绘（r5 只复现 2 个点） | 边界扩大 |
+| r5-F3 完整边界 | 致命 | `&` 丢失波及 1:n nested 形态 | 边界扩大 |
+
+修复优先级建议：r5 F-1（一处修复清 25 格）> r6-F1/F2（`&` 在 1:1/1:n 的崩溃，与 r5 F-3 同属「link 数据管线」应一并修）> r6-F3（1:n 所有权转移）。全部修复后 `KNOWN_BROKEN_CELLS` 应归零。

--- a/agentspace/output/deep-review-2026-07-09-r6-matrix.md
+++ b/agentspace/output/deep-review-2026-07-09-r6-matrix.md
@@ -1,5 +1,15 @@
 # 组合空间矩阵化探索报告（2026-07-09 第六轮）
 
+> **维护说明（2026-07-09 更新）**：本报告发现的全部 35 个破损格子已在同分支（`cursor/deep-code-review-r5-06e2`）修复清零，`aggregationConsistencyMatrix.spec.ts` 的 `KNOWN_BROKEN_CELLS` 已清空、转为纯回归守卫：
+>
+> - **家族 1（25 格）**：filtered 源 update 监听注册到物理 base 名 + Scheduler 成员资格守卫与事件名改写（r5 F-1 修复，详见 r5 报告维护说明）。
+> - **家族 2**：`handleUpdateReliance` 透传 `linkRecordData`（r5 F-3）。
+> - **家族 3（r6-F1）**：`createRecordDependency` 不再把端点 ref 对象别名进 link 数据（打破 `deps[attr]['&'].target === deps[attr]` 的环引用）；`NewRecordData` 剔除与 linkField 同列的 link 端点字段。1:1 `&` 载荷 create/update 双路可用。
+> - **家族 4（r6-F2）**：`handleCreationReliance` 把 `&` 数据挂到反向 attribute 值上而非实体记录顶层，1:n source 侧 `ref+&` create 可用。
+> - **家族 4（r6-F3）**：`flashOutCombinedRecordsAndMergedLinks` 抢夺端点行时剔除被替换的旧同名 link 列并补发旧 link 的 delete 事件，1:n 所有权转移可用且事件完整。
+>
+> 修复后全量测试 1733 passed / 26 skipped；`npm run check` 通过。下文正文保留探索时的原始判定。
+
 - 日期：2026-07-09
 - 基线：`cursor/deep-code-review-r5-06e2`（r5 报告之后，代码与 `main` @ `1f848596` 一致）
 - 方法：**不变式预言机（oracle）驱动的组合矩阵**——不再逐例人工写期望值，而是用两条自校验不变式让每个格子的断言零成本：

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -550,7 +550,10 @@ async function retrieveData(controller: Controller, interaction: InteractionInst
     const fixedModifier = interaction.dataPolicy?.modifier;
 
     const modifier = { ...(eventArgs.query?.modifier || {}), ...(fixedModifier || {}) };
-    const attributeQuery = eventArgs.query?.attributeQuery || [];
+    // CAUTION dataPolicy.attributeQuery 是交互作者声明的固定投影，声明了就必须生效（policy wins）。
+    //  与 modifier 的合并方向一致：调用方不能越权拓宽可见字段——否则 policy 形同虚设，
+    //  任何调用方都可以请求任意字段（含 '*'），这是数据暴露级缺陷（r5 F-2）。
+    const attributeQuery = interaction.dataPolicy?.attributeQuery ?? (eventArgs.query?.attributeQuery || []);
 
     const matchValue = typeof fixedMatch === 'function'
       ? await fixedMatch.call(controller, eventArgs)

--- a/src/runtime/ComputationSourceMap.ts
+++ b/src/runtime/ComputationSourceMap.ts
@@ -41,7 +41,13 @@ export type EntityUpdateEventsSourceMap = {
     sourceRecordName: string,
     targetPath?: string[],
     computation: Computation,
-    isRelation?: boolean
+    isRelation?: boolean,
+    // 当监听对象是 filtered entity/relation 时，update 事件只会以【物理 base 记录名】发出
+    // （filtered 名下只有成员资格 create/delete 事件）。此字段记录原 filtered 名：
+    //  - recordName 注册为物理 base 名（否则监听永远不触发——成员字段更新静默丢失）；
+    //  - Scheduler 路由时按此名做成员资格检查并把事件改写回 filtered 名，
+    //    使 computation 的增量分支看到的事件与成员资格事件同名（enter/exit 由后者负责）。
+    filteredRecordName?: string
 }
 
 export type DataBasedEntityEventsSourceMap = EntityCreateEventsSourceMap 
@@ -78,9 +84,45 @@ export type ComputationPhase = typeof PHASE_BEFORE_ALL|typeof PHASE_NORMAL|typeo
 export class ComputationSourceMapManager {
     private sourceMaps: EntityEventSourceMap[] = []
     private sourceMapTree: DataSourceMapTree = {}
+    // filtered entity/relation 名 -> 物理 base 记录名（穿透嵌套 filtered 链）
+    private filteredToPhysicalName: Map<string, string> = new Map()
 
     constructor(public controller: Controller, public scheduler: Scheduler) {
         
+    }
+
+    private buildFilteredToPhysicalNameMap(): void {
+        this.filteredToPhysicalName = new Map()
+        const all: any[] = [...this.controller.entities, ...this.controller.relations]
+        for (const item of all) {
+            if (!item?.name) continue
+            let cur: any = item
+            while (cur.baseEntity || cur.baseRelation) {
+                cur = cur.baseEntity || cur.baseRelation
+            }
+            if (cur !== item && cur?.name) {
+                this.filteredToPhysicalName.set(item.name, cur.name)
+            }
+        }
+    }
+
+    /**
+     * CAUTION filtered entity/relation 名下只有成员资格 create/delete 事件；
+     *  字段 update 事件永远以物理 base 记录名发出。注册在 filtered 名上的 update
+     *  监听是死监听——成员字段更新会静默丢失（聚合值永久陈旧）。
+     *  这里把 update 监听改挂到物理名上，并记录原 filtered 名，Scheduler 路由时
+     *  按 filteredRecordName 做成员资格守卫并把事件名改写回 filtered 名。
+     */
+    private normalizeFilteredUpdateSourceMap(source: EntityEventSourceMap): EntityEventSourceMap {
+        if (source.type !== 'update' || !('dataDep' in source)) return source
+        const updateSource = source as EntityUpdateEventsSourceMap
+        const physicalName = this.filteredToPhysicalName.get(updateSource.recordName)
+        if (!physicalName) return source
+        return {
+            ...updateSource,
+            recordName: physicalName,
+            filteredRecordName: updateSource.recordName,
+        }
     }
 
     /**
@@ -88,6 +130,7 @@ export class ComputationSourceMapManager {
      * @param sourceMaps EntityEventSourceMap 数组
      */
     initialize(computations: Set<Computation>): void {
+        this.buildFilteredToPhysicalNameMap()
         const sortedERMutationEventSources: EntityEventSourceMap[][] = [[], [], []]
 
         
@@ -160,7 +203,7 @@ export class ComputationSourceMapManager {
 
         // const ERMutationEventSources: EntityEventSourceMap[]= sortedERMutationEventSources.flat()
 
-        this.sourceMaps =  sortedERMutationEventSources.flat()
+        this.sourceMaps = sortedERMutationEventSources.flat().map(source => this.normalizeFilteredUpdateSourceMap(source))
         this.sourceMapTree = this.buildDataSourceMapTree(this.sourceMaps)
     }
     /**

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -15,6 +15,7 @@ import { DICTIONARY_RECORD, type InternalSchemaRequirement, RecordMutationCallba
 import { RequireSerializableRetry, runWithTransactionRetry } from "./transaction.js";
 import {
     EntityEventSourceMap,
+    EntityUpdateEventsSourceMap,
     DataSourceMapTree,
     ComputationSourceMapManager,
     EntityCreateEventsSourceMap
@@ -397,11 +398,65 @@ export class Scheduler {
                         if (!('dataDep' in source) && !this.sourceMapManager.shouldTriggerEventBasedComputation(source as EventBasedEntityEventsSourceMap, mutationEvent)) {
                             continue
                         }
-                        await this.runDirtyRecordsComputation(source, mutationEvent)
+                        // filtered 源的 update 监听挂在物理 base 名上（见 ComputationSourceMap），
+                        // 路由前做成员资格守卫并把事件名改写回 filtered 名。
+                        const routedEvent = await this.resolveFilteredUpdateEvent(source, mutationEvent, mutationEvents)
+                        if (!routedEvent) {
+                            continue
+                        }
+                        await this.runDirtyRecordsComputation(source, routedEvent)
                     }
                 }
             }
         })
+    }
+    /**
+     * filtered entity/relation 源上的 update 事件路由守卫。
+     *
+     * 背景：storage 的字段 update 事件只以物理 base 记录名发出；filtered 名下只有
+     * 成员资格 create/delete 事件。为了让「成员留在集合内的字段更新」也能触发聚合，
+     * source map 把 filtered 源的 update 监听注册到物理名上（携带 filteredRecordName）。
+     * 这里补上语义守卫，保证与成员资格事件不重复计算：
+     *  1. 同一事件批次里已有该记录在该 filtered 源上的成员资格 create/delete
+     *     （enter/exit 场景）→ 跳过，由成员资格事件驱动计算；
+     *  2. 否则查询当前成员资格：仍是成员 → 以 filtered 名改写事件后放行（stay-in 更新）；
+     *     不是成员 → 跳过（无关记录的字段更新）。
+     *
+     * 带 targetPath 的（property/关联路径）监听不需要此守卫：computeDirtyDataDepRecords
+     * 与各 handle 的增量分支都通过 filtered 路径查询定位记录，成员资格由查询本身保证。
+     */
+    private async resolveFilteredUpdateEvent(
+        source: EntityEventSourceMap,
+        mutationEvent: RecordMutationEvent,
+        batchEvents: RecordMutationEvent[]
+    ): Promise<RecordMutationEvent | null> {
+        if (!('dataDep' in source) || source.type !== 'update') return mutationEvent
+        const filteredRecordName = (source as EntityUpdateEventsSourceMap).filteredRecordName
+        if (!filteredRecordName) return mutationEvent
+        if (source.targetPath?.length) return mutationEvent
+
+        const recordId = mutationEvent.record?.id ?? mutationEvent.oldRecord?.id
+        if (recordId === undefined) return null
+
+        // 1. enter/exit 由同批次的成员资格事件驱动，避免双计。
+        const hasMembershipEventInBatch = batchEvents.some(event =>
+            event !== mutationEvent &&
+            event.recordName === filteredRecordName &&
+            (event.type === 'create' || event.type === 'delete') &&
+            (event.record?.id ?? event.oldRecord?.id) === recordId
+        )
+        if (hasMembershipEventInBatch) return null
+
+        // 2. stay-in / stay-out 判定：按 filtered 名查询当前成员资格。
+        const member = await this.controller.system.storage.findOne(
+            filteredRecordName,
+            MatchExp.atom({ key: 'id', value: ['=', recordId] }),
+            undefined,
+            ['id']
+        )
+        if (!member) return null
+
+        return { ...mutationEvent, recordName: filteredRecordName }
     }
     async computeDirtyDataDepRecords(source: DataBasedEntityEventsSourceMap, mutationEvent: RecordMutationEvent): Promise<any[]> {
         // 1. 就是自身的变化

--- a/src/storage/erstorage/CreationExecutor.ts
+++ b/src/storage/erstorage/CreationExecutor.ts
@@ -56,8 +56,12 @@ export class CreationExecutor {
 
             if (mergedLinkTargetRecord.linkRecordData) {
                 // 为 link 也要把 dependency 准备好。
+                // CAUTION link 的端点必须是全新的 {id} 对象，不能复用 newDepIdRef：
+                //  下面 deps[attr][LINK_SYMBOL] 会把 link 数据挂回 newDepIdRef 自身，
+                //  复用会形成 deps[attr]['&'].target === deps[attr] 的环引用——
+                //  任何对 rawData 的 JSON.stringify（日志、事件序列化）都会当场崩溃。
                 const newLinkRecordData = mergedLinkTargetRecord.linkRecordData.merge({
-                    [mergedLinkTargetRecord.info!.isRecordSource() ? 'target' : 'source']: newDepIdRef
+                    [mergedLinkTargetRecord.info!.isRecordSource() ? 'target' : 'source']: { id: newDepIdRef.id }
                 })
                 // 所有 Link dep 也准备好了
                 const newLinkRecordDataWithDep = await this.createRecordDependency(newLinkRecordData)
@@ -308,9 +312,15 @@ export class CreationExecutor {
                 key: 'id',
                 value: ['=', record.getRef().id]
             })
+            // CAUTION `&` 关系属性必须挂在反向 attribute 的值上（NewRecordData 会把它解析成
+            //  该 attribute 的 linkRecordData 并写入合并进关联记录行的 link 列）。
+            //  挂在实体记录的顶层会让 NewRecordData 试图以 info?.linkName === undefined
+            //  解析 link 数据，直接崩溃（"entity undefined not found"）。
+            const linkData = record.getData()[LINK_SYMBOL]
             const newData = {
-                [reverseInfo!.attributeName]: currentIdRef,
-                [LINK_SYMBOL]: record.getData()[LINK_SYMBOL]
+                [reverseInfo!.attributeName]: linkData === undefined
+                    ? currentIdRef
+                    : { ...currentIdRef, [LINK_SYMBOL]: linkData }
             }
             const [updatedRecord] = await this.agent.updateRecord(reverseInfo.parentEntityName, idMatch, new NewRecordData(this.map, reverseInfo.parentEntityName, newData), events)
             if (record.info!.isXToMany) {

--- a/src/storage/erstorage/NewRecordData.ts
+++ b/src/storage/erstorage/NewRecordData.ts
@@ -168,13 +168,33 @@ export class NewRecordData {
         
         // 获取记录的所有 value 属性定义，不仅仅是提供的属性
         const recordInfo = this.map.getRecordInfo(this.recordName)
+        // CAUTION computed 的契约是【只能引用同行 value 字段】。关系数据不在同行、
+        //  update 的前置查询也不会加载它——嵌套 create 时 payload 恰好携带关系数据会让
+        //  这种写法"表面可用"，然后在任意一次无关 update 时静默算错并持久化（r5 F-4）。
+        //  用 Proxy 把契约变成可执行的：computed 一旦访问关系属性立即抛出明确错误。
+        const recordAttributeNames = new Set(
+            Object.keys(recordInfo.data.attributes).filter(key => (recordInfo.data.attributes[key] as { isRecord?: boolean }).isRecord)
+        )
+        const guardComputedInput = (record: { [k: string]: unknown }, computedName: string) => new Proxy(record, {
+            get: (target, prop) => {
+                if (typeof prop === 'string' && recordAttributeNames.has(prop)) {
+                    throw new Error(
+                        `computed property "${computedName}" on "${this.recordName}" accessed relation property "${prop}". ` +
+                        `"computed" only receives the record's own same-row value fields; relation data is not loaded here ` +
+                        `and would be silently stale. Use a reactive computation (Count/Summation/Custom/StateMachine, etc.) ` +
+                        `for derivations that depend on related records.`
+                    )
+                }
+                return target[prop as keyof typeof target]
+            }
+        })
         const allValueAttributes = new Set<string>()
         
         // 先处理提供的属性
         this.valueAttributes.forEach((info) => {
             allValueAttributes.add(info.attributeName)
             // 处理默认值：如果字段值为 undefined 且有默认值函数，则调用默认值函数
-            let value = info.isComputed ? info.computed!(newRecord) : this.rawData[info.attributeName]
+            let value = info.isComputed ? info.computed!(guardComputedInput(newRecord, info.attributeName)) : this.rawData[info.attributeName]
             
             // 如果值为 undefined 且有默认值函数，使用默认值
             // 注意：null 是明确的值，不应该被默认值替换
@@ -217,7 +237,7 @@ export class NewRecordData {
         // CAUTION 只有更新自己的字段和递归更新三表合一的字段是需要岛上 oldRecord 的。因为我们只允许递归更新三表合一的 record。
         recordInfo.valueAttributes.forEach(info => {
             if (info.isComputed && !updatedComputedFields.has(info.attributeName)) {
-                const newValue = info.computed!(newRecord)
+                const newValue = info.computed!(guardComputedInput(newRecord, info.attributeName))
                 if (newValue !== oldRecord[info.attributeName]) {
                     result.push({
                         name: info.attributeName,

--- a/src/storage/erstorage/NewRecordData.ts
+++ b/src/storage/erstorage/NewRecordData.ts
@@ -247,7 +247,11 @@ export class NewRecordData {
             })
 
             if (recordData.linkRecordData) {
-                result.push(...recordData.linkRecordData.getSameRowFieldAndValue())
+                // CAUTION link 数据（`&`）里可能带有端点 ref（createRecordDependency 会补 source/target），
+                //  其 entityId 字段与上面刚写入的 linkField 是同一列——必须剔除，
+                //  否则 INSERT/UPDATE 出现重复列名直接崩溃。
+                result.push(...recordData.linkRecordData.getSameRowFieldAndValue()
+                    .filter(fieldAndValue => fieldAndValue.field !== recordData.info?.linkField))
             }
         })
 

--- a/src/storage/erstorage/RecordQueryAgent.ts
+++ b/src/storage/erstorage/RecordQueryAgent.ts
@@ -150,6 +150,34 @@ export class RecordQueryAgent implements RecordOperationAgent {
                     result[combinedRecordIdRef.info?.attributeName!] = {
                         ...recordWithCombined[combinedRecordIdRef.info?.attributeName!]
                     }
+
+                    // CAUTION 当正在创建的是 merged link record（如 1:n 关系合并进 n 端的行）而被抢夺的
+                    //  端点记录上已有【同一业务关系】的旧 link 时，旧 link 的列不能随行迁移：
+                    //  新 link 自己会写这些列（同名列重复导致 INSERT 崩溃），语义上旧 link 也已被替换。
+                    //  这里剔除旧 link 数据并补发业务 link 的 delete 事件（所有权转移的另一半事实）。
+                    const newRecordInfo = this.map.getRecordInfo(newEntityData.recordName)
+                    if (newRecordInfo.isRelation && this.map.data.links[newEntityData.recordName]) {
+                        const stolenData = result[combinedRecordIdRef.info?.attributeName!]
+                        const stolenRecordInfo = this.map.getRecordInfo(combinedRecordIdRef.recordName)
+                        for (const mergedAttrInfo of stolenRecordInfo.mergedRecordAttributes) {
+                            if (mergedAttrInfo.linkName !== newEntityData.recordName) continue
+                            const oldRelated = stolenData[mergedAttrInfo.attributeName]
+                            if (oldRelated?.id === undefined) continue
+                            const oldLink = oldRelated[LINK_SYMBOL]
+                            const stolenIsSource = !this.map.getLinkInfoByName(newEntityData.recordName)
+                                .isRelationSource(combinedRecordIdRef.recordName, mergedAttrInfo.attributeName)
+                            events?.push({
+                                type: 'delete',
+                                recordName: newEntityData.recordName,
+                                record: {
+                                    ...(oldLink || {}),
+                                    source: stolenIsSource ? { id: stolenData.id } : { id: oldRelated.id },
+                                    target: stolenIsSource ? { id: oldRelated.id } : { id: stolenData.id },
+                                }
+                            })
+                            delete stolenData[mergedAttrInfo.attributeName]
+                        }
+                    }
                     // 相当于新建了关系。如果不是虚拟link 就要记录。
                     // TODO 要给出一个明确的 虚拟 link  record 的差异
                     if (!combinedRecordIdRef.info!.isLinkSourceRelation()) {

--- a/src/storage/erstorage/UpdateExecutor.ts
+++ b/src/storage/erstorage/UpdateExecutor.ts
@@ -216,7 +216,10 @@ export class UpdateExecutor {
             }
 
             // FIXME 这里没有在更新的时候一次性写入，而是又通过 addLinkFromRecord 建立的关系。需要优化
-            const linkRecord = await this.agent.addLinkFromRecord(entityName, newRelatedEntityData.info?.attributeName!, matchedEntity.id, finalRelatedEntityRef.id, undefined, events)
+            // CAUTION `&` 关系属性必须透传给 addLinkFromRecord。create 路径（handleCreationReliance）
+            //  使用 linkRecordData 写入 link 属性，update 路径若传 undefined 会把关系属性静默丢弃——
+            //  替换关系后 link 行存在但属性全部为空（r5 F-3）。
+            const linkRecord = await this.agent.addLinkFromRecord(entityName, newRelatedEntityData.info?.attributeName!, matchedEntity.id, finalRelatedEntityRef.id, newRelatedEntityData.linkRecordData?.getData(), events)
 
             if (newRelatedEntityData.info!.isXToMany) {
                 if (!result[newRelatedEntityData.info!.attributeName!]) {

--- a/tests/runtime/aggregationConsistencyMatrix.spec.ts
+++ b/tests/runtime/aggregationConsistencyMatrix.spec.ts
@@ -1,0 +1,529 @@
+/**
+ * Combinatorial aggregation-consistency matrix (review round 6, 2026-07-09).
+ *
+ * Oracle-based exploration of the (source shape × aggregation kind × mutation kind)
+ * space: after EVERY mutation, each incrementally-maintained aggregation value must
+ * equal a full recompute from a fresh storage query (ground truth computed in JS).
+ * Mismatches are collected instead of thrown per-cell, so a single run reveals the
+ * state of the whole matrix.
+ *
+ * The final assertion compares the set of broken cells against KNOWN_BROKEN_CELLS —
+ * the currently-known defect inventory (see agentspace/output/deep-review-2026-07-09-r6-matrix.md):
+ *  - a NEW cell appearing        => regression, fix it;
+ *  - a KNOWN cell disappearing   => you fixed it, remove it from the allowlist so the
+ *    matrix permanently guards the fix.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  Any, Average, Controller, Count, Dictionary, Entity, Every, KlassByName, MatchExp, MonoSystem,
+  Property, Relation, Summation, WeightedSummation,
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+type Mismatch = { cell: string; step: string; expected: unknown; actual: unknown };
+const allMismatches: Mismatch[] = [];
+
+const near = (a: unknown, b: unknown) => {
+  if (typeof a === 'number' && typeof b === 'number') return Math.abs(a - b) < 1e-9;
+  return a === b;
+};
+
+// ---------------------------------------------------------------------------
+// Aggregation kinds: definition factory + JS ground-truth over queried rows
+// ---------------------------------------------------------------------------
+type AggKind = {
+  name: string;
+  dictType: string;
+  create: (record: any, field: string) => any;
+  truth: (rows: any[], field: string, emptyConvention: unknown) => unknown;
+};
+
+const aggKinds: AggKind[] = [
+  {
+    name: 'count', dictType: 'number',
+    create: (record) => Count.create({ record, callback: () => true }),
+    truth: (rows) => rows.length,
+  },
+  {
+    name: 'countCb', dictType: 'number',
+    create: (record, field) => Count.create({ record, attributeQuery: [field], callback: (r: any) => (r[field] ?? 0) > 10 }),
+    truth: (rows, field) => rows.filter(r => (r[field] ?? 0) > 10).length,
+  },
+  {
+    name: 'sum', dictType: 'number',
+    create: (record, field) => Summation.create({ record, attributeQuery: [field] }),
+    truth: (rows, field) => rows.reduce((a, r) => a + (r[field] ?? 0), 0),
+  },
+  {
+    name: 'avg', dictType: 'number',
+    create: (record, field) => Average.create({ record, attributeQuery: [field] }),
+    truth: (rows, field, empty) => {
+      const nums = rows.map(r => r[field]).filter((v: any) => typeof v === 'number');
+      return nums.length ? nums.reduce((a: number, b: number) => a + b, 0) / nums.length : empty;
+    },
+  },
+  {
+    name: 'weighted', dictType: 'number',
+    create: (record, field) => WeightedSummation.create({
+      record, attributeQuery: [field],
+      callback: (r: any) => ({ weight: 2, value: r[field] ?? 0 }),
+    }),
+    truth: (rows, field) => rows.reduce((a, r) => a + 2 * (r[field] ?? 0), 0),
+  },
+  {
+    name: 'every', dictType: 'boolean',
+    create: (record, field) => Every.create({ record, attributeQuery: [field], callback: (r: any) => (r[field] ?? 0) > 0, notEmpty: false }),
+    truth: (rows, field, empty) => rows.length === 0 ? empty : rows.every(r => (r[field] ?? 0) > 0),
+  },
+  {
+    name: 'any', dictType: 'boolean',
+    create: (record, field) => Any.create({ record, attributeQuery: [field], callback: (r: any) => (r[field] ?? 0) > 100 }),
+    truth: (rows, field, empty) => rows.length === 0 ? empty : rows.some(r => (r[field] ?? 0) > 100),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Harness: build dicts for every (source × agg), capture empty conventions,
+// then after each mutation compare dict values vs ground truth.
+// ---------------------------------------------------------------------------
+function buildGlobalDicts(sources: { key: string; entity: any; field: string }[]) {
+  const dicts: any[] = [];
+  const cells: { cell: string; dictName: string; sourceName: string; field: string; agg: AggKind }[] = [];
+  for (const src of sources) {
+    for (const agg of aggKinds) {
+      const dictName = `mx_${src.key}_${agg.name}`;
+      let computation: any;
+      try {
+        computation = agg.create(src.entity, src.field);
+      } catch (e: any) {
+        allMismatches.push({ cell: `${src.key}/${agg.name}`, step: 'declare', expected: 'accepted', actual: `throw: ${e.message}` });
+        continue;
+      }
+      dicts.push(Dictionary.create({ name: dictName, type: agg.dictType, collection: false, computation }));
+      cells.push({ cell: `${src.key}/${agg.name}`, dictName, sourceName: src.entity.name!, field: src.field, agg });
+    }
+  }
+  return { dicts, cells };
+}
+
+async function makeChecker(system: any, cells: { cell: string; dictName: string; sourceName: string; field: string; agg: AggKind }[]) {
+  const emptyConventions: Record<string, unknown> = {};
+  for (const c of cells) {
+    emptyConventions[c.cell] = await system.storage.dict.get(c.dictName);
+  }
+  return async (step: string) => {
+    for (const c of cells) {
+      let actual: unknown, rows: any[];
+      try {
+        actual = await system.storage.dict.get(c.dictName);
+        rows = await system.storage.find(c.sourceName, undefined, undefined, ['*']);
+      } catch (e: any) {
+        allMismatches.push({ cell: c.cell, step, expected: 'no throw', actual: `throw: ${e.message}` });
+        continue;
+      }
+      const expected = c.agg.truth(rows, c.field, emptyConventions[c.cell]);
+      if (!near(actual, expected)) {
+        allMismatches.push({ cell: c.cell, step, expected, actual });
+      }
+    }
+  };
+}
+
+describe('combinatorial matrix exploration', () => {
+  // =========================================================================
+  // PART 1: GLOBAL host × entity-family sources × 7 aggregations
+  // =========================================================================
+  test('P1 global × {entity, filtered, filtered-computed, nested-filtered}', async () => {
+    const Task = Entity.create({
+      name: 'MxeTask',
+      properties: [
+        Property.create({ name: 'title', type: 'string' }),
+        Property.create({ name: 'status', type: 'string' }),
+        Property.create({ name: 'isActive', type: 'boolean' }),
+        Property.create({ name: 'priority', type: 'string' }),
+        Property.create({ name: 'score', type: 'number' }),
+        Property.create({ name: 'isActiveC', type: 'boolean', computed: (r: any) => r.status === 'active' }),
+      ],
+    });
+    const Active = Entity.create({ name: 'MxeActive', baseEntity: Task, matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }) });
+    const ActiveC = Entity.create({ name: 'MxeActiveC', baseEntity: Task, matchExpression: MatchExp.atom({ key: 'isActiveC', value: ['=', true] }) });
+    const HighActive = Entity.create({ name: 'MxeHighActive', baseEntity: Active, matchExpression: MatchExp.atom({ key: 'priority', value: ['=', 'high'] }) });
+
+    const sources = [
+      { key: 'entity', entity: Task, field: 'score' },
+      { key: 'filtered', entity: Active, field: 'score' },
+      { key: 'filteredComputed', entity: ActiveC, field: 'score' },
+      { key: 'nestedFiltered', entity: HighActive, field: 'score' },
+    ];
+    const { dicts, cells } = buildGlobalDicts(sources);
+    const system = new MonoSystem(new PGLiteDB());
+    system.conceptClass = KlassByName;
+    const controller = new Controller({ system, entities: [Task, Active, ActiveC, HighActive], relations: [], dict: dicts });
+    await controller.setup(true);
+    const check = await makeChecker(system, cells);
+
+    const A = await system.storage.create('MxeTask', { title: 'A', status: 'active', isActive: true, priority: 'high', score: 5 });
+    await check('s1 create member A(score5)');
+    const B = await system.storage.create('MxeTask', { title: 'B', status: 'active', isActive: true, priority: 'low', score: 20 });
+    await check('s2 create member B(score20)');
+    const C = await system.storage.create('MxeTask', { title: 'C', status: 'inactive', isActive: false, priority: 'high', score: 50 });
+    await check('s3 create non-member C(score50)');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', A.id] }), { score: 15 });
+    await check('s4 member field update A.score->15');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', A.id] }), { title: 'A2' });
+    await check('s5 member irrelevant update A.title');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', C.id] }), { status: 'active', isActive: true });
+    await check('s6 enter C');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', B.id] }), { status: 'inactive', isActive: false });
+    await check('s7 exit B');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', C.id] }), { score: 200 });
+    await check('s8 member field update C.score->200');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', A.id] }), { score: 7, isActive: false });
+    await check('s9 simultaneous field-change + exit A');
+    await system.storage.delete('MxeTask', MatchExp.atom({ key: 'id', value: ['=', C.id] }));
+    await check('s10 delete member C');
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', B.id] }), { score: 1 });
+    await check('s11 non-member field update B.score->1');
+    const D = await system.storage.create('MxeTask', { title: 'D', status: 'active', isActive: true, priority: 'high', score: 0 });
+    await check('s12 create member D(score0 boundary)');
+    await system.storage.delete('MxeTask', MatchExp.atom({ key: 'id', value: ['=', B.id] }));
+    await check('s13 delete non-member B');
+    // flip `every` purely via a member field update (no membership event)
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', D.id] }), { score: -5 });
+    await check('s14 member field update D.score->-5 (every should flip)');
+    // flip `any` purely via a member field update
+    await system.storage.update('MxeTask', MatchExp.atom({ key: 'id', value: ['=', D.id] }), { score: 500 });
+    await check('s15 member field update D.score->500 (any should flip)');
+
+    console.log(`P1 mismatches so far: ${allMismatches.length}`);
+  }, 120000);
+
+  // =========================================================================
+  // PART 2: GLOBAL host × {relation, filtered relation} × 7 aggregations
+  // =========================================================================
+  test('P2 global × relation-family sources', async () => {
+    const Worker = Entity.create({ name: 'MxrWorker', properties: [Property.create({ name: 'name', type: 'string' })] });
+    const Job = Entity.create({ name: 'MxrJob', properties: [Property.create({ name: 'title', type: 'string' })] });
+    const Assign = Relation.create({
+      source: Worker, sourceProperty: 'jobs', target: Job, targetProperty: 'workers', type: 'n:n',
+      properties: [
+        Property.create({ name: 'flag', type: 'boolean' }),
+        Property.create({ name: 'rscore', type: 'number' }),
+      ],
+    });
+    const Flagged = Relation.create({
+      name: 'MxrFlagged', baseRelation: Assign, sourceProperty: 'flaggedJobs', targetProperty: 'flaggedWorkers',
+      matchExpression: MatchExp.atom({ key: 'flag', value: ['=', true] }),
+    });
+    const sources = [
+      { key: 'relation', entity: Assign, field: 'rscore' },
+      { key: 'filteredRelation', entity: Flagged, field: 'rscore' },
+    ];
+    const { dicts, cells } = buildGlobalDicts(sources);
+    const system = new MonoSystem(new PGLiteDB());
+    system.conceptClass = KlassByName;
+    const controller = new Controller({ system, entities: [Worker, Job], relations: [Assign, Flagged], dict: dicts });
+    await controller.setup(true);
+    const check = await makeChecker(system, cells);
+    const relName = Assign.name!;
+
+    const w = await system.storage.create('MxrWorker', { name: 'w' });
+    const j1 = await system.storage.create('MxrJob', { title: 'j1' });
+    const j2 = await system.storage.create('MxrJob', { title: 'j2' });
+    const l1 = await system.storage.create(relName, { source: { id: w.id }, target: { id: j1.id }, flag: true, rscore: 10 });
+    await check('s1 link create member l1(rscore10)');
+    const l2 = await system.storage.create(relName, { source: { id: w.id }, target: { id: j2.id }, flag: false, rscore: 120 });
+    await check('s2 link create non-member l2(rscore120)');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l1.id] }), { rscore: 25 });
+    await check('s3 member link field update l1.rscore->25');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l2.id] }), { flag: true });
+    await check('s4 enter l2');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l1.id] }), { flag: false });
+    await check('s5 exit l1');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l1.id] }), { rscore: 7 });
+    await check('s6 non-member link field update');
+    await system.storage.delete(relName, MatchExp.atom({ key: 'id', value: ['=', l2.id] }));
+    await check('s7 delete member link l2');
+    // cascade: delete an endpoint entity -> link cascades
+    const j3 = await system.storage.create('MxrJob', { title: 'j3' });
+    const l3 = await system.storage.create(relName, { source: { id: w.id }, target: { id: j3.id }, flag: true, rscore: 30 });
+    await check('s8 link create member l3');
+    await system.storage.delete('MxrJob', MatchExp.atom({ key: 'id', value: ['=', j3.id] }));
+    await check('s9 cascade delete endpoint j3');
+    // isolate every/any: flip them purely via member link field updates
+    const j4 = await system.storage.create('MxrJob', { title: 'j4' });
+    const l4 = await system.storage.create(relName, { source: { id: w.id }, target: { id: j4.id }, flag: true, rscore: 30 });
+    await check('s10 link create member l4(rscore30)');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l4.id] }), { rscore: -5 });
+    await check('s11 member link field update l4.rscore->-5 (every should flip)');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l4.id] }), { rscore: 500 });
+    await check('s12 member link field update l4.rscore->500 (any should flip)');
+
+    console.log(`P2 total mismatches so far: ${allMismatches.length}`);
+  }, 120000);
+
+  // =========================================================================
+  // PART 3: PROPERTY host × {relation, filtered relation} × aggregations
+  //   (per-host-record values, ground truth from per-record relation queries)
+  // =========================================================================
+  test('P3 property host over relation & filtered relation', async () => {
+    const Job = Entity.create({ name: 'MxpJob', properties: [
+      Property.create({ name: 'title', type: 'string' }),
+      Property.create({ name: 'tscore', type: 'number' }),
+    ] });
+    const Worker = Entity.create({ name: 'MxpWorker', properties: [Property.create({ name: 'name', type: 'string' })] });
+    const Assign = Relation.create({
+      source: Worker, sourceProperty: 'jobs', target: Job, targetProperty: 'workers', type: 'n:n',
+      properties: [
+        Property.create({ name: 'flag', type: 'boolean' }),
+        Property.create({ name: 'rscore', type: 'number' }),
+      ],
+    });
+    const Flagged = Relation.create({
+      name: 'MxpFlagged', baseRelation: Assign, sourceProperty: 'flaggedJobs', targetProperty: 'flaggedWorkers',
+      matchExpression: MatchExp.atom({ key: 'flag', value: ['=', true] }),
+    });
+    // property computations on Worker
+    const propCells: { cell: string; propName: string; truth: (links: { rscore: number, flag: boolean, tscore: number }[], empty: unknown) => unknown; useFlagged: boolean }[] = [];
+    const addProp = (propName: string, type: string, computation: any, truth: (links: any[], empty: unknown) => unknown, useFlagged: boolean) => {
+      Worker.properties!.push(Property.create({ name: propName, type, computation }));
+      propCells.push({ cell: `prop/${propName}`, propName, truth, useFlagged });
+    };
+    addProp('cnt', 'number', Count.create({ property: 'jobs', callback: () => true }), ls => ls.length, false);
+    addProp('cntF', 'number', Count.create({ property: 'flaggedJobs', callback: () => true }), ls => ls.length, true);
+    addProp('sumLink', 'number', Summation.create({ property: 'jobs', attributeQuery: [['&', { attributeQuery: ['rscore'] }]] }),
+      ls => ls.reduce((a, l) => a + (l.rscore ?? 0), 0), false);
+    addProp('sumLinkF', 'number', Summation.create({ property: 'flaggedJobs', attributeQuery: [['&', { attributeQuery: ['rscore'] }]] }),
+      ls => ls.reduce((a, l) => a + (l.rscore ?? 0), 0), true);
+    addProp('sumTarget', 'number', Summation.create({ property: 'jobs', attributeQuery: ['tscore'] }),
+      ls => ls.reduce((a, l) => a + (l.tscore ?? 0), 0), false);
+    addProp('sumTargetF', 'number', Summation.create({ property: 'flaggedJobs', attributeQuery: ['tscore'] }),
+      ls => ls.reduce((a, l) => a + (l.tscore ?? 0), 0), true);
+    addProp('everyBig', 'boolean', Every.create({ property: 'jobs', attributeQuery: [['&', { attributeQuery: ['rscore'] }]], callback: (j: any) => (j['&']?.rscore ?? 0) > 5, notEmpty: false }),
+      (ls, empty) => ls.length === 0 ? empty : ls.every(l => (l.rscore ?? 0) > 5), false);
+    addProp('anyBig', 'boolean', Any.create({ property: 'jobs', attributeQuery: [['&', { attributeQuery: ['rscore'] }]], callback: (j: any) => (j['&']?.rscore ?? 0) > 100 }),
+      (ls, empty) => ls.length === 0 ? empty : ls.some(l => (l.rscore ?? 0) > 100), false);
+
+    const system = new MonoSystem(new PGLiteDB());
+    system.conceptClass = KlassByName;
+    const controller = new Controller({ system, entities: [Worker, Job], relations: [Assign, Flagged] });
+    await controller.setup(true);
+    const relName = Assign.name!;
+
+    const w = await system.storage.create('MxpWorker', { name: 'w' });
+    const emptyConv: Record<string, unknown> = {};
+    {
+      const row = await system.storage.findOne('MxpWorker', MatchExp.atom({ key: 'id', value: ['=', w.id] }), undefined, ['*']);
+      for (const c of propCells) emptyConv[c.cell] = row[c.propName];
+    }
+    const check = async (step: string) => {
+      const row = await system.storage.findOne('MxpWorker', MatchExp.atom({ key: 'id', value: ['=', w.id] }), undefined, ['*']);
+      // ground truth: all links of w with link props + target props
+      const links = await system.storage.find(relName,
+        MatchExp.atom({ key: 'source.id', value: ['=', w.id] }), undefined,
+        ['*', ['target', { attributeQuery: ['tscore'] }]]);
+      const shaped = links.map((l: any) => ({ rscore: l.rscore, flag: l.flag, tscore: l.target?.tscore }));
+      for (const c of propCells) {
+        const subset = c.useFlagged ? shaped.filter(l => l.flag === true) : shaped;
+        const expected = c.truth(subset, emptyConv[c.cell]);
+        const actual = row[c.propName];
+        if (!near(actual, expected)) allMismatches.push({ cell: c.cell, step, expected, actual });
+      }
+    };
+
+    const j1 = await system.storage.create('MxpJob', { title: 'j1', tscore: 3 });
+    const j2 = await system.storage.create('MxpJob', { title: 'j2', tscore: 4 });
+    const l1 = await system.storage.create(relName, { source: { id: w.id }, target: { id: j1.id }, flag: true, rscore: 10 });
+    await check('s1 link create flagged l1');
+    const l2 = await system.storage.create(relName, { source: { id: w.id }, target: { id: j2.id }, flag: false, rscore: 120 });
+    await check('s2 link create unflagged l2');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l1.id] }), { rscore: 25 });
+    await check('s3 link field update l1.rscore->25');
+    await system.storage.update('MxpJob', MatchExp.atom({ key: 'id', value: ['=', j1.id] }), { tscore: 9 });
+    await check('s4 target field update j1.tscore->9');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l2.id] }), { flag: true });
+    await check('s5 enter l2 (flagged)');
+    await system.storage.update(relName, MatchExp.atom({ key: 'id', value: ['=', l1.id] }), { flag: false });
+    await check('s6 exit l1');
+    await system.storage.delete(relName, MatchExp.atom({ key: 'id', value: ['=', l2.id] }));
+    await check('s7 delete link l2');
+
+    console.log(`P3 total mismatches so far: ${allMismatches.length}`);
+  }, 120000);
+
+  // =========================================================================
+  // PART 4: create/update parity for relation payload forms
+  //   invariant: state reached via update == state declared via create
+  // =========================================================================
+  test('P4 create/update parity of relation payload forms', async () => {
+    const parityIssues: Mismatch[] = [];
+    const Team = Entity.create({ name: 'MxfTeam', properties: [Property.create({ name: 'name', type: 'string' })] });
+    const UserE = Entity.create({ name: 'MxfUser', properties: [Property.create({ name: 'uname', type: 'string' })] });
+    const Membership = Relation.create({
+      source: UserE, sourceProperty: 'teams', target: Team, targetProperty: 'members', type: 'n:n',
+      properties: [Property.create({ name: 'role', type: 'string' })],
+    });
+    const Profile = Entity.create({ name: 'MxfProfile', properties: [Property.create({ name: 'bio', type: 'string' })] });
+    const UserProfile = Relation.create({
+      source: UserE, sourceProperty: 'profile', target: Profile, targetProperty: 'owner', type: '1:1',
+      properties: [Property.create({ name: 'since', type: 'string' })],
+    });
+    const Order = Entity.create({ name: 'MxfOrder', properties: [Property.create({ name: 'title', type: 'string' })] });
+    const UserOrder = Relation.create({
+      source: UserE, sourceProperty: 'orders', target: Order, targetProperty: 'buyer', type: '1:n',
+      properties: [Property.create({ name: 'note', type: 'string' })],
+    });
+    const system = new MonoSystem(new PGLiteDB());
+    system.conceptClass = KlassByName;
+    const controller = new Controller({ system, entities: [Team, UserE, Profile, Order], relations: [Membership, UserProfile, UserOrder] });
+    await controller.setup(true);
+
+    const linkState = async (userId: string) => {
+      const links = await system.storage.find(Membership.name!,
+        MatchExp.atom({ key: 'source.id', value: ['=', userId] }), undefined,
+        ['*', ['target', { attributeQuery: ['name'] }]]);
+      return links.map((l: any) => ({ team: l.target?.name, role: l.role ?? null })).sort((a: any, b: any) => (a.team || '').localeCompare(b.team || ''));
+    };
+    const profileState = async (userId: string) => {
+      const links = await system.storage.find(UserProfile.name!,
+        MatchExp.atom({ key: 'source.id', value: ['=', userId] }), undefined,
+        ['*', ['target', { attributeQuery: ['bio'] }]]);
+      return links.map((l: any) => ({ bio: l.target?.bio, since: l.since ?? null }));
+    };
+
+    const t1 = await system.storage.create('MxfTeam', { name: 'alpha' });
+
+    // n:n forms
+    const forms: { name: string; payload: (tid: string) => any }[] = [
+      { name: 'ref', payload: (tid) => [{ id: tid }] },
+      { name: 'ref+&', payload: (tid) => [{ id: tid, '&': { role: 'lead' } }] },
+      { name: 'nested+&', payload: () => [{ name: 'beta', '&': { role: 'member' } }] },
+    ];
+    for (const form of forms) {
+      try {
+        const uC = await system.storage.create('MxfUser', { uname: `c-${form.name}`, teams: form.payload(t1.id) });
+        const uU = await system.storage.create('MxfUser', { uname: `u-${form.name}` });
+        await system.storage.update('MxfUser', MatchExp.atom({ key: 'id', value: ['=', uU.id] }), { teams: form.payload(t1.id) });
+        const sC = await linkState(uC.id); const sU = await linkState(uU.id);
+        if (JSON.stringify(sC) !== JSON.stringify(sU)) {
+          parityIssues.push({ cell: `parity/n:n/${form.name}`, step: 'create-vs-update', expected: sC, actual: sU });
+        }
+      } catch (e: any) {
+        parityIssues.push({ cell: `parity/n:n/${form.name}`, step: 'CRASH', expected: 'no throw', actual: e.message });
+      }
+    }
+    // 1:1 forms
+    const p1 = await system.storage.create('MxfProfile', { bio: 'b1' });
+    const p2 = await system.storage.create('MxfProfile', { bio: 'b2' });
+    const oneForms: { name: string; payloadC: any; payloadU: any }[] = [
+      { name: 'ref', payloadC: { id: p1.id }, payloadU: { id: p2.id } },
+      { name: 'ref+&', payloadC: { id: p1.id, '&': { since: '2020' } }, payloadU: { id: p2.id, '&': { since: '2020' } } },
+      { name: 'nested', payloadC: { bio: 'nestedC' }, payloadU: { bio: 'nestedU' } },
+      { name: 'nested+&', payloadC: { bio: 'nestedC2', '&': { since: '2021' } }, payloadU: { bio: 'nestedU2', '&': { since: '2021' } } },
+    ];
+    for (const form of oneForms) {
+      let uC: any, uU: any, sC: any = 'CREATE-CRASH', sU: any = 'UPDATE-CRASH';
+      try {
+        uC = await system.storage.create('MxfUser', { uname: `c1-${form.name}`, profile: form.payloadC });
+        sC = (await profileState(uC.id)).map(s => ({ since: s.since, hasBio: !!s.bio }));
+      } catch (e: any) {
+        parityIssues.push({ cell: `parity/1:1/${form.name}/create`, step: 'CRASH', expected: 'no throw', actual: e.message });
+      }
+      try {
+        uU = await system.storage.create('MxfUser', { uname: `u1-${form.name}` });
+        await system.storage.update('MxfUser', MatchExp.atom({ key: 'id', value: ['=', uU.id] }), { profile: form.payloadU });
+        sU = (await profileState(uU.id)).map(s => ({ since: s.since, hasBio: !!s.bio }));
+      } catch (e: any) {
+        parityIssues.push({ cell: `parity/1:1/${form.name}/update`, step: 'CRASH', expected: 'no throw', actual: e.message });
+      }
+      if (typeof sC !== 'string' && typeof sU !== 'string' && JSON.stringify(sC) !== JSON.stringify(sU)) {
+        parityIssues.push({ cell: `parity/1:1/${form.name}`, step: 'create-vs-update', expected: sC, actual: sU });
+      }
+    }
+    // 1:n forms (source side, xToMany array payload)
+    const orderState = async (userId: string) => {
+      const links = await system.storage.find(UserOrder.name!,
+        MatchExp.atom({ key: 'source.id', value: ['=', userId] }), undefined,
+        ['*', ['target', { attributeQuery: ['title'] }]]);
+      return links.map((l: any) => ({ order: l.target?.title, note: l.note ?? null })).sort((a: any, b: any) => (a.order || '').localeCompare(b.order || ''));
+    };
+    const o1 = await system.storage.create('MxfOrder', { title: 'ord1' });
+    const oForms: { name: string; payload: (oid: string) => any }[] = [
+      { name: 'ref', payload: (oid) => [{ id: oid }] },
+      { name: 'ref+&', payload: (oid) => [{ id: oid, '&': { note: 'n1' } }] },
+      { name: 'nested+&', payload: () => [{ title: 'ord-new', '&': { note: 'n2' } }] },
+    ];
+    for (const form of oForms) {
+      let sC: any = 'CREATE-CRASH', sU: any = 'UPDATE-CRASH';
+      try {
+        const uC = await system.storage.create('MxfUser', { uname: `co-${form.name}`, orders: form.payload(o1.id) });
+        sC = await orderState(uC.id);
+      } catch (e: any) {
+        parityIssues.push({ cell: `parity/1:n/${form.name}/create`, step: 'CRASH', expected: 'no throw', actual: e.message.split('\n')[0] });
+      }
+      try {
+        const uU = await system.storage.create('MxfUser', { uname: `uo-${form.name}` });
+        await system.storage.update('MxfUser', MatchExp.atom({ key: 'id', value: ['=', uU.id] }), { orders: form.payload(o1.id) });
+        sU = await orderState(uU.id);
+      } catch (e: any) {
+        parityIssues.push({ cell: `parity/1:n/${form.name}/update`, step: 'CRASH', expected: 'no throw', actual: e.message.split('\n')[0] });
+      }
+      if (typeof sC !== 'string' && typeof sU !== 'string' && JSON.stringify(sC.map((s: any) => s.note)) !== JSON.stringify(sU.map((s: any) => s.note))) {
+        parityIssues.push({ cell: `parity/1:n/${form.name}`, step: 'create-vs-update', expected: sC, actual: sU });
+      }
+    }
+    allMismatches.push(...parityIssues);
+    console.log(`P4 total mismatches so far: ${allMismatches.length}`);
+  }, 120000);
+
+  // =========================================================================
+  // FINAL: compare the whole matrix against the known defect inventory
+  // =========================================================================
+  test('ZZ matrix result matches known defect inventory', () => {
+    // Known broken cells as of r6 (2026-07-09). Every entry is a real, reproduced
+    // defect documented in agentspace/output/deep-review-2026-07-09-r6-matrix.md.
+    // DO NOT add entries to hide regressions; REMOVE entries when the defect is fixed.
+    const KNOWN_BROKEN_CELLS = [
+      // r5 F-1 family: aggregations over filtered sources are blind to in-member
+      // field updates (listener registered on filtered name, events fire on base name).
+      'filtered/countCb', 'filtered/sum', 'filtered/avg', 'filtered/weighted', 'filtered/every', 'filtered/any',
+      'filteredComputed/countCb', 'filteredComputed/sum', 'filteredComputed/avg', 'filteredComputed/weighted', 'filteredComputed/every', 'filteredComputed/any',
+      'nestedFiltered/countCb', 'nestedFiltered/sum', 'nestedFiltered/avg', 'nestedFiltered/weighted', 'nestedFiltered/every', 'nestedFiltered/any',
+      'filteredRelation/countCb', 'filteredRelation/sum', 'filteredRelation/avg', 'filteredRelation/weighted', 'filteredRelation/every', 'filteredRelation/any',
+      // same family, property host over a filtered relation reading link fields
+      'prop/sumLinkF',
+      // r5 F-3 family: update drops '&' link attributes on relation replace
+      'parity/n:n/ref+&', 'parity/n:n/nested+&', 'parity/1:n/nested+&',
+      // r6 new: 1:1 '&' payload crashes at create AND update (circular structure in log serialization path)
+      'parity/1:1/ref+&/create', 'parity/1:1/ref+&/update',
+      'parity/1:1/nested+&/create', 'parity/1:1/nested+&/update',
+      // r6 new: 1:n ref+'&' from the source side crashes create ("entity undefined not found")
+      'parity/1:n/ref+&/create',
+      // r6 new: 1:n update stealing an already-linked target crashes
+      // ("column ... specified more than once"); ref+& update hits the same path
+      'parity/1:n/ref/update', 'parity/1:n/ref+&/update',
+    ].sort();
+
+    const byCell = new Map<string, Mismatch[]>();
+    for (const m of allMismatches) {
+      if (!byCell.has(m.cell)) byCell.set(m.cell, []);
+      byCell.get(m.cell)!.push(m);
+    }
+    console.log('==================== MATRIX RESULT ====================');
+    console.log(`broken cells: ${byCell.size}; total mismatch events: ${allMismatches.length}`);
+    for (const [cell, ms] of byCell) {
+      console.log(`\n[CELL] ${cell} (${ms.length} mismatches)`);
+      for (const m of ms.slice(0, 4)) {
+        console.log(`   step="${m.step}" expected=${JSON.stringify(m.expected)} actual=${JSON.stringify(m.actual)}`);
+      }
+      if (ms.length > 4) console.log(`   ... ${ms.length - 4} more`);
+    }
+    console.log('========================================================');
+
+    const actualCells = Array.from(byCell.keys()).sort();
+    const newRegressions = actualCells.filter(c => !KNOWN_BROKEN_CELLS.includes(c));
+    const fixedCells = KNOWN_BROKEN_CELLS.filter(c => !actualCells.includes(c));
+    expect(newRegressions, 'NEW broken cells (regressions) — investigate and fix').toEqual([]);
+    expect(fixedCells, 'cells now passing — remove them from KNOWN_BROKEN_CELLS to lock in the fix').toEqual([]);
+  });
+});

--- a/tests/runtime/aggregationConsistencyMatrix.spec.ts
+++ b/tests/runtime/aggregationConsistencyMatrix.spec.ts
@@ -480,29 +480,15 @@ describe('combinatorial matrix exploration', () => {
   // FINAL: compare the whole matrix against the known defect inventory
   // =========================================================================
   test('ZZ matrix result matches known defect inventory', () => {
-    // Known broken cells as of r6 (2026-07-09). Every entry is a real, reproduced
-    // defect documented in agentspace/output/deep-review-2026-07-09-r6-matrix.md.
+    // Known broken cells inventory. Every entry must be a real, reproduced defect
+    // documented in agentspace/output/ review reports.
     // DO NOT add entries to hide regressions; REMOVE entries when the defect is fixed.
-    const KNOWN_BROKEN_CELLS = [
-      // r5 F-1 family: aggregations over filtered sources are blind to in-member
-      // field updates (listener registered on filtered name, events fire on base name).
-      'filtered/countCb', 'filtered/sum', 'filtered/avg', 'filtered/weighted', 'filtered/every', 'filtered/any',
-      'filteredComputed/countCb', 'filteredComputed/sum', 'filteredComputed/avg', 'filteredComputed/weighted', 'filteredComputed/every', 'filteredComputed/any',
-      'nestedFiltered/countCb', 'nestedFiltered/sum', 'nestedFiltered/avg', 'nestedFiltered/weighted', 'nestedFiltered/every', 'nestedFiltered/any',
-      'filteredRelation/countCb', 'filteredRelation/sum', 'filteredRelation/avg', 'filteredRelation/weighted', 'filteredRelation/every', 'filteredRelation/any',
-      // same family, property host over a filtered relation reading link fields
-      'prop/sumLinkF',
-      // r5 F-3 family: update drops '&' link attributes on relation replace
-      'parity/n:n/ref+&', 'parity/n:n/nested+&', 'parity/1:n/nested+&',
-      // r6 new: 1:1 '&' payload crashes at create AND update (circular structure in log serialization path)
-      'parity/1:1/ref+&/create', 'parity/1:1/ref+&/update',
-      'parity/1:1/nested+&/create', 'parity/1:1/nested+&/update',
-      // r6 new: 1:n ref+'&' from the source side crashes create ("entity undefined not found")
-      'parity/1:n/ref+&/create',
-      // r6 new: 1:n update stealing an already-linked target crashes
-      // ("column ... specified more than once"); ref+& update hits the same path
-      'parity/1:n/ref/update', 'parity/1:n/ref+&/update',
-    ].sort();
+    //
+    // History: the r6 exploration (deep-review-2026-07-09-r6-matrix.md) found 35 broken
+    // cells (filtered-source aggregation blindness ×25, '&' link-data loss/crashes ×10).
+    // All were fixed in the same branch — the inventory is now empty and this suite
+    // acts as a pure regression guard over the whole combination space.
+    const KNOWN_BROKEN_CELLS: string[] = [].sort();
 
     const byCell = new Map<string, Mismatch[]>();
     for (const m of allMismatches) {

--- a/tests/runtime/queryDataInteraction.spec.ts
+++ b/tests/runtime/queryDataInteraction.spec.ts
@@ -925,14 +925,61 @@ describe('Get Data Interaction', () => {
             const data = result.data as any[]
             // Should be limited to 5 by fixed modifier
             expect(data.length).toBeLessThanOrEqual(5)
-            // All should be published (from fixed match) AND have views >= 500 (from user match)
-            expect(data.every((a: any) => a.status === 'published' && a.views >= 500)).toBe(true)
+            // All should have views >= 500 (from user match; fixed match filtered to published)
+            expect(data.every((a: any) => a.views >= 500)).toBe(true)
+            // dataPolicy.attributeQuery is a fixed projection: the caller-requested extra
+            // field `status` must NOT be exposed (policy wins, callers cannot widen).
+            expect(data.every((a: any) => !('status' in a))).toBe(true)
+            expect(data.every((a: any) => 'title' in a && 'author' in a && 'views' in a)).toBe(true)
             // Should be ordered by views desc (from fixed modifier)
             if (data.length > 1) {
                 for (let i = 1; i < data.length; i++) {
                     expect(data[i-1].views).toBeGreaterThanOrEqual(data[i].views)
                 }
             }
+        })
+
+        test('dataPolicy.attributeQuery caps caller projection (cannot widen to hidden fields)', async () => {
+            const Secret = Entity.create({
+                name: 'PolicySecret',
+                properties: [
+                    Property.create({ name: 'title', type: 'string' }),
+                    Property.create({ name: 'ssn', type: 'string' })
+                ]
+            })
+            const GetSecrets = Interaction.create({
+                name: 'getPolicySecrets',
+                action: GetAction,
+                data: Secret,
+                dataPolicy: DataPolicy.create({
+                    attributeQuery: ['id', 'title'] as any
+                })
+            })
+            controller = new Controller({
+                system,
+                entities: [Secret],
+                eventSources: [GetSecrets]
+            })
+            await controller.setup(true)
+            await system.storage.create('PolicySecret', { title: 't', ssn: '123-45-6789' })
+
+            // caller tries to widen the projection to the hidden field
+            const widened = await controller.dispatch(GetSecrets, {
+                user: { id: 'u1' },
+                query: { attributeQuery: ['id', 'title', 'ssn'] }
+            })
+            expect(widened.error).toBeUndefined()
+            const rows = widened.data as any[]
+            expect(rows.length).toBe(1)
+            expect(rows[0].title).toBe('t')
+            expect('ssn' in rows[0]).toBe(false)
+
+            // caller passing no attributeQuery still gets the policy projection
+            const bare = await controller.dispatch(GetSecrets, { user: { id: 'u1' }, query: {} })
+            expect(bare.error).toBeUndefined()
+            const bareRows = bare.data as any[]
+            expect(bareRows[0].title).toBe('t')
+            expect('ssn' in bareRows[0]).toBe(false)
         })
 
         test('should work with complex fixed match expressions', async () => {

--- a/tests/storage/computedRelationGuard.spec.ts
+++ b/tests/storage/computedRelationGuard.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * r5 F-4 regression: `computed` properties must only read same-row value fields.
+ *
+ * Relation data is never loaded for computed recomputation on update, so a computed
+ * function reading a relation property would look "working" on nested create and then
+ * silently flip (and persist) the wrong value on any unrelated update. The framework
+ * now enforces the contract at first use: accessing a relation property inside a
+ * computed function throws a clear error instead of corrupting data.
+ */
+import { describe, expect, test } from "vitest";
+import { Controller, Entity, KlassByName, MatchExp, MonoSystem, Property, Relation } from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+describe('computed property relation access guard', () => {
+    test('computed reading a relation property fails fast instead of silently corrupting', async () => {
+        const Team = Entity.create({ name: 'CgTeam', properties: [Property.create({ name: 'type', type: 'string' })] });
+        const User = Entity.create({
+            name: 'CgUser',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'inTech', type: 'boolean', computed: (r: any) => r.team?.type === 'tech' }),
+            ],
+        });
+        const UserTeam = Relation.create({ source: User, sourceProperty: 'team', target: Team, targetProperty: 'members', type: 'n:1' });
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Team, User], relations: [UserTeam] });
+        await controller.setup(true);
+
+        // nested create used to look "working" (payload happened to carry team.type),
+        // then an unrelated update silently flipped inTech to false. Now: fail fast.
+        await expect(
+            system.storage.create('CgUser', { name: 'A', team: { type: 'tech' } })
+        ).rejects.toThrow(/computed property "inTech" on "CgUser" accessed relation property "team"/);
+    });
+
+    test('computed over same-row fields keeps working across create and update', async () => {
+        const Task = Entity.create({
+            name: 'CgTask',
+            properties: [
+                Property.create({ name: 'status', type: 'string' }),
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean', computed: (r: any) => r.status === 'active' }),
+            ],
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [Task], relations: [] });
+        await controller.setup(true);
+
+        const t = await system.storage.create('CgTask', { status: 'active', title: 'x' });
+        let row = await system.storage.findOne('CgTask', MatchExp.atom({ key: 'id', value: ['=', t.id] }), undefined, ['*']);
+        expect(row.isActive).toBe(true);
+
+        // unrelated update must not disturb the computed value
+        await system.storage.update('CgTask', MatchExp.atom({ key: 'id', value: ['=', t.id] }), { title: 'y' });
+        row = await system.storage.findOne('CgTask', MatchExp.atom({ key: 'id', value: ['=', t.id] }), undefined, ['*']);
+        expect(row.isActive).toBe(true);
+
+        await system.storage.update('CgTask', MatchExp.atom({ key: 'id', value: ['=', t.id] }), { status: 'inactive' });
+        row = await system.storage.findOne('CgTask', MatchExp.atom({ key: 'id', value: ['=', t.id] }), undefined, ['*']);
+        expect(row.isActive).toBe(false);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three stages on this branch:

### 1. Fifth-round deep review (`agentspace/output/deep-review-2026-07-09-r5.md`)

Five parallel deep-dive explorations with minimal reproduction tests actually run for every fatal candidate: 4 reproduced fatal bugs (filtered-source aggregation blindness, `dataPolicy.attributeQuery` never enforced, update drops `&` link attributes, relation-reading `computed` silent corruption), plus reproduced important issues and a knowledge-base drift (`getValue` API doesn't exist).

### 2. Combinatorial matrix exploration (`tests/runtime/aggregationConsistencyMatrix.spec.ts` + `agentspace/output/deep-review-2026-07-09-r6-matrix.md`)

Oracle-based exhaustive exploration (~700 assertion points: incremental value == full recompute after every mutation; update state == create state). Found **35 broken cells / 144 mismatch events** including **3 new fatal crashes** beyond r5: 1:1 `&` payload crash (circular structure), 1:n `ref+&` create crash, 1:n ownership-steal update crash.

### 3. Fixes — all 7 fatal items, matrix now fully green (35 → 0 broken cells)

- **r5 F-1 (25 cells)**: `ComputationSourceMap` registers filtered-source update listeners on the physical base record name (update events never fire under filtered names); `Scheduler.resolveFilteredUpdateEvent` guards routing with same-batch membership-event dedupe + current-membership query, then rewrites the event back to the filtered name. Aggregations over filtered entities/relations now react to in-member field updates.
- **r5 F-2**: `retrieveData` enforces `dataPolicy.attributeQuery` as the fixed projection (policy wins, callers cannot widen to hidden fields) — consistent with the modifier merge direction. Existing test asserting caller-widening updated to the new contract; new negative test added.
- **r5 F-3**: `UpdateExecutor.handleUpdateReliance` passes `linkRecordData` into `addLinkFromRecord` — `&` relation attributes survive relation replacement on update.
- **r6-F1**: `createRecordDependency` no longer aliases the endpoint ref object into link data (broke the `deps[attr]['&'].target === deps[attr]` cycle that crashed every 1:1 `&` payload on `JSON.stringify`); `NewRecordData` filters link endpoint fields duplicating the just-written linkField.
- **r6-F2**: `handleCreationReliance` nests `&` data under the reverse attribute value instead of the entity record top level — 1:n `ref+&` create works.
- **r6-F3**: `flashOutCombinedRecordsAndMergedLinks` strips the replaced old link's columns from stolen endpoint rows (fixing the duplicate-column INSERT crash) and emits the old link's delete event — 1:n ownership transfer works with complete events.
- **r5 F-4**: `NewRecordData` wraps `computed` inputs in a Proxy that throws a clear error on relation-property access — the "computed reads same-row fields only" contract is now executable instead of silently corrupting persisted values. Regression tests in `tests/storage/computedRelationGuard.spec.ts`.

The matrix suite's `KNOWN_BROKEN_CELLS` inventory is emptied — it now acts as a pure regression guard over the whole (source shape × aggregation × mutation) + create/update-parity space.

Left for follow-up PRs (documented in the reports): r5 important items R-1–R-8 (large-`IN` chunking, duplicate-ref idempotency, `contains` type guard, `Scheduler.setup` atomic listener swap, partial-install recovery, dispatch deep clone, side-effect result aggregation, knowledge-base `getValue` correction) and the accumulated P2 backlog from earlier rounds.

## Testing

- ✅ `npm run check`
- ✅ `npm test` — 1733 passed / 26 skipped (full suite)
- ✅ `aggregationConsistencyMatrix.spec.ts` — 0 broken cells (was 35); control cells still green
- ✅ New regression tests: `computedRelationGuard.spec.ts` (2), `queryDataInteraction.spec.ts` dataPolicy projection cap (1), plus the 35 matrix cells acting as regressions for F-1/F-3/r6-F1/F2/F3
- ✅ Standalone crash repros re-run after fixes: 1:1 `ref+&`/`nested+&` create OK, 1:n steal update OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f2ce4f0-9157-4736-b993-03f7294206e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f2ce4f0-9157-4736-b993-03f7294206e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

