### PR TITLE
Deep code review r8: fix filtered-endpoint relation schema corruption, aggregation create-path drift, callback attributeQuery fail-fast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,7 @@ npm run build               # vite library build → dist/
 - PGLite does not support `GENERATED ALWAYS AS IDENTITY`
 - PGLite requires single-quoted string defaults
 - Avoid dynamic functions in `defaultValue`
+- The MySQL driver declares `transactions: false` — `Controller.dispatch` requires transactions and fails fast with `TransactionCapabilityError` on MySQL; use PostgreSQL/PGLite/SQLite for dispatch-driven applications
 
 ### Common pitfalls
 

--- a/agent/agentspace/knowledge/generator/api-reference.md
+++ b/agent/agentspace/knowledge/generator/api-reference.md
@@ -799,6 +799,7 @@ const userTotalScore = Property.create({
     type: 'number',
     computation: WeightedSummation.create({
         property: 'scores',  // Use property name from relation
+        attributeQuery: ['multiplier', 'points'],  // Required when callback reads fields
         callback: function(scoreRecord) {
             return {
                 weight: scoreRecord.multiplier || 1,
@@ -811,6 +812,7 @@ const userTotalScore = Property.create({
 // Global weighted summation
 const globalWeightedScore = WeightedSummation.create({
     record: ScoreRecord,
+    attributeQuery: ['difficulty', 'score'],  // Required when callback reads fields
     callback: function(record) {
         return {
             weight: record.difficulty,

--- a/agent/agentspace/knowledge/usage/00-mindset-shift.md
+++ b/agent/agentspace/knowledge/usage/00-mindset-shift.md
@@ -215,6 +215,7 @@ const Product = Entity.create({
       name: 'currentStock',
       computation: WeightedSummation.create({
         record: OrderItemRelation,
+        attributeQuery: ['quantity'],  // Required when callback reads fields
         callback: (orderItem) => ({
           weight: -1,  // Reduce inventory
           value: orderItem.quantity
@@ -225,6 +226,7 @@ const Product = Entity.create({
       name: 'totalSales',
       computation: WeightedSummation.create({
         record: OrderItemRelation,
+        attributeQuery: ['quantity'],  // Required when callback reads fields
         callback: (orderItem) => ({
           weight: 1,
           value: orderItem.quantity

--- a/agent/agentspace/knowledge/usage/04-reactive-computations.md
+++ b/agent/agentspace/knowledge/usage/04-reactive-computations.md
@@ -495,6 +495,7 @@ const Student = Entity.create({
       defaultValue: () => 0,
       computation: WeightedSummation.create({
         record: StudentGrades,
+        attributeQuery: [['target', { attributeQuery: ['credit', 'score'] }]],  // Required when callback reads fields
         callback: (relation) => ({
           weight: relation.target.credit,
           value: relation.target.score
@@ -508,6 +509,7 @@ const Student = Entity.create({
       defaultValue: () => 0,
       computation: WeightedSummation.create({
         record: StudentGrades,
+        attributeQuery: [['target', { attributeQuery: ['credit'] }]],  // Required when callback reads fields
         callback: (relation) => ({
           weight: 1,
           value: relation.target.credit
@@ -534,6 +536,7 @@ const Student = Entity.create({
       defaultValue: () => 0,
       computation: WeightedSummation.create({
         record: StudentGrades,
+        attributeQuery: [['target', { attributeQuery: ['score', 'credit'] }]],  // Required when callback reads fields
         callback: (relation) => {
           // Only count subjects with score >= 60
           if (relation.target.score >= 60) {
@@ -573,6 +576,7 @@ const Project = Entity.create({
       defaultValue: () => false,
       computation: Every.create({
         record: ProjectTasks,
+        attributeQuery: [['target', { attributeQuery: ['status'] }]],  // Required when callback reads fields
         callback: (relation) => relation.target.status === 'completed'
       })
     })
@@ -610,6 +614,7 @@ const Project = Entity.create({
       defaultValue: () => false,
       computation: Any.create({
         record: ProjectMember,
+        attributeQuery: ['role'],  // Required when callback reads fields
         callback: (relation) => relation.role === 'admin'
       })
     })
@@ -644,6 +649,7 @@ const Order = Entity.create({
       defaultValue: () => false,
       computation: Every.create({
         record: OrderItems,
+        attributeQuery: [['target', { attributeQuery: ['quantity', 'stockQuantity'] }]],  // Required when callback reads fields
         callback: (relation) => {
           const item = relation.target;
           return item.quantity > 0 && item.stockQuantity >= item.quantity;
@@ -657,6 +663,7 @@ const Order = Entity.create({
       defaultValue: () => false,
       computation: Any.create({
         record: OrderItems,
+        attributeQuery: [['target', { attributeQuery: ['quantity', 'price'] }]],  // Required when callback reads fields
         callback: (relation) => {
           const item = relation.target;
           return (item.quantity * item.price) > 1000;
@@ -1905,6 +1912,7 @@ const Post = Entity.create({
       defaultValue: () => 0,
       computation: WeightedSummation.create({
         record: PostInteractions,
+        attributeQuery: [['target', { attributeQuery: ['type'] }]],  // Required when callback reads fields
         callback: (relation) => {
           const interaction = relation.target;
           switch (interaction.type) {
@@ -1936,6 +1944,7 @@ const Post = Entity.create({
       defaultValue: () => false,
       computation: Every.create({
         record: PostComments,
+        attributeQuery: [['target', { attributeQuery: ['status'] }]],  // Required when callback reads fields
         callback: (relation) => relation.target.status === 'approved'
       })
     })
@@ -1980,6 +1989,7 @@ Property.create({
   defaultValue: () => 0,
   computation: Count.create({
     record: User,
+    attributeQuery: ['status'],  // Required when callback reads fields
     callback: (user) => user.status === 'active'
   })
 });

--- a/agent/agentspace/knowledge/usage/05-interactions.md
+++ b/agent/agentspace/knowledge/usage/05-interactions.md
@@ -1344,6 +1344,7 @@ const Order = Entity.create({
       computation: Every.create({
         record: OrderItemRelation,
         relationDirection: 'source',
+        attributeQuery: ['quantity', ['product', { attributeQuery: ['stock'] }]],  // Required when callback reads fields
         callback: function(orderItem) {
           // Check if each order item has sufficient product inventory
           return orderItem.product.stock >= orderItem.quantity;

--- a/agent/agentspace/knowledge/usage/09-filtered-entities.md
+++ b/agent/agentspace/knowledge/usage/09-filtered-entities.md
@@ -373,6 +373,7 @@ const User = Entity.create({
       defaultValue: () => 0,
       computation: WeightedSummation.create({
         record: UserPublishedPosts,
+        attributeQuery: [['target', { attributeQuery: ['viewCount'] }]],  // Required when callback reads fields
         callback: (relation) => ({
           weight: 1,
           value: relation.target.viewCount

--- a/agent/agentspace/knowledge/usage/14-api-reference.md
+++ b/agent/agentspace/knowledge/usage/14-api-reference.md
@@ -299,6 +299,7 @@ const userTotalScore = Property.create({
     defaultValue: () => 0,  // Must provide default value
     computation: WeightedSummation.create({
         record: UserScoreRelation,
+        attributeQuery: ['multiplier', 'points'],  // Required when callback reads fields
         callback: function(scoreRecord) {
             return {
                 weight: scoreRecord.multiplier || 1,
@@ -311,6 +312,7 @@ const userTotalScore = Property.create({
 // Global weighted summation
 const globalWeightedScore = WeightedSummation.create({
     record: ScoreRecord,
+    attributeQuery: ['difficulty', 'score'],  // Required when callback reads fields
     callback: function(record) {
         return {
             weight: record.difficulty,
@@ -460,6 +462,7 @@ const completedAllRequired = Property.create({
     defaultValue: () => false,  // Must provide default value
     computation: Every.create({
         record: UserCourseRelation,
+        attributeQuery: ['status'],  // Required when callback reads fields
         callback: function(courseRelation) {
             return courseRelation.status === 'completed'
         },
@@ -491,6 +494,7 @@ const hasPendingTasks = Property.create({
     defaultValue: () => false,  // Must provide default value
     computation: Any.create({
         record: UserTaskRelation,
+        attributeQuery: ['status'],  // Required when callback reads fields
         callback: function(taskRelation) {
             return taskRelation.status === 'pending'
         }

--- a/agent/agentspace/knowledge/usage/15-entity-crud-patterns.md
+++ b/agent/agentspace/knowledge/usage/15-entity-crud-patterns.md
@@ -973,6 +973,7 @@ const User = Entity.create({
       computation: Count.create({
         record: UserArticleRelation,
         direction: 'target',
+        attributeQuery: [['source', { attributeQuery: ['status'] }]],  // Required when callback reads fields
         callback: (relation) => relation.source.status !== 'deleted'
       })
     })

--- a/agent/agentspace/knowledge/usage/19-common-anti-patterns.md
+++ b/agent/agentspace/knowledge/usage/19-common-anti-patterns.md
@@ -33,6 +33,7 @@ import { Every } from 'interaqt';
 
 const allCompleted = Every.create({
   record: UserTaskRelation,
+  attributeQuery: ['status'],  // Required when callback reads fields
   callback: (relation) => relation.status === 'completed'
 });
 ```

--- a/agentspace/output/deep-review-2026-07-09-r8.md
+++ b/agentspace/output/deep-review-2026-07-09-r8.md
@@ -1,0 +1,129 @@
+# 全代码库深度 Review 报告（2026-07-09 第八轮）
+
+> **维护说明（2026-07-09）**：本报告的致命项已在同分支（`cursor/deep-code-review-r8-c6a5`）修复，回归测试见 `tests/storage/review-fixes-2026-07-09-r8.spec.ts`（4 用例）+ `tests/runtime/review-fixes-2026-07-09-r8.spec.ts`（7 用例）：
+>
+> - **F-1（新发现，已复现，schema 级腐蚀）**：以 filtered entity 为端点的 relation（`Relation.create({ source: ActiveUser, ... })`，`filteredEntityRelationValidation.spec.ts` 明确断言该声明合法），其关系属性在 `DBSetup.buildMap` 里被 `copyAttributesToFilteredEntities` **整体抹掉**——查询编译按 `resolvedBaseRecordName` 解析属性直接崩溃（`attribute activePosts not found in User`），删除 base 实体时级联清理看不到该关系、留下**孤儿 link**。修复：`populateRecordAttributes` 把 filtered 端点的关系属性同步登记到 resolved base record（copy 阶段自然回流到所有 filtered 变体）；`LinkInfo.isRelationSource` 按 resolved 名比较端点；`EntityToTableMap.getReverseAttribute` 改用属性自身的 `isSource` 判向；`validateRelations` 补齐家族级（兄弟 filtered entity 之间）属性名冲突校验。
+> - **F-2（新发现，已复现，聚合漂移）**：Global `Count`/`Every`/`Any`/`WeightedSummation` 的 **create** 增量分支直接把 mutation 事件里的局部 record（defaultValues + payload）喂给 callback；callback 读 `attributeQuery` 声明的关联数据（如 `rel.target.vip`）或 computed 列时，增量结果与全量重算漂移（实测 Count 少计、总和错误）。update 路径在 r2/F-2 已改为 findOne 全量拉取，create 一直是漏网（r3 I-9 曾点名"两种策略并存是漂移温床"但未修）。修复：create 与 update 对齐，先按 `attributeQuery` findOne 再调 callback，记录已不在时退回 fullRecompute（与 PropertyCount 的防御一致）。
+> - **F-3（r2/r3 家族收尾，已复现，静默冻结）**：内置聚合声明了 `callback` 却没有 `attributeQuery` 时——full compute 取数是 **id-only**（callback 读字段拿到 undefined）、字段 update **不注册任何监听**（`ComputationSourceMap` L365–374 对空 attributeQuery 跳过）——聚合值静默错误或永久冻结。r3 F-3 已对 `Custom` 的 records dataDep 做了 setup 期 fail-fast，四个内置聚合一直豁免。修复：`Count`/`Every`/`Any`/`WeightedSummation`（global + property）构造时抛 `ComputationProtocolError`；显式 `attributeQuery: []`（纯成员资格 callback）仍然合法，与 Custom 契约一致。同步修正了 9 处编码了该反模式的既有测试与 14 处知识库示例（`agent/agentspace/knowledge/`）。
+>
+> 修复后 `npm run check` 通过；`npm test` 全量 **1758 passed / 26 skipped**（基线 1747，净 +11：4 个 F-1 storage 回归 + 7 个 F-2/F-3 runtime 回归）。下文正文保留 review 时的原始判定。
+
+- 日期：2026-07-09
+- 基线：`main` @ `56d700ff`（PR #24 合入之后，r1–r7 的致命/重要修复全部落地）
+- 范围：`src/core`、`src/runtime`（Scheduler / migration / computations / 事务）、`src/storage/erstorage` 全量、`src/builtins`（守卫链 / Activity / 序列化）、`src/drivers`
+- 方法：四路并行深度探查（storage 全量 / runtime 引擎与 migration / computations 增量语义 / core+builtins+drivers）→ 与 r1–r7 报告**逐条去重**（本轮候选中约六成为既有遗留项的重复发现，见第四节）→ 对每个新致命候选**编写最小复现测试实际运行**（PGLiteDB）。只有「已运行复现确认」的问题列为致命；复现失败的候选明确证伪（见第五节）。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1747 passed / 26 skipped。
+
+---
+
+## 一、结论摘要
+
+经七轮修复，storage 读写主路径、对称关系、增量聚合边界、Activity/序列化、migration 均已高度收敛。本轮延续既往规律，新致命问题依然全部落在「**声明合法、测试矩阵从未走过的组合**」：filtered entity 作 relation 端点只测过 `createTables()` 成功（从未 CRUD）、聚合 create 增量路径只测过「callback 只读事件自带字段」的场景。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修） | 3 | filtered 端点关系被 setup 抹掉（查询崩溃 + 孤儿 link）、聚合 create 增量用局部事件 record（漂移）、callback 无 attributeQuery 静默冻结（fail-fast 收尾） |
+| 重要（精读，高置信度，未修） | 4 | MigrationScheduler 缺 filtered update 路由守卫、GlobalAverage/GlobalEvery 负值无守卫、combined record 挤出/搬迁不发事件（r2 遗留复确）、`computeOldRecord` 关联路径占位（S4 遗留复确） |
+| 既有遗留复确（r2–r7 已记录，本轮核实仍在） | 约 15 | 见第四节清单 |
+| 证伪 | 2 | 见第五节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认，本轮已修复）
+
+### F-1 以 filtered entity 为端点的 relation：属性被 setup 抹掉，查询崩溃、删除留孤儿 link
+
+- 位置：
+  - `src/storage/erstorage/Setup.ts` `copyAttributesToFilteredEntities`（原 L638–652）——`record.attributes = this.copyAttributes(baseRecord.attributes)` 整体**替换**，把 `populateRecordAttributes`（步骤 4）刚写到 filtered record 上的关系属性抹掉；
+  - `src/storage/erstorage/RecordQuery.ts` L31–48——查询编译统一按 `resolvedBaseRecordName` 解析属性，所以该属性本来就**必须**存在于 base record 上，而 populate 只写了 filtered record；
+  - `src/storage/erstorage/LinkInfo.ts` `isRelationSource`（原 L102–104）——按端点名字符串精确匹配，删除级联拿 base 名（'User'）匹配 link 的 filtered 端点名（'ActiveUser'）恒 false，方向判反。
+- 声明合法性：`filteredEntityRelationValidation.spec.ts` 明确断言 `source: ActiveUser` "now allowed"；`filteredEntityRelationPropertyConflict.spec.ts` 为它专门做了冲突校验。但**没有任何测试对这种 relation 做过 CRUD**——现有用例止步于 `createTables()` 成功。
+- 复现（实测输出）：`ActiveUser`（`User` 的 filtered entity）为 source 的 `activePosts` 关系：
+
+```
+setup 后 ActiveUser attributes: [name, isActive, id]      ❌ activePosts 消失
+findOne('ActiveUser', ..., ['activePosts']) →
+    Error: attribute activePosts not found in User        ❌ 查询直接崩溃
+（修 Setup 后）delete User → link 表残留 1 行              ❌ 孤儿 link（isRelationSource 方向判反）
+```
+
+- 影响：「对实体的某个子集建模关系」（活跃用户的推荐位、已发布文章的置顶记录……）是 filtered entity 的自然延伸用法。声明期零告警、建表成功，任何经由该关系的查询崩溃；删除端点实体则静默留下孤儿关系行——引用完整性腐蚀（r7 刚为此类问题建立了预言机矩阵，但矩阵没覆盖 filtered 端点关系）。
+- 修复（三处联动 + 一处校验）：
+  1. `populateRecordAttributes` 把 filtered 端点的关系属性同步登记到 resolved base record（虚拟 link 除外——filtered relation 的 `source`/`target` 属性仍由 copy 阶段统一继承 base relation 的虚拟 link）；copy 阶段自然把它回流到全部 filtered 变体；
+  2. `LinkInfo.isRelationSource` 端点名按 `resolvedBaseRecordName` 归一后比较（家族内属性名唯一由校验保证）；
+  3. `EntityToTableMap.getReverseAttribute` 改用属性自身的 `isSource` 判定方向；
+  4. `validateRelations` 新增家族级冲突校验：兄弟 filtered entity 之间（或 filtered 声明在先、base 声明在后）同名关系属性 setup 期即报错——否则两者会在共享的 base 属性命名空间里静默互相覆盖。
+- 回归：`tests/storage/review-fixes-2026-07-09-r8.spec.ts`——source 端/target 端双向查询（filtered 名与 base 名都可达）、删除 base 实体无孤儿 link、兄弟冲突 fail-fast。
+
+### F-2 Global 聚合 create 增量分支用局部事件 record，callback 读关联数据/计算列时结果漂移
+
+- 位置：`src/runtime/computations/Count.ts` L74–78、`Every.ts` L75–79、`Any.ts` L70–73、`WeightedSummation.ts` L76–81（修复前）。
+- 根因：create 事件的 `record` 是 `{...defaultValues, ...payload}`（`CreationExecutor`），不含 computed 列，关联端只有 `{id}`。update 分支在 r2 F-2 已改为 `findOne(..., attributeQuery)` 全量拉取，create 分支四个 handle 全部维持事件局部 record。`Summation`/`Average` 的 create 分支一直是 findOne——六个同族 handle 两种策略并存（r3 I-9 明确点名，一直未修）。
+- 复现（实测输出）：`Count({ record: AuthorRelation, attributeQuery: [['target', {attributeQuery: ['vip']}]], callback: rel => rel.target?.vip === true })`，创建 vip 用户的 Post：
+
+```
+增量结果: 0    ❌（事件 record 的 target 只有 {id}，读不到 vip）
+全量真值: 1
+```
+
+- 影响：所有「callback 依赖关联数据或计算列」的全局聚合在 create 时静默漂移，且**永不自愈**（后续增量都基于错误的 bound state）。这正是 r6 聚合一致性矩阵的口径盲区：矩阵的 callback 只读记录自身在 create payload 里的字段。
+- 修复：四个 handle 的 create 分支与 update 对齐——先按 `attributeQuery` findOne 全量 new record 再调 callback（`Count` 仅在声明了 callback 时增加这次查询，无 callback 路径零开销）；记录已不在（同批级联删除等竞态）时退回 `fullRecompute`，与 `PropertyCount` 的既有防御一致。
+- 回归：`tests/runtime/review-fixes-2026-07-09-r8.spec.ts`——Count 读关系 target 字段、WeightedSummation 读关联实体字段、Every/Any 读 computed 列，create/update 全路径断言与真值一致。
+
+### F-3 内置聚合 callback 无 attributeQuery：取数 id-only + update 零监听，静默冻结（fail-fast 收尾）
+
+- 位置：`src/runtime/ComputationSourceMap.ts` L365–374（merged attributeQuery 为空时不注册 update 监听）；`EntityQueryHandle.ts` L29（attributeQuery 缺省为 `[]`，取数 id-only）。
+- 复现（实测输出）：`Count({ record: Task, callback: t => t.done === true })`（无 attributeQuery）：
+
+```
+create {done:false} → count 0   ✓（碰巧对：事件 record 带 payload）
+update {done:true}  → count 0   ❌（无监听，永久冻结）
+```
+
+- 家族史：r2 F-2 对 property dataDep、r3 F-3 对 Custom 的 records dataDep 均已 fail-fast，唯独四个内置聚合的主依赖一直豁免——同一族问题第三次出现，本轮收尾。
+- 修复：`Count`/`Every`/`Any`/`WeightedSummation`（global + property 六个 handle）构造时校验：声明了 callback 而 `attributeQuery === undefined` → 抛带定位信息的 `ComputationProtocolError`；显式 `attributeQuery: []`（callback 只依赖成员资格/id/外部 dataDeps）仍然合法——契约与 Custom 完全一致。共享校验器 `assertCallbackAttributeQueryDeclared` 放在 `Computation.ts`，为将来六 handle 模板抽取预留。
+- 连带修正：9 处既有测试编码了该反模式（恒真 callback 改为去掉 callback 或显式 `attributeQuery: []`；`weightedSummation.spec.ts` 两处 callback 读字段但没声明——它们此前只测 create/delete 所以侥幸通过，正是 F-2 的活体样本）；知识库 14 处示例（`agent/agentspace/knowledge/usage/` 与 `generator/api-reference.md`）全部补上 `attributeQuery`——这些示例是代码生成管线的模板，此前每一份都会教下游生成静默冻结的聚合。
+
+---
+
+## 三、重要问题（精读判定，高置信度，本轮未修）
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| R-1 | `MigrationScheduler` 增量重算路径没有 live `Scheduler` 的 `resolveFilteredUpdateEvent` 守卫 | `migration.ts` L3220–3327 vs `Scheduler.ts` L403–459 | `propagateOutputEvents: true` 的链式 rebuild 涉及 filtered entity 时，同批 membership + 字段 update 可能被双计或路由到错误 recordName。常规迁移走全量重算不受影响；建议迁移增量路径复用 live 守卫或降级为全量 |
+| R-2 | `GlobalAverage`/`GlobalEvery` 聚合计数可为负且无守卫 | `Average.ts` L103–135、`Every.ts` L99–111 | `GlobalCount`（`count < 0` 即抛）与 `PropertyAverage`（负 count 检测）都有 fail-fast，这两处没有——状态失步时产出 NaN/错误布尔而非报错。六 handle 模板抽取时一并对齐 |
+| R-3 | combined record 挤出/搬迁不发事件 | `RecordQueryAgent.ts` L137、L225–234 | r2 I-7/I-9 遗留，本轮 storage 复查确认仍在；该路径仅显式 `mergeLinks` 配置可达（`MonoSystem.setup` 未暴露），维持「先决策 mergeLinks 去留」结论 |
+| R-4 | `computeOldRecord` 对关联路径返回 `{...newRecord}` 占位 | `Scheduler.ts` L512–518（带 FIXME） | S4/r5 I-16 遗留复确。关联实体变更合成的宿主 update 事件中 `oldRecord` 是现值副本，依赖 old/new diff 的成员资格判断可能误判为 `none`。内置聚合的增量路径都重查关系行所以未实际中招，但对自定义 incremental handle 是暗雷 |
+
+## 四、既有遗留项复确（r2–r7 已记录，本轮四路探查再次命中，不重复展开）
+
+本轮子探查产出的候选中约六成与既往报告重复，逐条比对后确认以下遗留项**仍然存在**（编号沿用原报告）：
+
+- **生命周期边缘**：`Scheduler.setup` 先注销后注册、中途失败留下零监听系统（r5 R-4）；migration `succeeded` 落账早于 `scheduler.setup(false)`（r3 R-6）；`setup(true)` 半途失败进 `MigrationBaselineError` 死角（r5 R-5）。
+- **驱动层**：MySQL `transactions: false`——dispatch 全线不可用（r2 已记录）；SQLite/MySQL `getAutoId` 读-改-写非原子（r2 I-17，SQLite 被单进程事务队列缓解）；`number` 类型 SQLite/MySQL 映射 `INT` vs PG/PGLite `DOUBLE PRECISION`（r2 驱动类型映射项）；boolean 写侧不归一化（r1 R-6 读侧已修，写侧遗留）。
+- **语义/契约**：查询结果丢弃 SQL NULL（键缺失而非 `null`，r4 I-1，属 API 行为变更需评审）；x:n 谓词分页退化为全量拉取 + 内存分页（r3 I-2）、扇出 orderBy 取代表行语义（r1 I-7）；`MatchExp.fromObject` 类型签名与实现矛盾（r3 I-1）；`dispatch` 默认吞错返回 `{error}`（既定 API 语义）。
+- **builtins 弱校验族**：非 isRef 的 Entity payload `base` 接受任意对象（r7 I-14 弱校验矩阵）；独立 Interaction 的 `userRef`/Entity `itemRef` 静默不写（r7 I-11/I-13）；Activity 首步 guard 未接 `checkUserRef`（isRef attributive 在首步抛错，fail-closed 但破坏合法模式）；`Payload.stringify`/`PayloadItem.stringify`（丢 `itemRef`）/`DataPolicy.stringify` 未走统一 `stringifyAttribute` 管线、`core/init.ts` 漏注册 `EventSource`（r1 I-10 序列化往返项，r4 只修了 `Interaction.stringify` 与 builtins 注册）。
+- **信任边界**：`func::` + `new Function` 反序列化即代码执行（r3 I-16——序列化图与应用源码同信任级时可接受，文档化信任边界仍未做）。
+- **性能**：global dict 变更触发依赖它的每个 property 计算宿主的全表 `['*']` 扫描（S3）；`deleteDifferentTableReliance` 事件回填 O(n×m)（r2 记录）。
+- **最高投入产出比的债务**：六聚合 handle 共享模板抽取——r1 至今累计 **15+ 个具体缺陷**（本轮 F-2/F-3 又 +2 族）全部源于六 handle 手工同步漂移。本轮已把 create/update 取数策略与 callback 校验统一，抽取的前置条件比以往任何时候都好。
+
+## 五、本轮证伪的候选
+
+| 候选 | 证伪依据 |
+|------|----------|
+| `resolveRootBaseRecordNameAndMatchExpression` 对「有 baseEntity 无 matchExpression」的实体 `undefined.and()` 崩溃（storage 探查 #9） | 实测 `Entity.create({ baseEntity: User })` 不带 matchExpression，`DBSetup` + `createTables()` 正常完成，无崩溃 |
+| 「`copyAttributesToFilteredEntities` 抹掉属性只影响 filtered 名下查询」 | 实际更糟：查询编译统一走 resolved base 名，base 上从来就没有该属性——即 F-1 不是 copy 一处的 bug，而是 populate/copy/LinkInfo 三处对「filtered 端点」这一合法形态的系统性缺失 |
+
+## 六、修复优先级建议（遗留项）
+
+1. **六聚合 handle 模板抽取**（含 R-2 负值守卫对齐）——累计缺陷最多、本轮已铺平前置条件；
+2. R-1 迁移增量路径的 filtered 路由守卫（或文档化「filtered 链式 rebuild 走全量」）；
+3. 生命周期边缘三件套（scheduler.setup 原子切换 / migration 终态 phase / install 半途恢复）；
+4. 序列化往返收尾（Payload/PayloadItem/DataPolicy/EventSource）；
+5. 驱动一致性（number 类型映射统一、MySQL 事务实现或文档化不支持）。
+
+## 附录：复现要点（验证用）
+
+- F-1：`Relation.create({ source: FilteredEntity, sourceProperty, target, targetProperty })` → `DBSetup` → 检查 `setup.map.records[base].attributes` 是否含 sourceProperty；`findOne(filteredName, ..., [[sourceProperty, {...}]])`；`delete(baseName, ...)` 后查 link 表残留。
+- F-2：聚合 record 为 relation、callback 读 `target.<field>`、`attributeQuery: [['target', {attributeQuery: [field]}]]`，create 后对比 dict 值与全量真值。
+- F-3：聚合 callback 读字段但不声明 attributeQuery，create（碰巧对）→ update（冻结）；修复后 setup 即抛 `ComputationProtocolError`。

--- a/agentspace/output/deep-review-2026-07-09-r8.md
+++ b/agentspace/output/deep-review-2026-07-09-r8.md
@@ -1,5 +1,20 @@
 # 全代码库深度 Review 报告（2026-07-09 第八轮）
 
+> **维护说明二（2026-07-09 追加）**：本报告第三节（R-1~R-4）与第六节优先级清单（1~5）的**显著改进项已在同分支全部完成**：
+>
+> - **优先级 1 · 六聚合 handle 模板抽取（含 R-2）**：新增 `src/runtime/computations/aggregationTemplate.ts`——`GlobalRecordsAggregationHandle` / `PropertyRelationAggregationHandle` 收敛全部共享骨架（事件守卫、拉全记录、竞态防御、逐项绑定状态复位、负值守卫入口）；六个聚合（12 个 handle，原 ~1440 行）只声明「单项贡献 / 增量应用 / 全量落盘」三件事（净 -700 行）。绑定状态名与形状全部保留（兼容既有部署）。顺带统一了历史漂移：负值守卫补齐到 GlobalAverage/GlobalEvery/GlobalAny/PropertyEvery/PropertyAny，x:n 断言补齐到 PropertyEvery（原 Any 独有），attributeQuery 非空校验补齐到 PropertySum/PropertyAverage（原 global 独有），create 路径的 `&` 一律挂载回查后的关系记录（原 Count/Every/Any 挂事件局部 record）。
+> - **优先级 2 · R-1**：`MigrationScheduler.runIncrementalRecompute` 复用 live Scheduler 的 `resolveFilteredUpdateEvent` 守卫（该方法从 private 改为共享并注明用途），filtered 源的链式 rebuild 不再可能双计成员资格+字段更新或路由 stay-out 记录。
+> - **优先级 3 · 生命周期三件套**（回归测试 `tests/runtime/review-improvements-2026-07-09.spec.ts`，3 用例）：`Scheduler.setup` 改为**原子切换**（先完整构建新 listener 再注销旧的，构建失败不再留下零监听的静默系统，r5 R-4）；`Controller.setup(true)` 半途失败抛带恢复指引的 `SchedulerError`（指向重跑 install，不再落进误导性的 `MigrationBaselineError` 死角，r5 R-5）；`Controller.migrate` 后的 `scheduler.setup` 失败同样抛明确指引（「数据库已迁移完成，修复后 setup(false)，不要重跑迁移」，r3 R-6）。
+> - **优先级 4 · 序列化往返收尾**（回归测试 `tests/builtins/serialization-r8.spec.ts`，3 用例）：`Payload.stringify`/`PayloadItem.stringify`（itemRef 不再丢失）/`DataPolicy.stringify`（match 函数编码为 func::）全部走统一 `stringifyInstance` 管线；`EventSource` 注册进 `core/init.ts`、补齐 `static public`（含全部生命周期回调）、stringify/parse 与统一契约对齐。
+> - **优先级 5 · 驱动一致性**（回归测试 `tests/storage/driverIdAllocation.spec.ts`；MySQL 侧对真实 MariaDB 10.11 实测验证）：SQLite `getAutoId` 改单语句 UPSERT（唯一索引 IF NOT EXISTS 兼容旧表）；MySQL `getAutoId` 改 `ON DUPLICATE KEY UPDATE + LAST_INSERT_ID(expr)`（两语句对用本地分配链防会话交错——修复前实测并发 30 次分配全部撞同一 id）；MySQL 建库路径参数化/反引号转义；MySQL 事务按「文档化不支持」处置（AGENTS.md + 驱动 capability note，dispatch 已 fail-fast）；SQLite `number → INT` 经核实为非问题（动态类型按值存储，注释文档化，不改声明避免触发存量 schema 迁移）。
+> - **R-3**：以预言机测试固化 combined record 挤出/搬迁的**正确事件语义**（物理行搬迁不发实体级事件、只发 link 事实——`tests/storage/combinedRecordEvents.spec.ts` 2 用例，两条路径实测事件完整），两个函数补上语义注释；`mergeLinks` 的去留仍是产品决策（参数未从 MonoSystem 暴露）。
+> - **R-4**：删除 `computeOldRecord` 占位（FIXME 兑现）——关联路径合成事件的 `oldRecord` 如实置 undefined（真实快照在 `relatedMutationEvent` 上），不再用现值副本冒充；global dict 扇出事件的 `oldRecord` 改为独立副本防别名污染。
+> - **附带快速项**：`MatchExp.fromObject` 签名与实现对齐（原始相等值 + 空对象 fail-fast，r3 I-1）；`deleteDifferentTableReliance` 事件回填只扫描本级新增区间（消除 O(n×m)）；`decodeFunctionValues`/`createInstances` 文档化 `func::`/new Function 信任边界（r3 I-16）。
+>
+> **有意不做（需维护者决策，非本轮遗漏）**：SQL NULL 键缺失语义（API 行为变更需评审，r4 I-1）；x:n 谓词分页/orderBy 代表行（查询编译器级重设计，r3 I-2）；global dict 变更触发宿主全表扫描（需要依赖粒度追踪设计，S3）；`dispatch` 默认吞错返回 `{error}`（既定 API 语义）；payload `base` 弱校验矩阵与 `userRef`/Entity `itemRef` 死 API（行为契约变更家族，r7 I-11~I-14，现状已有测试固化）；MySQL 事务的**实现**路线（本轮选择文档化不支持）。
+>
+> 完成后 `npm run check` 通过；`npm test` 全量 **1768 passed / 26 skipped**（r8 致命修复后基线 1758，净 +10 回归用例：生命周期 3 + 序列化 3 + id 分配 2 + combined 事件预言机 2）。
+>
 > **维护说明（2026-07-09）**：本报告的致命项已在同分支（`cursor/deep-code-review-r8-c6a5`）修复，回归测试见 `tests/storage/review-fixes-2026-07-09-r8.spec.ts`（4 用例）+ `tests/runtime/review-fixes-2026-07-09-r8.spec.ts`（7 用例）：
 >
 > - **F-1（新发现，已复现，schema 级腐蚀）**：以 filtered entity 为端点的 relation（`Relation.create({ source: ActiveUser, ... })`，`filteredEntityRelationValidation.spec.ts` 明确断言该声明合法），其关系属性在 `DBSetup.buildMap` 里被 `copyAttributesToFilteredEntities` **整体抹掉**——查询编译按 `resolvedBaseRecordName` 解析属性直接崩溃（`attribute activePosts not found in User`），删除 base 实体时级联清理看不到该关系、留下**孤儿 link**。修复：`populateRecordAttributes` 把 filtered 端点的关系属性同步登记到 resolved base record（copy 阶段自然回流到所有 filtered 变体）；`LinkInfo.isRelationSource` 按 resolved 名比较端点；`EntityToTableMap.getReverseAttribute` 改用属性自身的 `isSource` 判向；`validateRelations` 补齐家族级（兄弟 filtered entity 之间）属性名冲突校验。

--- a/src/builtins/interaction/Data.ts
+++ b/src/builtins/interaction/Data.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues, stringifyInstance } from '@core';
 
 // DataPolicy - defines fixed constraints for data fetching in interactions
 export interface DataPolicyInstance extends IInstance {
@@ -65,19 +65,10 @@ export class DataPolicy implements DataPolicyInstance {
     return instance;
   }
   
+  // CAUTION 必须走统一的 stringifyInstance 管线：match 常见形态是函数（GetAction 的动态过滤），
+  //  手写 JSON.stringify 会把函数静默丢成 undefined，round-trip 后 dataPolicy 失去过滤语义。
   static stringify(instance: DataPolicyInstance): string {
-    const args: DataPolicyCreateArgs = {};
-    if (instance.match !== undefined) args.match = instance.match;
-    if (instance.modifier !== undefined) args.modifier = instance.modifier;
-    if (instance.attributeQuery !== undefined) args.attributeQuery = instance.attributeQuery;
-    
-    const data: SerializedData<DataPolicyCreateArgs> = {
-      type: 'DataPolicy',
-      options: instance._options,
-      uuid: instance.uuid,
-      public: args
-    };
-    return JSON.stringify(data);
+    return stringifyInstance(this, instance);
   }
   
   static clone(instance: DataPolicyInstance, deep: boolean): DataPolicyInstance {

--- a/src/builtins/interaction/Payload.ts
+++ b/src/builtins/interaction/Payload.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, decodeFunctionValues } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues, stringifyInstance } from '@core';
 import { PayloadItemInstance } from './PayloadItem.js';
 
 export interface PayloadInstance extends IInstance {
@@ -48,16 +48,10 @@ export class Payload implements PayloadInstance {
     return instance;
   }
   
+  // CAUTION 必须走统一的 stringifyInstance 管线：items 编码为 uuid:: 引用，
+  //  否则 graph round-trip 后 items 变成与 PayloadItem 实例失去身份关联的裸对象。
   static stringify(instance: PayloadInstance): string {
-    const data: SerializedData<PayloadCreateArgs> = {
-      type: 'Payload',
-      options: instance._options,
-      uuid: instance.uuid,
-      public: {
-        items: instance.items
-      }
-    };
-    return JSON.stringify(data);
+    return stringifyInstance(this, instance);
   }
   
   static clone(instance: PayloadInstance, deep: boolean): PayloadInstance {

--- a/src/builtins/interaction/PayloadItem.ts
+++ b/src/builtins/interaction/PayloadItem.ts
@@ -1,4 +1,4 @@
-import { IInstance, SerializedData, generateUUID, decodeFunctionValues, EntityInstance } from '@core';
+import { IInstance, SerializedData, generateUUID, decodeFunctionValues, stringifyInstance, EntityInstance } from '@core';
 import { AttributiveInstance, AttributivesInstance } from './Attributive.js';
 
 export interface PayloadItemInstance extends IInstance {
@@ -103,23 +103,11 @@ export class PayloadItem implements PayloadItemInstance {
     return instance;
   }
   
+  // CAUTION 必须走统一的 stringifyInstance 管线（以 static public 为单一事实来源）：
+  //  base/itemRef 编码为 uuid:: 引用。此前手写字段清单漏掉了 itemRef，
+  //  round-trip 后 activity 的 ref 绑定静默丢失。
   static stringify(instance: PayloadItemInstance): string {
-    const args: PayloadItemCreateArgs = {
-      name: instance.name,
-      base: instance.base,
-      isCollection: instance.isCollection,
-      required: instance.required,
-      isRef: instance.isRef,
-      type: instance.type,
-    };
-    
-    const data: SerializedData<PayloadItemCreateArgs> = {
-      type: 'PayloadItem',
-      options: instance._options,
-      uuid: instance.uuid,
-      public: args
-    };
-    return JSON.stringify(data);
+    return stringifyInstance(this, instance);
   }
   
   static clone(instance: PayloadItemInstance, deep: boolean): PayloadItemInstance {

--- a/src/core/EventSource.ts
+++ b/src/core/EventSource.ts
@@ -1,4 +1,5 @@
 import { IInstance, generateUUID, SerializedData } from './interfaces.js';
+import { decodeFunctionValues, stringifyInstance } from './utils.js';
 import { EntityInstance } from './Entity.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `this` is bound at runtime by Controller; core layer cannot reference it
@@ -74,6 +75,46 @@ export class EventSource<TArgs = unknown, TResult = void> implements EventSource
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous collection
   static instances: EventSourceInstance<any, any>[] = [];
 
+  // CAUTION public 是 stringifyInstance 的单一事实来源：所有回调都必须列出，
+  //  否则序列化会静默丢弃 guard/resolve 等行为定义，round-trip 后得到残缺实例。
+  static public = {
+    name: {
+      type: 'string' as const,
+      required: true as const,
+      collection: false as const,
+    },
+    entity: {
+      type: 'Entity' as const,
+      required: true as const,
+      collection: false as const,
+    },
+    guard: {
+      type: 'function' as const,
+      required: false as const,
+      collection: false as const,
+    },
+    mapEventData: {
+      type: 'function' as const,
+      required: false as const,
+      collection: false as const,
+    },
+    resolve: {
+      type: 'function' as const,
+      required: false as const,
+      collection: false as const,
+    },
+    afterDispatch: {
+      type: 'function' as const,
+      required: false as const,
+      collection: false as const,
+    },
+    postCommit: {
+      type: 'function' as const,
+      required: false as const,
+      collection: false as const,
+    },
+  };
+
   static create<TArgs = unknown, TResult = void>(
     args: EventSourceCreateArgs<TArgs, TResult>,
     options?: { uuid?: string }
@@ -97,17 +138,10 @@ export class EventSource<TArgs = unknown, TResult = void> implements EventSource
     return data !== null && typeof data === 'object' && typeof (data as IInstance).uuid === 'string';
   }
 
+  // CAUTION 必须走统一的 stringifyInstance 管线：entity 编码为 uuid:: 引用、回调编码为 func::，
+  //  否则 graph round-trip（createInstances）无法还原实例身份与行为。
   static stringify(instance: EventSourceInstance): string {
-    const data: SerializedData<EventSourceCreateArgs> = {
-      type: 'EventSource',
-      options: instance._options,
-      uuid: instance.uuid,
-      public: {
-        name: instance.name,
-        entity: instance.entity,
-      }
-    };
-    return JSON.stringify(data);
+    return stringifyInstance(this, instance as unknown as IInstance);
   }
 
   static clone(instance: EventSourceInstance, deep: boolean): EventSourceInstance {
@@ -122,8 +156,10 @@ export class EventSource<TArgs = unknown, TResult = void> implements EventSource
     });
   }
 
+  // 与其他 Klass 的 parse 契约一致：还原 func:: 编码的回调、保持 uuid 身份；
+  // uuid:: 引用（entity）需要 graph 管线（createInstances）才能解析。
   static parse(json: string): EventSourceInstance {
     const data: SerializedData<EventSourceCreateArgs> = JSON.parse(json);
-    return this.create(data.public, data.options);
+    return this.create(decodeFunctionValues(data.public), { ...data.options, uuid: data.uuid });
   }
 }

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -19,6 +19,7 @@ import { SideEffect } from './SideEffect.js';
 import { Dictionary } from './RealDictionary.js';
 import { ScopedSequence } from './ScopedSequence.js';
 import { BoolAtomData, BoolExpressionData } from './BoolExp.js';
+import { EventSource } from './EventSource.js';
 
 const klassesToRegister = [
   Entity,
@@ -43,6 +44,7 @@ const klassesToRegister = [
   ScopedSequence,
   BoolAtomData,
   BoolExpressionData,
+  EventSource,
 ];
 
 klassesToRegister.forEach(klass => {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -75,6 +75,11 @@ export function stringifyInstance(
 
 // 递归还原 `func::` 编码的函数。单个实例的 parse 只能还原函数；
 // `uuid::` 引用需要完整的实例集合才能解析（见 createInstances）。
+//
+// SECURITY 信任边界：`func::` 的还原通过 `new Function` 执行序列化文本，等价于执行任意代码。
+//  序列化的实例图（stringifyAllInstances 的产物、migration manifest 等）必须与应用源码同信任级：
+//  只能来自你自己构建/部署的制品。绝不能把来自网络请求、用户上传、不可信存储的 JSON
+//  喂给 createInstancesFromString / Klass.parse——那等于给对方远程代码执行能力。
 export function decodeFunctionValues<T>(value: T): T {
   if (typeof value === 'string' && value.startsWith('func::')) {
     return new Function('return ' + value.substring(6))() as T;
@@ -164,6 +169,8 @@ export function createInstancesFromString(objStr: string) {
 // 依赖引用按需递归创建；循环引用（如 property.computation -> relation -> entity ->
 // property）通过延迟回填解决：先以 undefined 占位创建，被引用实例创建完成后再赋值。
 // 未注册的类型、无法解析的引用、重复 uuid 一律抛错（fail-closed，不静默丢数据）。
+//
+// SECURITY 输入必须与应用源码同信任级（`func::` 还原会执行任意代码，见 decodeFunctionValues）。
 export function createInstances(objects: SerializedInstanceInput[]) {
   const dataByUUID = new Map<string, SerializedInstanceInput>();
   for (const object of objects) {

--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -3,19 +3,40 @@ import mysql, {type Connection, type ConnectionOptions, RowDataPacket} from 'mys
 
 class IDSystem {
     constructor(public db: Database) {}
-    setup() {
-        return this.db.scheme(`CREATE Table IF NOT EXISTS _IDS_ (last INTEGER, name TEXT)`)
-    }
-    async getAutoId(recordName: string) {
-        const lastId =  (await this.db.query<{last: number}>( `SELECT last FROM "_IDS_" WHERE name = '${recordName}'`, [], `finding last id of ${recordName}` ))[0]?.last
-        const newId = (lastId || 0) +1
-        const name =`set last id for ${recordName}: ${newId}`
-        if (lastId === undefined) {
-            await this.db.scheme(`INSERT INTO "_IDS_" (name, last) VALUES ('${recordName}', ${newId})`, name)
-        } else {
-            await this.db.update(`UPDATE "_IDS_" SET last = ? WHERE name = ?`, [newId, recordName], undefined, name)
+    async setup() {
+        // name 必须有唯一约束（原子 UPSERT 依赖它）；MySQL 的 TEXT 不能做主键，用定长 VARCHAR。
+        await this.db.scheme(`CREATE Table IF NOT EXISTS "_IDS_" (last INTEGER, name VARCHAR(191), PRIMARY KEY (name))`)
+        // 兼容旧版建出的无约束 _IDS_ 表：检测到缺主键时补齐。
+        const primaryKey = await this.db.query<{ cnt: number }>(
+            `SELECT COUNT(1) AS cnt FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = '_IDS_' AND index_name = 'PRIMARY'`,
+            [],
+            'check _IDS_ primary key'
+        )
+        if (!primaryKey[0]?.cnt) {
+            await this.db.scheme(`ALTER TABLE "_IDS_" MODIFY name VARCHAR(191), ADD PRIMARY KEY (name)`)
         }
-        return newId as unknown as string
+    }
+    // CAUTION LAST_INSERT_ID() 是会话级的，而「UPSERT + SELECT」是两条语句：同一连接上并发的
+    //  getAutoId 交错执行会让两次 SELECT 读到同一个值（实测复现）。用本地分配链把两条语句
+    //  串成不可交错的对；跨连接/跨进程由 UPSERT 的原子性 + 会话隔离保证。
+    private allocating: Promise<unknown> = Promise.resolve()
+    async getAutoId(recordName: string) {
+        const allocation = this.allocating.then(async () => {
+            // 原子 UPSERT：此前的「SELECT 再 INSERT/UPDATE」读-改-写在并发下会分配重复 id；
+            //  recordName 一律走参数绑定。LAST_INSERT_ID(expr) 是 MySQL 的会话级取值惯用法：
+            //  插入分支把会话值置为 1，冲突分支置为 last+1。
+            await this.db.update(
+                `INSERT INTO "_IDS_" (name, last) VALUES (?, LAST_INSERT_ID(1))
+ON DUPLICATE KEY UPDATE last = LAST_INSERT_ID(last + 1)`,
+                [recordName],
+                undefined,
+                `allocate next id for ${recordName}`
+            )
+            const rows = await this.db.query<{ id: number }>(`SELECT LAST_INSERT_ID() AS id`, [], `read allocated id for ${recordName}`)
+            return rows[0].id as unknown as string
+        })
+        this.allocating = allocation.catch(() => {})
+        return allocation
     }
 }
 
@@ -57,12 +78,15 @@ export class MysqlDB implements Database{
         })
         await bootstrapConnection.connect()
         try {
-            const [rows] = await bootstrapConnection.query(`SHOW DATABASES LIKE '${this.database}'`)
+            // CAUTION 库名不能字符串拼接进 SQL：LIKE 走参数绑定，标识符用反引号转义
+            //  （bootstrap 连接尚未 SET ANSI_QUOTES，双引号不可用）。
+            const quotedDatabase = `\`${this.database.replace(/`/g, '``')}\``
+            const [rows] = await bootstrapConnection.query(`SHOW DATABASES LIKE ?`, [this.database])
             if ((rows as RowDataPacket[]).length === 0) {
-                await bootstrapConnection.query(`CREATE DATABASE ${this.database}`)
+                await bootstrapConnection.query(`CREATE DATABASE ${quotedDatabase}`)
             } else if (forceDrop) {
-                await bootstrapConnection.query(`DROP DATABASE ${this.database}`)
-                await bootstrapConnection.query(`CREATE DATABASE ${this.database}`)
+                await bootstrapConnection.query(`DROP DATABASE ${quotedDatabase}`)
+                await bootstrapConnection.query(`CREATE DATABASE ${quotedDatabase}`)
             }
         } finally {
             await bootstrapConnection.end()

--- a/src/drivers/SQLite.ts
+++ b/src/drivers/SQLite.ts
@@ -5,19 +5,22 @@ import {Database, DatabaseLogger, EntityIdRef, ROW_ID_ATTR, asyncInteractionCont
 
 class IDSystem {
     constructor(public db: Database) {}
-    setup() {
-        return this.db.scheme(`CREATE Table IF NOT EXISTS _IDS_ (last INTEGER, name TEXT)`)
+    async setup() {
+        await this.db.scheme(`CREATE Table IF NOT EXISTS _IDS_ (last INTEGER, name TEXT)`)
+        // 原子 UPSERT 依赖 name 上的唯一索引；IF NOT EXISTS 同时兼容旧版建出的无约束 _IDS_ 表。
+        await this.db.scheme(`CREATE UNIQUE INDEX IF NOT EXISTS "_IDS__name_unique" ON _IDS_ (name)`)
     }
     async getAutoId(recordName: string) {
-        const lastId =  (await this.db.query<{last: number}>( `SELECT last FROM _IDS_ WHERE name = '${recordName}'`, [], `finding last id of ${recordName}` ))[0]?.last
-        const newId = (lastId || 0) +1
-        const name =`set last id for ${recordName}: ${newId}`
-        if (lastId === undefined) {
-            await this.db.scheme(`INSERT INTO _IDS_ (name, last) VALUES ('${recordName}', ${newId})`, name)
-        } else {
-            await this.db.update(`UPDATE _IDS_ SET last = ? WHERE name = ?`, [newId, recordName], undefined, name)
-        }
-        return newId as unknown as string
+        // CAUTION 原子 UPSERT：此前的「SELECT 再 INSERT/UPDATE」读-改-写在并发下会分配重复 id；
+        //  recordName 一律走参数绑定（与 PostgreSQL 驱动的参数化路径一致）。
+        const rows = await this.db.query<{ last: number }>(
+            `INSERT INTO _IDS_ (name, last) VALUES (?, 1)
+ON CONFLICT(name) DO UPDATE SET last = last + 1
+RETURNING last`,
+            [recordName],
+            `allocate next id for ${recordName}`
+        )
+        return rows[0].last as unknown as string
     }
 }
 
@@ -191,6 +194,9 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
         } else if (type === 'boolean') {
             return 'INT(2)'
         } else if(type === 'number'){
+            // CAUTION SQLite 是动态类型（type affinity）：INT 亲和的列写入 2.5 仍原样存为 REAL，
+            //  不会像 PG/MySQL 的 INT 那样报错或截断，所以 number 在 SQLite 上没有精度问题。
+            //  保持 INT 声明是为了既有部署的 schema/manifest 兼容（改声明会触发迁移 diff）。
             return "INT"
         }else if(type === 'timestamp'){
             return "INT"

--- a/src/runtime/Controller.ts
+++ b/src/runtime/Controller.ts
@@ -15,7 +15,7 @@ import { RealTimeHandles } from "./computations/RealTime.js";
 import { StateMachineHandles } from "./computations/StateMachine.js";
 import { CustomHandles } from "./computations/Custom.js";
 import { ScopedSequenceHandles } from "./computations/ScopedSequence.js";
-import { SideEffectError } from "./errors/index.js";
+import { SchedulerError, SideEffectError } from "./errors/index.js";
 import { assert } from "./util.js";
 import { asyncEffectsContext } from "./asyncEffectsContext.js";
 import { asyncInteractionContext } from "./asyncInteractionContext.js";
@@ -268,7 +268,21 @@ export class Controller {
         }
         await this.system.setup(this.entities, this.relations, states, { install, internalRequirements })
         const nextManifest = createMigrationManifest(this)
-        await this.scheduler.setup(install)
+        try {
+            await this.scheduler.setup(install)
+        } catch (error) {
+            // CAUTION install 半途失败恢复路径：此时表已创建、manifest 尚未写入，
+            //  直接重试 setup(false) 会撞上误导性的 MigrationBaselineError（有数据无 manifest）。
+            //  用明确的错误告诉调用方正确的恢复动作是修复后重跑 setup(true)（install 会重建表）。
+            throw new SchedulerError(
+                'Initial install failed after database tables were created but before the migration manifest was written. ' +
+                'Fix the underlying error and re-run setup(true) (install recreates tables from scratch); do NOT call setup(false) — it will fail with a misleading MigrationBaselineError.',
+                {
+                    schedulingPhase: 'install-scheduler-setup',
+                    causedBy: error instanceof Error ? error : new Error(String(error))
+                }
+            )
+        }
         if (install) {
             await writeMigrationManifest(this, nextManifest)
         }
@@ -495,7 +509,21 @@ export class Controller {
             if (migrationRun) await migrationSystem.finishMigration?.(migrationRun.id, 'failed', error)
             throw error
         }
-        await this.scheduler.setup(false)
+        try {
+            await this.scheduler.setup(false)
+        } catch (error) {
+            // CAUTION 数据库已完成迁移（manifest 已提交、migration log 已记 succeeded），
+            //  失败的只是本进程的计算监听层。必须用明确的错误告诉调用方恢复路径，
+            //  否则调用方会误判为「迁移失败」而重跑迁移或回滚，与实际数据库状态矛盾。
+            throw new SchedulerError(
+                'Migration completed successfully (database schema, data and manifest are all migrated), but scheduler setup failed afterwards: ' +
+                'the reactive computation layer is NOT active in this process. Fix the underlying error and call controller.setup() (without install) to register computation listeners; do NOT retry the migration.',
+                {
+                    schedulingPhase: 'post-migration-scheduler-setup',
+                    causedBy: error instanceof Error ? error : new Error(String(error))
+                }
+            )
+        }
         return plan
     }
     

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -424,8 +424,11 @@ export class Scheduler {
      *
      * 带 targetPath 的（property/关联路径）监听不需要此守卫：computeDirtyDataDepRecords
      * 与各 handle 的增量分支都通过 filtered 路径查询定位记录，成员资格由查询本身保证。
+     *
+     * CAUTION 非 private：MigrationScheduler（migration.ts）的增量重算路径必须复用同一守卫，
+     *  否则迁移期的链式 rebuild 对 filtered 源会出现「成员资格事件 + 字段 update」双计或错误路由。
      */
-    private async resolveFilteredUpdateEvent(
+    async resolveFilteredUpdateEvent(
         source: EntityEventSourceMap,
         mutationEvent: RecordMutationEvent,
         batchEvents: RecordMutationEvent[]

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -326,7 +326,8 @@ export class Scheduler {
         }
         this.registeredMutationListeners = []
     }
-    addMutationPropertyComputationDefaultValueListeners() {
+    private buildPropertyDefaultValueListeners(): RecordMutationCallback[] {
+        const listeners: RecordMutationCallback[] = []
         for(const computation of this.computationsHandles.values()) {
             if(computation.getInitialValue) {
                 if (computation.dataContext.type==='property') {
@@ -338,7 +339,7 @@ export class Scheduler {
                     assert(!propertyDataContext.id.defaultValue, `${propertyDataContext.host.name}.${propertyDataContext.id.name} property shuold not has a defaultValue, because it will be overridden by computation`)
 
                     // TODO 未来合成一个 listener ?
-                    this.registerMutationListener(async (mutationEvents) => {
+                    listeners.push(async (mutationEvents) => {
                         for(let mutationEvent of mutationEvents){
                             if (mutationEvent.type === 'create' && mutationEvent.recordName === propertyDataContext.host.name) {
                                 const defaultValue = await computation.getInitialValue?.(mutationEvent.record)
@@ -353,6 +354,7 @@ export class Scheduler {
                 }
             }
         }
+        return listeners
     }
     async setupGlobalComputationDefaultValue() {
         for(const computation of this.computationsHandles.values()) {
@@ -382,11 +384,11 @@ export class Scheduler {
     }
     erMutationEventSources: EntityEventSourceMap[] = []
     dataSourceMapTree: DataSourceMapTree = {}
-    addMutationComputationListeners() {
+    private buildComputationMutationListener(): RecordMutationCallback {
         this.sourceMapManager.initialize(new Set(this.computationsHandles.values()))
         this.dataSourceMapTree = this.sourceMapManager.getSourceMapTree()
 
-        this.registerMutationListener(async (mutationEvents) => {
+        return (async (mutationEvents) => {
             for(let mutationEvent of mutationEvents){
                 const sources = this.sourceMapManager.findSourceMapsForMutation(mutationEvent)
                 if (sources.length > 0) {
@@ -1295,10 +1297,18 @@ export class Scheduler {
     
     async setup(createDefaultDictValue: boolean = false) {
         try {
-            // 幂等：重复 setup（或 migrate 后的重建）先注销上一次注册的 listener。
+            // CAUTION 原子切换：先完整构建新 listener（含 sourceMapManager.initialize 等可抛出的路径），
+            //  全部构建成功后才注销旧的、注册新的。如果先注销再构建，构建中途抛出会留下一个
+            //  「零监听」的静默系统——事实写入照常、所有增量计算冻结、无任何后续报错。
+            const listeners = [
+                ...this.buildPropertyDefaultValueListeners(),
+                this.buildComputationMutationListener()
+            ]
+            // 幂等：重复 setup（或 migrate 后的重建）注销上一次注册的 listener，否则同一 mutation 会触发多次计算。
             this.removeRegisteredMutationListeners()
-            this.addMutationPropertyComputationDefaultValueListeners()
-            this.addMutationComputationListeners()
+            for (const listener of listeners) {
+                this.registerMutationListener(listener)
+            }
             if (createDefaultDictValue) {   
                 // 一定要先把 bound state default value 设置后，因为后面开始设置 dict default value 时，可能触发 computation。可能要读 state。
                 await this.setupGlobalBoundStateDefaultValues()

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -514,13 +514,6 @@ export class Scheduler {
 
         return dirtyDataDepRecords
     }
-    computeOldRecord(newRecord: any, sourceMap: DataBasedEntityEventsSourceMap, mutationEvent: RecordMutationEvent) {
-        // FIXME 理论上我们现在不需要 computeOldRecord 了。
-        if(!sourceMap.targetPath?.length) {
-            return mutationEvent.oldRecord
-        }
-        return {...newRecord}
-    }
     async computeDataBasedDirtyRecordsAndEvents(source: DataBasedEntityEventsSourceMap, mutationEvent: RecordMutationEvent) {
         let dirtyRecordsAndEvents: [any, EtityMutationEvent][] = []
 
@@ -536,7 +529,9 @@ export class Scheduler {
                     type: 'update',
                     recordName: propertyContext.host.name!,
                     record: record,
-                    oldRecord: record,
+                    // 变化发生在 global dict 上，宿主记录自身没有变：old/new 快照内容相同是语义事实，
+                    // 但必须是独立副本，避免消费方原地修改 record 时污染 oldRecord。
+                    oldRecord: {...record},
                     relatedMutationEvent: mutationEvent
                 }])
             } else if (source.computation.dataContext.type === 'global') {
@@ -560,7 +555,12 @@ export class Scheduler {
                 type: 'update',
                 recordName: source.sourceRecordName,
                 record: record,
-                oldRecord: this.computeOldRecord(record, source, mutationEvent),
+                // CAUTION 关联路径的合成宿主 update 事件拿不到宿主的"变更前"快照（变化发生在关联记录上，
+                //  宿主行自身没有旧值）。这里如实置 undefined，而不是像旧实现那样用当前记录副本冒充
+                //  oldRecord——假的 oldRecord 会让依赖 old/new diff 的自定义增量计算把成员资格变化误判
+                //  为 none。真正的变更前后快照在 relatedMutationEvent 上；框架内消费方
+                //  （buildMatchEventContext）对带 relatedAttribute 的事件一律走 full recompute。
+                oldRecord: undefined,
                 relatedAttribute: source.targetPath,
                 relatedMutationEvent: mutationEvent
             }])

--- a/src/runtime/computations/Any.ts
+++ b/src/runtime/computations/Any.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext } from "./Computation.js";
 import { Any } from "@core";
 import { Controller } from "../Controller.js";
 import { AnyInstance, RelationInstance } from "@core";
-import { buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
+import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
 import { DataBasedComputation } from "./Computation.js";
 import { EtityMutationEvent } from "../ComputationSourceMap.js";
 import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
@@ -19,6 +19,7 @@ export class GlobalAnyHandle implements DataBasedComputation {
     primaryDataDepKeys = ['main']
     constructor(public controller: Controller,  public args: AnyInstance,  public dataContext: DataContext, ) {
         this.callback = this.args.callback.bind(this.controller)
+        assertCallbackAttributeQueryDeclared('Any', dataContext, this.args.attributeQuery)
         this.dataDeps = {
             main: {
                 type: 'records',
@@ -68,8 +69,17 @@ export class GlobalAnyHandle implements DataBasedComputation {
 
         let delta = 0
         if (mutationEvent.type === 'create') {
-            const newItemMatch = !!this.callback.call(this.controller, mutationEvent.record, dataDeps) 
-            const { oldValue } = await this.state!.isItemMatch.replace(mutationEvent.record, newItemMatch)
+            // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
+            //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
+            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
+                key: 'id',
+                value: ['=', mutationEvent.record!.id]
+            }), undefined, this.args.attributeQuery)
+            if (!newRecord) {
+                return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for global any`)
+            }
+            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps) 
+            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
             delta = Number(newItemMatch) - Number(!!oldValue)
         } else if (mutationEvent.type === 'delete') {
             // Get the old match status from state instead of recalculating
@@ -114,6 +124,7 @@ export class PropertyAnyHandle implements DataBasedComputation {
     relatedAttributeQuery: AttributeQueryData
     constructor(public controller: Controller,  public args: AnyInstance,  public dataContext: PropertyDataContext ) {
         this.callback = this.args.callback.bind(this.controller)
+        assertCallbackAttributeQueryDeclared('Any', dataContext, this.args.attributeQuery)
 
         this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
         assert(this.relation, `cannot find relation for property ${this.args.property} in "Any" computation`)

--- a/src/runtime/computations/Any.ts
+++ b/src/runtime/computations/Any.ts
@@ -1,267 +1,83 @@
-import { DataContext, PropertyDataContext } from "./Computation.js";
-import { Any } from "@core";
+import { Any, AnyInstance } from "@core";
 import { Controller } from "../Controller.js";
-import { AnyInstance, RelationInstance } from "@core";
-import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
-import { DataBasedComputation } from "./Computation.js";
-import { EtityMutationEvent } from "../ComputationSourceMap.js";
-import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
-import { assert } from "../util.js";
+import { DataContext, GlobalBoundState, PropertyDataContext, RecordBoundState } from "./Computation.js";
+import { GlobalRecordsAggregationHandle, PropertyRelationAggregationHandle } from "./aggregationTemplate.js";
 
-
-export class GlobalAnyHandle implements DataBasedComputation {
+export class GlobalAnyHandle extends GlobalRecordsAggregationHandle<boolean, boolean, AnyInstance> {
     static computationType = Any
     static contextType = 'global' as const
-    callback: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => boolean
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['main']
-    constructor(public controller: Controller,  public args: AnyInstance,  public dataContext: DataContext, ) {
-        this.callback = this.args.callback.bind(this.controller)
-        assertCallbackAttributeQueryDeclared('Any', dataContext, this.args.attributeQuery)
-        this.dataDeps = {
-            main: {
-                type: 'records',
-                source:this.args.record!,
-                attributeQuery: this.args.attributeQuery
-            },
-            ...(this.args.dataDeps || {})
-        }
+    protected readonly itemStateKey = 'isItemMatch'
+    protected readonly emptyItemValue = false
+
+    constructor(controller: Controller, args: AnyInstance, dataContext: DataContext) {
+        super(controller, args, dataContext, { computationName: 'Any', requireCallback: true })
     }
 
     createState() {
         return {
             matchCount: new GlobalBoundState<number>(0),
-            isItemMatch: new RecordBoundState<boolean>(false, this.args.record!.name!)
+            isItemMatch: new RecordBoundState<boolean>(false, this.record.name!)
         }
     }
-    
+
     getInitialValue() {
         return false
     }
 
-    async compute({main: records, ...dataDeps}: {main: any[], [key: string]: any}): Promise<boolean> {
-        let matchCount = 0
-        
-        for (const item of records) {
-            const isMatch = this.callback.call(this.controller, item, dataDeps)
-            if (isMatch) {
-                matchCount++
-            }
-            await this.state.isItemMatch.setInternal(item, isMatch)
-        }
-        
+    protected computeItemValue(record: Record<string, unknown>, dataDeps: { [key: string]: unknown }): boolean {
+        return !!this.callback!.call(this.controller, record, dataDeps)
+    }
+
+    protected async applyDelta(newValue: boolean | null, oldValue: boolean | null): Promise<boolean> {
+        const matchCount = await this.state.matchCount.increment(Number(!!newValue) - Number(!!oldValue))
+        this.assertNonNegative('matchCount', matchCount)
+        return matchCount > 0
+    }
+
+    protected async persistFullResult(values: boolean[]): Promise<boolean> {
+        const matchCount = values.filter(Boolean).length
         await this.state.matchCount.setInternal(matchCount)
-
-        return matchCount>0
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
-    }
-
-    async incrementalCompute(lastValue: boolean, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<boolean|ComputationResult> {
-        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新，因为可能有自己和自己的关联关系的 dataDep。
-        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-
-        let delta = 0
-        if (mutationEvent.type === 'create') {
-            // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
-            //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
-            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
-                key: 'id',
-                value: ['=', mutationEvent.record!.id]
-            }), undefined, this.args.attributeQuery)
-            if (!newRecord) {
-                return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for global any`)
-            }
-            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps) 
-            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
-            delta = Number(newItemMatch) - Number(!!oldValue)
-        } else if (mutationEvent.type === 'delete') {
-            // Get the old match status from state instead of recalculating
-            const oldItemMatch = await this.state!.isItemMatch.get(mutationEvent.record)
-            delta = oldItemMatch ? -1 : 0
-            // CAUTION delete 事件可能只是 filtered entity 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则记录再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
-            await this.state!.isItemMatch.setInternal(mutationEvent.record, false)
-        } else if (mutationEvent.type === 'update') {
-            // 拉取全量的 new record 数据，因为可能关联关系有变化。
-            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
-                key: 'id',
-                value: ['=', mutationEvent.record!.id]
-            }), undefined, this.args.attributeQuery)
-
-            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
-            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
-            delta = Number(newItemMatch) - Number(!!oldValue)
-        }
-
-        const matchCount = await this.state!.matchCount.increment(delta)
         return matchCount > 0
     }
 }
 
-
-export class PropertyAnyHandle implements DataBasedComputation {
+export class PropertyAnyHandle extends PropertyRelationAggregationHandle<boolean, boolean, AnyInstance> {
     static computationType = Any
     static contextType = 'property' as const
-    callback: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => boolean
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['_current']
-    relationAttr: string
-    relatedRecordName: string
-    isSource: boolean
-    relation: RelationInstance
-    property: string
-    reverseProperty: string
-    relationAttributeQuery: AttributeQueryData
-    relatedAttributeQuery: AttributeQueryData
-    constructor(public controller: Controller,  public args: AnyInstance,  public dataContext: PropertyDataContext ) {
-        this.callback = this.args.callback.bind(this.controller)
-        assertCallbackAttributeQueryDeclared('Any', dataContext, this.args.attributeQuery)
+    protected readonly itemStateKey = 'isItemMatch'
+    protected readonly emptyItemValue = false
 
-        this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
-        assert(this.relation, `cannot find relation for property ${this.args.property} in "Any" computation`)
-        this.isSource = this.args.direction ? this.args.direction === 'source' : this.relation.source.name === dataContext.host.name
-        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, 'any computation relation direction error')
-
-        let baseRelation = this.relation.baseRelation || this.relation
-        while(baseRelation.baseRelation) {
-            baseRelation = baseRelation.baseRelation
-        }
-        const relType = baseRelation.type.split(':')
-        assert(relType[this.isSource?1:0]==='n', `property-level Any computation argument must be an x:n relation. ${this.dataContext.host.name}.${this.args.property}" is a ${this.isSource?relType.join(':'):relType.slice().reverse().join(':')} relation`)
-        
-        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
-        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
-        this.property = this.args.property!
-        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
-        const attributeQuery = this.args.attributeQuery || []
-        this.relatedAttributeQuery = this.args.attributeQuery?.filter(item => item[0] !== LINK_SYMBOL) || []
-        const relationQuery: AttributeQueryData|undefined = ((attributeQuery.find(item => item[0] === LINK_SYMBOL)||[])[1] as RecordQueryData)?.attributeQuery
-        this.relationAttributeQuery = [
-            [this.isSource ? 'target' : 'source', {attributeQuery: this.relatedAttributeQuery}],
-            ...(relationQuery ? relationQuery : [])
-        ]
-        this.dataDeps = {
-            _current: {
-                type: 'property',
-                attributeQuery: [[this.property, {attributeQuery: this.args.attributeQuery}]]
-            },
-            ...(this.args.dataDeps || {})
-        }
+    constructor(controller: Controller, args: AnyInstance, dataContext: PropertyDataContext) {
+        super(controller, args, dataContext, { computationName: 'Any', requireCallback: true, requireXToMany: true })
     }
 
     createState() {
         return {
             matchCount: new RecordBoundState<number>(0),
             isItemMatch: new RecordBoundState<boolean>(false, this.relation.name!)
-        }   
+        }
     }
-    
+
     getInitialValue() {
         return false
     }
 
-    async compute({_current, ...dataDeps}: {_current: any, [key: string]: any}): Promise<boolean> {
-        let matchCount = 0
-        for(const item of _current[this.relationAttr]) {
-            const relationStateRecord = item[LINK_SYMBOL] || item['&'] || item
-            const isMatch = this.callback.call(this.controller, item, dataDeps)
-            if (isMatch) {
-                matchCount++
-                await this.state!.isItemMatch.setInternal(relationStateRecord, true)
-            } else {
-                await this.state!.isItemMatch.setInternal(relationStateRecord, false)
-            }
-        }
-        await this.state.matchCount.setInternal(_current, matchCount)
-        return matchCount>0
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected computeItemValue(relatedItem: Record<string, unknown>, dataDeps: { [key: string]: unknown }): boolean {
+        return !!this.callback!.call(this.controller, relatedItem, dataDeps)
     }
 
-    async incrementalCompute(lastValue: boolean, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<boolean|ComputationResult> {
-        // 只能支持通过 args.record 指定的关联关系或者关联实体的增量更新。
-        if (
-            mutationEvent.recordName !== this.dataContext.host.name ||
-            !mutationEvent.relatedAttribute ||
-            mutationEvent.relatedAttribute.length === 0 || 
-            mutationEvent.relatedAttribute.length > 3 ||
-            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
-            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== '&') ||
-            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== (this.isSource ? 'target' : 'source'))
-        ) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
+    protected async applyDelta(hostRecord: Record<string, unknown>, newValue: boolean | null, oldValue: boolean | null): Promise<boolean> {
+        const matchCount = await this.state.matchCount.increment(hostRecord, Number(!!newValue) - Number(!!oldValue))
+        this.assertNonNegative('matchCount', matchCount)
+        return matchCount > 0
+    }
 
-        let delta = 0
-        const relatedMutationEvent = mutationEvent.relatedMutationEvent!
-
-        if (relatedMutationEvent.type === 'create'&&relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的新建
-            const relationRecord = relatedMutationEvent.record!
-            const newRelationWithEntity = await this.controller.system.storage.findOne(this.relation.name!, MatchExp.atom({
-                key: 'id',
-                value: ['=', relationRecord.id]
-            }), undefined, this.relationAttributeQuery)
-            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃（与 Count/Summation 一致）。
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source']
-            relatedRecord['&'] = relationRecord
-
-            const newItemMatch = !!this.callback.call(this.controller, relatedRecord, dataDeps) 
-            const { oldValue } = await this.state!.isItemMatch.replace(relationRecord, newItemMatch)
-            delta = Number(newItemMatch) - Number(!!oldValue)
-        } else if (relatedMutationEvent.type === 'delete'&&relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的删除
-            const relationRecord = relatedMutationEvent.record!
-            const oldItemMatch = !!await this.state!.isItemMatch.get(relationRecord)
-            delta = oldItemMatch ? -1 : 0
-            // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则关系再次进入时 replace 读到陈旧值导致增量错误（与 global 路径保持一致）。
-            await this.state!.isItemMatch.setInternal(relationRecord, false)
-        } else if (relatedMutationEvent.type === 'update'&&(relatedMutationEvent.recordName === this.relation.name!||relatedMutationEvent.recordName === this.relatedRecordName)) {
-            // 关联实体或者关联关系上的字段的更新
-            // 关联关系或者关联实体的更新
-            // relatedAttribute 是从当前 dataContext 出发
-            // 现在要把匹配的 key 改成从关联关系出发。
-            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
-
-            const relationMatch = MatchExp.atom({
-                key: relationMatchKey,
-                value: ['=', relatedMutationEvent!.oldRecord!.id]
-            }) 
-
-            const relationRecord = await this.controller.system.storage.findOne(this.relation.name!, relationMatch, undefined, this.relationAttributeQuery)
-            // 关系记录已不可见（被删除/filtered 成员资格变化竞态）时退回全量重算（与 Count/Summation 一致）。
-            if (!relationRecord) {
-                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = relationRecord[this.isSource ? 'target' : 'source']
-            relatedRecord['&'] = relationRecord
-
-            const newItemMatch = !!this.callback.call(this.controller, relatedRecord, dataDeps) 
-            const { oldValue } = await this.state!.isItemMatch.replace(relationRecord, newItemMatch)
-            delta = Number(newItemMatch) - Number(!!oldValue)
-        } else {
-            return ComputationResult.fullRecompute('mutation is not caused by relation.')
-        }
-
-        const matchCount = await this.state!.matchCount.increment(mutationEvent.record, delta)
-        return matchCount>0
+    protected async persistFullResult(hostRecord: Record<string, unknown>, values: boolean[]): Promise<boolean> {
+        const matchCount = values.filter(Boolean).length
+        await this.state.matchCount.setInternal(hostRecord, matchCount)
+        return matchCount > 0
     }
 }
-
 
 // Export Any computation handles
 export const AnyHandles = [GlobalAnyHandle, PropertyAnyHandle];

--- a/src/runtime/computations/Average.ts
+++ b/src/runtime/computations/Average.ts
@@ -1,191 +1,81 @@
-import { DataContext, PropertyDataContext } from "./Computation.js";
-import { Average, AverageInstance, RelationInstance, EntityInstance } from "@core";
+import { Average, AverageInstance } from "@core";
 import { Controller } from "../Controller.js";
-import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, RecordBoundState, GlobalBoundState, IncrementalPlan, RecordsDataDep } from "./Computation.js";
-import { EtityMutationEvent } from "../Scheduler.js";
-import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
-import { assert } from "../util.js";
+import { DataContext, GlobalBoundState, PropertyDataContext, RecordBoundState } from "./Computation.js";
+import { GlobalRecordsAggregationHandle, parseAggregationFieldPath, PropertyRelationAggregationHandle } from "./aggregationTemplate.js";
 
-export class GlobalAverageHandle implements DataBasedComputation {
+/**
+ * CAUTION 既定语义（average.spec.ts 固化）：null/undefined/NaN/Infinity 按 0 计且计入分母。
+ * 与 SQL AVG（忽略 NULL）不同；全量与增量口径一致。
+ */
+function resolveAvgField(record: Record<string, unknown>, avgFieldPath: string[]): number {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let base: any = record
+    for (const attr of avgFieldPath) {
+        base = base[attr]
+        if (base === undefined || base === null) return 0
+    }
+    return (Number.isNaN(base) || !Number.isFinite(base)) ? 0 : base
+}
+
+export class GlobalAverageHandle extends GlobalRecordsAggregationHandle<number, number, AverageInstance> {
     static computationType = Average
     static contextType = 'global' as const
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['main']
-    record: (EntityInstance|RelationInstance)
+    protected readonly itemStateKey = 'itemValue'
+    protected readonly emptyItemValue = 0
     avgFieldPath: string[]
-    
-    constructor(public controller: Controller, public args: AverageInstance, public dataContext: DataContext) {
-        this.record = this.args.record!
-        
-        // 获取 attributeQuery 的第一个字段作为平均值计算字段
-        if (!this.args.attributeQuery || this.args.attributeQuery.length === 0) {
-            throw new Error('Average computation requires attributeQuery with at least one field')
-        }
 
-        this.avgFieldPath = []
-        let attrPointer:any = this.args.attributeQuery
-        while(attrPointer) {
-            this.avgFieldPath.push(Array.isArray(attrPointer[0]) ? attrPointer[0][0]: attrPointer[0])
-            attrPointer = Array.isArray(attrPointer[0]) ? attrPointer[0][1].attributeQuery : null
-        }
-
-        this.dataDeps = {
-            main: {
-                type: 'records',
-                source: this.record,
-                attributeQuery: this.args.attributeQuery
-            }
-        }
+    constructor(controller: Controller, args: AverageInstance, dataContext: DataContext) {
+        super(controller, args, dataContext, { computationName: 'Average', requireAttributeQueryField: true })
+        this.avgFieldPath = parseAggregationFieldPath(this.args.attributeQuery!)
     }
-    
+
     createState() {
         return {
             aggregate: new GlobalBoundState<Record<string, number>>({ sum: 0, count: 0 }),
             itemValue: new RecordBoundState<number>(0, this.record.name!)
-        }   
+        }
     }
-    
+
     getInitialValue() {
         return 0
     }
 
-    resolveAvgField(record:any, avgFieldPath = this.avgFieldPath) {
-        let base:any = record
-        for(let attr of avgFieldPath) {
-            base = base[attr]
-            if (base === undefined || base === null) return null
-        }
-        return (Number.isNaN(base)||!Number.isFinite(base) ) ? null: base
-    }
-    
-    async compute({main: records}: {main: any[]}): Promise<number> {
-        let sum = 0;
-        let count = 0;
-        
-        for (const record of records) {
-            const value = this.resolveAvgField(record) || 0;
-            sum += value;
-            count++;
-            await this.state.itemValue.setInternal(record, value);
-        }
-        
-        await this.state.aggregate.setInternal({ sum, count });
-        
-        return count > 0 ? sum / count : 0;
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected computeItemValue(record: Record<string, unknown>): number {
+        return resolveAvgField(record, this.avgFieldPath)
     }
 
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新
-        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-        
-        let sumDelta = 0
-        let countDelta = 0
-
-        if (mutationEvent.type === 'create') {
-            const newRecord = await this.controller.system.storage.findOne(
-                this.record.name!, 
-                MatchExp.atom({key:'id', value:['=', mutationEvent.record!.id]}), 
-                undefined, 
-                this.args.attributeQuery
-            )
-            const value = this.resolveAvgField(newRecord) || 0;
-            const { oldValue } = await this.state.itemValue.replace(newRecord, value);
-            sumDelta = value - (oldValue ?? 0);
-            countDelta = 1;
-        } else if (mutationEvent.type === 'delete') {
-            // Get the old value from state instead of returning fullRecompute
-            const oldValue = (await this.state.itemValue.get(mutationEvent.record)) || 0;
-            sumDelta = -oldValue;
-            countDelta = -1;
-            // CAUTION delete 事件可能只是 filtered entity 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则记录再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
-            await this.state.itemValue.setInternal(mutationEvent.record, 0)
-        } else if (mutationEvent.type === 'update') {
-            const newRecord = await this.controller.system.storage.findOne(
-                this.record.name!, 
-                MatchExp.atom({key:'id', value:['=', mutationEvent.record!.id]}), 
-                undefined, 
-                this.args.attributeQuery
-            )
-            const newValue = this.resolveAvgField(newRecord) || 0;
-            const { oldValue } = await this.state.itemValue.replace(newRecord, newValue);
-            sumDelta = newValue - (oldValue ?? 0);
-        }
-        
+    protected async applyDelta(newValue: number | null, oldValue: number | null, presenceDelta: 1 | 0 | -1): Promise<number> {
         const aggregate = await this.controller.system.storage.atomic.updateGlobalFields(
             {
                 key: this.state.aggregate.key,
                 valueType: 'json',
                 defaultValue: { sum: 0, count: 0 }
             },
-            { sum: sumDelta, count: countDelta },
+            { sum: (newValue ?? 0) - (oldValue ?? 0), count: presenceDelta },
             { sum: 0, count: 0 }
         )
-        const sum = aggregate.sum
-        const count = aggregate.count
-        
-        return count > 0 ? sum / count : 0;
+        this.assertNonNegative('count', aggregate.count)
+        return aggregate.count > 0 ? aggregate.sum / aggregate.count : 0
+    }
+
+    protected async persistFullResult(values: number[]): Promise<number> {
+        const sum = values.reduce((acc, value) => acc + value, 0)
+        const count = values.length
+        await this.state.aggregate.setInternal({ sum, count })
+        return count > 0 ? sum / count : 0
     }
 }
 
-
-export class PropertyAverageHandle implements DataBasedComputation {
+export class PropertyAverageHandle extends PropertyRelationAggregationHandle<number, number, AverageInstance> {
     static computationType = Average
     static contextType = 'property' as const
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['_current']
-    relationAttr: string
-    relatedRecordName: string
-    isSource: boolean
-    relation: RelationInstance
-    property: string
-    reverseProperty: string
-    relationAttributeQuery: AttributeQueryData
-    relatedAttributeQuery: AttributeQueryData
+    protected readonly itemStateKey = 'itemResult'
+    protected readonly emptyItemValue = 0
     avgFieldPath: string[]
 
-    constructor(public controller: Controller, public args: AverageInstance, public dataContext: PropertyDataContext) {
-        // Find relation by property name or fall back to record
-        this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
-        this.isSource = this.args.direction ? this.args.direction === 'source' : this.relation.source.name === dataContext.host.name
-        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, 'average computation relation direction error')
-        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
-        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
-        this.property = this.args.property || this.relationAttr
-        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
-        
-        const attributeQuery = this.args.attributeQuery || []
-        this.relatedAttributeQuery = attributeQuery.filter(item => item && item[0] !== LINK_SYMBOL) || []
-        const relationQuery: AttributeQueryData|undefined = ((attributeQuery.find(item => item && item[0] === LINK_SYMBOL)||[])[1] as RecordQueryData)?.attributeQuery
-        this.relationAttributeQuery = [
-            [this.isSource ? 'target' : 'source', {attributeQuery: this.relatedAttributeQuery}],
-            ...(relationQuery ? relationQuery : [])
-        ]
-        
-        
-        this.avgFieldPath = []
-        let attrPointer:any = attributeQuery
-        while(attrPointer) {
-            this.avgFieldPath.push(Array.isArray(attrPointer[0]) ? attrPointer[0][0]: attrPointer[0])
-            attrPointer = Array.isArray(attrPointer[0]) ? attrPointer[0][1].attributeQuery : null
-        }
-        
-        this.dataDeps = {
-            _current: {
-                type: 'property',
-                attributeQuery: [[this.relationAttr, {attributeQuery: this.args.attributeQuery}]]
-            }
-        }
+    constructor(controller: Controller, args: AverageInstance, dataContext: PropertyDataContext) {
+        super(controller, args, dataContext, { computationName: 'Average', requireAttributeQueryField: true })
+        this.avgFieldPath = parseAggregationFieldPath(this.args.attributeQuery!)
     }
 
     createState() {
@@ -193,125 +83,32 @@ export class PropertyAverageHandle implements DataBasedComputation {
             sum: new RecordBoundState<number>(0, this.dataContext.host.name),
             count: new RecordBoundState<number>(0, this.dataContext.host.name),
             itemResult: new RecordBoundState<number>(0, this.relation.name!)
-        }   
+        }
     }
-    
+
     getInitialValue() {
         return 0
     }
-    
-    resolveAvgField(record:any, avgFieldPath = this.avgFieldPath) {
-        let base:any = record
-        for(let attr of avgFieldPath) {
-            base = base[attr]
-            if (base === undefined || base === null) return null
-        }
-        // 与 GlobalAverageHandle 保持一致：NaN/Infinity 归为 null，避免污染 sum。
-        return (Number.isNaN(base)||!Number.isFinite(base)) ? null : base
+
+    protected computeItemValue(relatedItem: Record<string, unknown>): number {
+        return resolveAvgField(relatedItem, this.avgFieldPath)
     }
 
-    async compute({_current}: {_current: any}): Promise<number> {
-        const relations = _current[this.relationAttr] || [];
-        let sum = 0;
-        let count = 0;
-        
-        for (const relatedItem of relations) {
-            const relationStateRecord = relatedItem[LINK_SYMBOL] || relatedItem['&'] || relatedItem
-            const value = this.resolveAvgField(relatedItem, this.avgFieldPath) || 0;
-            sum += value;
-            count++;
-            await this.state.itemResult.setInternal(relationStateRecord, value);
-        }
-        
-        await this.state.sum.setInternal(_current, sum);
-        await this.state.count.setInternal(_current, count);
-        
-        return count > 0 ? sum / count : 0;
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected async applyDelta(hostRecord: Record<string, unknown>, newValue: number | null, oldValue: number | null, presenceDelta: 1 | 0 | -1): Promise<number> {
+        const sum = await this.state.sum.increment(hostRecord, (newValue ?? 0) - (oldValue ?? 0))
+        const count = await this.state.count.increment(hostRecord, presenceDelta)
+        this.assertNonNegative('count', count)
+        return count > 0 ? sum / count : 0
     }
 
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 只能支持通过 args.record 指定的关联关系或者关联实体的增量更新
-        if (
-            mutationEvent.recordName !== this.dataContext.host.name ||
-            !mutationEvent.relatedAttribute ||
-            mutationEvent.relatedAttribute.length === 0 || 
-            mutationEvent.relatedAttribute.length > 3 ||
-            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
-            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== '&') ||
-            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== (this.isSource ? 'target' : 'source'))
-        ) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-        const relatedMutationEvent = mutationEvent.relatedMutationEvent;
-        if (!relatedMutationEvent) {
-            return ComputationResult.fullRecompute('No related mutation event')
-        }
-        
-        let sumDelta = 0
-        let countDelta = 0
-
-        // 关联关系的新建
-        if (relatedMutationEvent.type === 'create' && relatedMutationEvent.recordName === this.relation.name!) {
-            
-            const relationRecord = relatedMutationEvent.record!;
-            const newRelationWithEntity = await this.controller.system.storage.findOne(
-                this.relation.name!, 
-                MatchExp.atom({key: 'id', value: ['=', relationRecord.id]}), 
-                undefined, 
-                this.relationAttributeQuery
-            );
-            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃。
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source'];
-            relatedRecord['&'] = newRelationWithEntity;
-            const value = this.resolveAvgField(relatedRecord) || 0;
-            const { oldValue } = await this.state.itemResult.replace(newRelationWithEntity, value);
-            sumDelta = value - (oldValue ?? 0);
-            countDelta = 1;
-        } else if (relatedMutationEvent.type === 'delete' && relatedMutationEvent.recordName === this.relation.name!) {
-            const oldResult = await this.state!.itemResult.get(relatedMutationEvent.record);
-            sumDelta = -(oldResult ?? 0);
-            countDelta = -1;
-            // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则关系再次进入时 replace 读到陈旧值导致增量错误（与 global 路径保持一致）。
-            await this.state!.itemResult.setInternal(relatedMutationEvent.record, 0);
-        } else if (relatedMutationEvent.type === 'update') {
-            // 可能是关系更新也可能是关联实体更新
-            // relatedAttribute 是从当前 dataContext 出发，要转换成从关联关系出发的 match key。
-            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
-            const newRelationWithEntity = await this.controller.system.storage.findOne(
-                this.relation.name!, 
-                MatchExp.atom({key: relationMatchKey, value: ['=', relatedMutationEvent.oldRecord!.id]}), 
-                undefined, 
-                this.relationAttributeQuery
-            );
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source'];
-            relatedRecord['&'] = newRelationWithEntity;
-            const newValue = this.resolveAvgField(relatedRecord) || 0;
-
-            const { oldValue } = await this.state.itemResult.replace(newRelationWithEntity, newValue);
-            sumDelta = newValue - (oldValue ?? 0);
-        } else {
-            // 与 Count/Any/Every 保持一致：未知的 related 事件形态必须退回全量重算。
-            return ComputationResult.fullRecompute(`unknown related mutation event for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-        }
-
-        const sum = await this.state.sum.increment(mutationEvent.record, sumDelta);
-        const count = await this.state.count.increment(mutationEvent.record, countDelta);
-        // 与 PropertyCount 的负值守卫对齐：count 为负说明事件序与绑定状态已不一致，静默返回比例是错误数据。
-        if (count < 0) throw new Error(`PropertyAverage count became negative for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-        return count > 0 ? sum / count : 0;
+    protected async persistFullResult(hostRecord: Record<string, unknown>, values: number[]): Promise<number> {
+        const sum = values.reduce((acc, value) => acc + value, 0)
+        const count = values.length
+        await this.state.sum.setInternal(hostRecord, sum)
+        await this.state.count.setInternal(hostRecord, count)
+        return count > 0 ? sum / count : 0
     }
 }
 
 // Export Average computation handles
-export const AverageHandles = [GlobalAverageHandle, PropertyAverageHandle]; 
+export const AverageHandles = [GlobalAverageHandle, PropertyAverageHandle];

--- a/src/runtime/computations/Computation.ts
+++ b/src/runtime/computations/Computation.ts
@@ -7,6 +7,7 @@ import { Controller } from "../Controller";
 import { AttributeQueryData, LINK_SYMBOL, MatchExp, MatchExpressionData, ModifierData } from "@storage";
 import { type ComputationPhase, PHASE_AFTER_ALL, PHASE_BEFORE_ALL, PHASE_NORMAL} from "../ComputationSourceMap";
 import type { EtityMutationEvent } from "../ComputationSourceMap.js";
+import { ComputationProtocolError } from "../errors/ComputationErrors.js";
 
 // Types from ComputationHandle.ts
 export type GlobalDataContext = {
@@ -277,6 +278,39 @@ export type DataDepEventContext = {
 export function externalDataDepKeys(dataDeps: Record<string, DataDep>, primaryKeys: string[]) {
     const primary = new Set(primaryKeys)
     return Object.keys(dataDeps).filter(key => !primary.has(key))
+}
+
+export function describeDataContext(dataContext: DataContext): string {
+    if (dataContext.type === 'property') {
+        return `${dataContext.host.name}.${dataContext.id.name}`
+    }
+    return `${dataContext.type} '${dataContext.id.name}'`
+}
+
+/**
+ * CAUTION fail fast（与 Custom 的 records dataDep 校验对齐）：声明了 callback 却没有 attributeQuery 时，
+ *  full compute 的取数是 id-only（callback 读字段静默拿到 undefined），且字段 update 不会注册任何监听——
+ *  聚合结果静默错误或永久冻结，必须在 setup 阶段拒绝。
+ *  显式声明 attributeQuery: [] 表示 "callback 只依赖 id / 关系成员资格 / dataDeps"，仍然允许。
+ */
+export function assertCallbackAttributeQueryDeclared(
+    computationName: string,
+    dataContext: DataContext,
+    attributeQuery: AttributeQueryData | undefined
+): void {
+    if (attributeQuery === undefined) {
+        throw new ComputationProtocolError(
+            `${computationName} computation of ${describeDataContext(dataContext)} declares a callback but no attributeQuery. ` +
+            `Without attributeQuery the callback receives id-only records (fields read as undefined) and field updates never re-trigger the computation. ` +
+            `Declare the fields your callback reads (e.g. attributeQuery: ['status']), ` +
+            `or explicitly pass attributeQuery: [] if the callback only depends on record membership (create/delete) or external dataDeps.`,
+            {
+                computationName,
+                dataContext,
+                computationPhase: 'callback-attribute-query-validation'
+            }
+        )
+    }
 }
 
 /**

--- a/src/runtime/computations/Count.ts
+++ b/src/runtime/computations/Count.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext } from "./Computation.js";
 import { Count } from "@core";
 import { Controller } from "../Controller.js";
 import { CountInstance, EntityInstance, RelationInstance } from "@core";
-import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
+import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
 import { EtityMutationEvent } from "../Scheduler.js";
 import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
 import { assert } from "../util.js";
@@ -25,6 +25,9 @@ export class GlobalCountHandle implements DataBasedComputation {
     constructor(public controller: Controller, public args: CountInstance, public dataContext: DataContext) {
         this.record = this.args.record!
         this.callback = this.args.callback?.bind(this) || (() => true)
+        if (this.args.callback) {
+            assertCallbackAttributeQueryDeclared('Count', dataContext, this.args.attributeQuery)
+        }
         
         this.dataDeps = {
             main: {
@@ -73,8 +76,20 @@ export class GlobalCountHandle implements DataBasedComputation {
         let delta = 0
         if (mutationEvent.type === 'create') {
             // 检查新创建的记录是否符合条件
-            const itemMatch = !!this.callback.call(this.controller, mutationEvent.record, dataDeps)
-            const { oldValue } = await this.state.isItemMatch.replace(mutationEvent.record, itemMatch)
+            let newRecord = mutationEvent.record
+            if (this.args.callback) {
+                // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
+                //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
+                newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
+                    key: 'id',
+                    value: ['=', mutationEvent.record!.id]
+                }), undefined, this.args.attributeQuery)
+                if (!newRecord) {
+                    return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for ${this.dataContext.type} count`)
+                }
+            }
+            const itemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
+            const { oldValue } = await this.state.isItemMatch.replace(newRecord, itemMatch)
             delta = Number(itemMatch) - Number(!!oldValue)
         } else if (mutationEvent.type === 'delete') {
             const itemMatch = await this.state.isItemMatch.get(mutationEvent.record)
@@ -126,6 +141,9 @@ export class PropertyCountHandle implements DataBasedComputation {
 
     constructor(public controller: Controller, public args: CountInstance, public dataContext: PropertyDataContext) {
         this.callback = this.args.callback?.bind(this.controller)
+        if (this.args.callback) {
+            assertCallbackAttributeQueryDeclared('Count', dataContext, this.args.attributeQuery)
+        }
         
         // Find relation by property name or fall back to record
         if (this.args.property) {

--- a/src/runtime/computations/Count.ts
+++ b/src/runtime/computations/Count.ts
@@ -1,183 +1,72 @@
-import { DataContext, PropertyDataContext } from "./Computation.js";
 import { Count } from "@core";
 import { Controller } from "../Controller.js";
-import { CountInstance, EntityInstance, RelationInstance } from "@core";
-import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
-import { EtityMutationEvent } from "../Scheduler.js";
-import { MatchExp, AttributeQueryData, RecordQueryData, LINK_SYMBOL } from "@storage";
-import { assert } from "../util.js";
+import { CountInstance } from "@core";
+import { DataContext, GlobalBoundState, PropertyDataContext, RecordBoundState } from "./Computation.js";
+import { GlobalRecordsAggregationHandle, PropertyRelationAggregationHandle } from "./aggregationTemplate.js";
 
-type GlobalCountState = {
-    count: GlobalBoundState<number>,
-    isItemMatch: RecordBoundState<boolean>
-}
-
-export class GlobalCountHandle implements DataBasedComputation {
+export class GlobalCountHandle extends GlobalRecordsAggregationHandle<boolean, number, CountInstance> {
     static computationType = Count
     static contextType = 'global' as const
-    callback: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => boolean
-    state!: GlobalCountState
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['main']
-    record: (EntityInstance|RelationInstance)
+    protected readonly itemStateKey = 'isItemMatch'
+    protected readonly emptyItemValue = false
 
-    constructor(public controller: Controller, public args: CountInstance, public dataContext: DataContext) {
-        this.record = this.args.record!
-        this.callback = this.args.callback?.bind(this) || (() => true)
-        if (this.args.callback) {
-            assertCallbackAttributeQueryDeclared('Count', dataContext, this.args.attributeQuery)
-        }
-        
-        this.dataDeps = {
-            main: {
-                type: 'records',
-                source: this.record,
-                attributeQuery: this.args.attributeQuery
-            },
-            ...(this.args.dataDeps || {})
-        }
+    constructor(controller: Controller, args: CountInstance, dataContext: DataContext) {
+        super(controller, args, dataContext, { computationName: 'Count' })
     }
-    
+
     createState() {
         return {
             count: new GlobalBoundState<number>(0),
             isItemMatch: new RecordBoundState<boolean>(false, this.record.name!)
         }
     }
-    
+
     getInitialValue() {
         return 0
     }
 
-    async compute({main: records, ...dataDeps}: {main: any[], [key: string]: any}): Promise<number> {
-        let count: number = 0
-        
-        for (const item of records) {
-            const isMatch = this.callback!.call(this.controller, item, dataDeps)
-            if (isMatch) {
-                count++
-            }
-            await this.state.isItemMatch.setInternal(item, isMatch)
-        }
-        
-        await this.state.count.setInternal(count)
-        return count;
+    // 无 callback 时贡献恒为 true（计所有记录），无需回查全量记录。
+    protected requiresItemFetch(): boolean {
+        return !!this.args.callback
     }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
-    }
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新，因为可能有自己和自己的关联关系的 dataDep。
-        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
 
-        let delta = 0
-        if (mutationEvent.type === 'create') {
-            // 检查新创建的记录是否符合条件
-            let newRecord = mutationEvent.record
-            if (this.args.callback) {
-                // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
-                //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
-                newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
-                    key: 'id',
-                    value: ['=', mutationEvent.record!.id]
-                }), undefined, this.args.attributeQuery)
-                if (!newRecord) {
-                    return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for ${this.dataContext.type} count`)
-                }
-            }
-            const itemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
-            const { oldValue } = await this.state.isItemMatch.replace(newRecord, itemMatch)
-            delta = Number(itemMatch) - Number(!!oldValue)
-        } else if (mutationEvent.type === 'delete') {
-            const itemMatch = await this.state.isItemMatch.get(mutationEvent.record)
-            delta = itemMatch ? -1 : 0
-            // CAUTION delete 事件不一定意味着物理行删除：filtered entity 的成员资格退出事件里，
-            //  底层行仍然存在，必须复位绑定状态，否则记录再次进入（create 事件）时 replace 会读到
-            //  陈旧的 true 导致增量为 0。物理删除场景下行已不存在，setInternal 会安全地忽略。
-            await this.state.isItemMatch.setInternal(mutationEvent.record, false)
-        } else if (mutationEvent.type === 'update') {
-            // 没有 callback 时所有记录恒匹配，字段更新不会改变计数。
-            if (this.args.callback) {
-                // CAUTION update 事件的 record 只携带本次变更的字段，callback 可能依赖其他字段，
-                //  必须拉取全量的 new record 数据再判断（与 Any/Summation 的 update 路径一致）。
-                const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
-                    key: 'id',
-                    value: ['=', mutationEvent.record!.id]
-                }), undefined, this.args.attributeQuery)
-                const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
-                const { oldValue } = await this.state.isItemMatch.replace(newRecord, newItemMatch)
-                delta = Number(newItemMatch) - Number(!!oldValue)
-            }
-        }
-        
+    protected computeItemValue(record: Record<string, unknown>, dataDeps: { [key: string]: unknown }): boolean {
+        return this.callback ? !!this.callback.call(this.controller, record, dataDeps) : true
+    }
+
+    protected async applyDelta(newValue: boolean | null, oldValue: boolean | null): Promise<number> {
+        const delta = Number(!!newValue) - Number(!!oldValue)
         const count = await this.state.count.increment(delta)
-        if (count < 0) throw new Error('GlobalCount became negative')
-        return count;
+        this.assertNonNegative('count', count)
+        return count
+    }
+
+    protected async persistFullResult(values: boolean[]): Promise<number> {
+        const count = values.filter(Boolean).length
+        await this.state.count.setInternal(count)
+        return count
     }
 }
 
-
-type StateWithCallback = {[k:string]: RecordBoundState<boolean>}
-
-export class PropertyCountHandle implements DataBasedComputation {
+export class PropertyCountHandle extends PropertyRelationAggregationHandle<boolean, number, CountInstance> {
     static computationType = Count
     static contextType = 'property' as const
-    callback?: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => boolean
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['_current']
-    relationAttr: string
-    relatedRecordName: string
-    isSource: boolean
-    relation: RelationInstance
-    property: string
-    reverseProperty: string
-    relationAttributeQuery: AttributeQueryData
-    relatedAttributeQuery: AttributeQueryData
+    protected readonly emptyItemValue = false
 
-    constructor(public controller: Controller, public args: CountInstance, public dataContext: PropertyDataContext) {
-        this.callback = this.args.callback?.bind(this.controller)
-        if (this.args.callback) {
-            assertCallbackAttributeQueryDeclared('Count', dataContext, this.args.attributeQuery)
-        }
-        
-        // Find relation by property name or fall back to record
-        if (this.args.property) {
-            this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
-        } else {
-            this.relation = this.args.record as RelationInstance
-        }
-        this.isSource = this.args.direction ? this.args.direction === 'source' : this.relation.source.name === dataContext.host.name
-        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, 'count computation relation direction error')
-        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
-        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
-        this.property = this.args.property || this.relationAttr
-        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
-        
-        const attributeQuery = this.args.attributeQuery || []
-        this.relatedAttributeQuery = attributeQuery.filter(item => item && item[0] !== LINK_SYMBOL) || []
-        const relationQuery: AttributeQueryData|undefined = ((attributeQuery.find(item => item && item[0] === LINK_SYMBOL)||[])[1] as RecordQueryData)?.attributeQuery
-        this.relationAttributeQuery = [
-            [this.isSource ? 'target' : 'source', {attributeQuery: this.relatedAttributeQuery}],
-            ...(relationQuery ? relationQuery : [])
-        ]
-        
-        this.dataDeps = {
-            _current: {
-                type: 'property',
-                attributeQuery: this.callback ? 
-                    [[this.relationAttr, {attributeQuery: attributeQuery.length > 0 ? attributeQuery : ['id']}]] : 
-                    [[this.relationAttr, {attributeQuery: ['id']}]]
-            },
-            ...(this.args.dataDeps || {})
-        }
+    constructor(controller: Controller, args: CountInstance, dataContext: PropertyDataContext) {
+        super(controller, args, dataContext, { computationName: 'Count', allowRecordFallback: true })
     }
 
-    createState(): { count: RecordBoundState<number> } | ({ count: RecordBoundState<number> } & StateWithCallback) {
+    // 无 callback 时贡献恒为「存在即 1」，无逐项状态。
+    protected get itemStateKey(): string | null {
+        return this.callback ? 'isItemMatchCount' : null
+    }
+
+    protected presenceItemValue(): boolean {
+        return true
+    }
+
+    createState() {
         return {
             count: new RecordBoundState<number>(0, this.dataContext.host.name),
             ...(this.callback ? {
@@ -185,125 +74,26 @@ export class PropertyCountHandle implements DataBasedComputation {
             } : {})
         }
     }
-    
+
     getInitialValue() {
         return 0
     }
 
-    async compute({_current, ...dataDeps}: {_current: any, [key: string]: any}): Promise<number> {
-        const relations = _current[this.relationAttr] || [];
-        let count: number = 0;
-        
-        if (this.callback) {
-            // 如果有 callback，过滤符合条件的关联记录
-            for(let item of relations) {
-                const relationStateRecord = item[LINK_SYMBOL] || item['&'] || item
-                const isItemMatch = this.callback!.call(this.controller, item, dataDeps)
-                if (isItemMatch) {
-                    await (this.state as StateWithCallback).isItemMatchCount!.setInternal(relationStateRecord, true)
-                    count++
-                } else {
-                    await (this.state as StateWithCallback).isItemMatchCount!.setInternal(relationStateRecord, false)
-                }
-            }
-        } else {
-            // 如果没有 callback，统计所有关联记录
-            count = relations.length;
-        }
-        
-        await this.state.count.setInternal(_current, count)
-        return count;
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected computeItemValue(relatedItem: Record<string, unknown>, dataDeps: { [key: string]: unknown }): boolean {
+        return this.callback ? !!this.callback.call(this.controller, relatedItem, dataDeps) : true
     }
 
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 只能支持通过 args.record 指定的关联关系或者关联实体的增量更新。
-        if (
-            mutationEvent.recordName !== this.dataContext.host.name ||
-            !mutationEvent.relatedAttribute ||
-            mutationEvent.relatedAttribute.length === 0 || 
-            mutationEvent.relatedAttribute.length > 3 ||
-            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
-            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== '&') ||
-            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== (this.isSource ? 'target' : 'source'))
-        ) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
+    protected async applyDelta(hostRecord: Record<string, unknown>, newValue: boolean | null, oldValue: boolean | null): Promise<number> {
+        const delta = Number(!!newValue) - Number(!!oldValue)
+        const count = await this.state.count.increment(hostRecord, delta)
+        this.assertNonNegative('count', count)
+        return count
+    }
 
-        const relatedMutationEvent = mutationEvent.relatedMutationEvent!;
-        
-        let delta = 0
-
-        if (relatedMutationEvent.type === 'create' && relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的新建
-            if (this.callback) {
-                const relationRecord = relatedMutationEvent.record!;
-                const newRelationWithEntity = await this.controller.system.storage.findOne(
-                    this.relation.name!, 
-                    MatchExp.atom({key: 'id', value: ['=', relationRecord.id]}), 
-                    undefined, 
-                    this.relationAttributeQuery
-                );
-                // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃。
-                if (!newRelationWithEntity) {
-                    return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-                }
-                const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source']
-                relatedRecord['&'] = relationRecord
-                
-                const itemMatch = !!this.callback.call(this.controller, relatedRecord, dataDeps);
-                const { oldValue } = await (this.state as StateWithCallback).isItemMatchCount!.replace(relationRecord, itemMatch)
-                delta = Number(itemMatch) - Number(!!oldValue)
-            } else {
-                delta = 1
-            }
-        } else if (relatedMutationEvent.type === 'delete' && relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的删除。
-            // 注意：删除事件中只有 record（被删除的记录），没有 oldRecord
-            // 这与 Every 和 Summation 的实现保持一致
-            if (this.callback) {
-                if((await (this.state as StateWithCallback).isItemMatchCount!.get(relatedMutationEvent.record))) {
-                    delta = -1
-                }
-                // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
-                //  否则关系再次进入时 replace 读到陈旧值导致增量错误（与 global 路径保持一致）。
-                //  物理删除场景 setInternal 会安全忽略。
-                await (this.state as StateWithCallback).isItemMatchCount!.setInternal(relatedMutationEvent.record, false)
-            } else {
-                delta = -1;
-            }
-        } else if (relatedMutationEvent.type === 'update') {
-            // 这里可能是关联关系上的更新，也可能是关联实体的更新。不管哪一种，我们都重新查询一遍。
-            if(this.callback) {
-                // relatedAttribute 是从当前 dataContext 出发
-                // 现在要把匹配的 key 改成从关联关系出发。
-                const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
-                
-                const newRelationWithEntity = await this.controller.system.storage.findOne(
-                    this.relation.name!, 
-                    MatchExp.atom({key: relationMatchKey, value: ['=', relatedMutationEvent.oldRecord!.id]}), 
-                    undefined, 
-                    this.relationAttributeQuery
-                );
-                if (!newRelationWithEntity) {
-                    return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-                }
-                const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source']
-                relatedRecord['&'] = newRelationWithEntity
-                
-                const isNewMatch = !!this.callback.call(this.controller, relatedRecord, dataDeps);
-                const { oldValue } = await (this.state as StateWithCallback).isItemMatchCount!.replace(newRelationWithEntity, isNewMatch)
-                delta = Number(isNewMatch) - Number(!!oldValue)
-            }
-        } else {
-            return ComputationResult.fullRecompute(`unknown related mutation event for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-        }
-
-        const count = await this.state.count.increment(mutationEvent.record, delta)
-        if (count < 0) throw new Error('PropertyCount became negative')
-        return count;
+    protected async persistFullResult(hostRecord: Record<string, unknown>, values: boolean[]): Promise<number> {
+        const count = values.filter(Boolean).length
+        await this.state.count.setInternal(hostRecord, count)
+        return count
     }
 }
 

--- a/src/runtime/computations/Every.ts
+++ b/src/runtime/computations/Every.ts
@@ -1,6 +1,6 @@
 import { PropertyDataContext } from "./Computation.js";
 import { Every } from "@core";
-import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
+import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
 import { EveryInstance, RelationInstance } from "@core";
 import { Controller } from "../Controller.js";
 import { DataContext } from "./Computation.js";
@@ -20,6 +20,7 @@ export class GlobalEveryHandle implements DataBasedComputation {
     defaultValue: boolean
     constructor(public controller: Controller,  public args: EveryInstance,  public dataContext: DataContext, ) {
         this.callback = this.args.callback.bind(this.controller)
+        assertCallbackAttributeQueryDeclared('Every', dataContext, this.args.attributeQuery)
         this.dataDeps = {
             main: {
                 type: 'records',
@@ -74,8 +75,17 @@ export class GlobalEveryHandle implements DataBasedComputation {
         let matchDelta = 0
         if (mutationEvent.type === 'create') {
             totalDelta = 1
-            const newItemMatch = !!this.callback.call(this.controller, mutationEvent.record, dataDeps) 
-            const { oldValue } = await this.state!.isItemMatch.replace(mutationEvent.record, newItemMatch)
+            // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
+            //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
+            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
+                key: 'id',
+                value: ['=', mutationEvent.record!.id]
+            }), undefined, this.args.attributeQuery)
+            if (!newRecord) {
+                return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for global every`)
+            }
+            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps) 
+            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
             matchDelta = Number(newItemMatch) - Number(!!oldValue)
         } else if (mutationEvent.type === 'delete') {
             totalDelta = -1
@@ -133,6 +143,7 @@ export class PropertyEveryHandle implements DataBasedComputation {
     relatedAttributeQuery: AttributeQueryData
     constructor(public controller: Controller,  public args: EveryInstance,  public dataContext: PropertyDataContext ) {
         this.callback = this.args.callback.bind(this.controller)
+        assertCallbackAttributeQueryDeclared('Every', dataContext, this.args.attributeQuery)
 
         this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
         this.isSource = this.args.direction ? this.args.direction === 'source' :this.relation.source.name === dataContext.host.name

--- a/src/runtime/computations/Every.ts
+++ b/src/runtime/computations/Every.ts
@@ -1,173 +1,72 @@
-import { PropertyDataContext } from "./Computation.js";
-import { Every } from "@core";
-import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, GlobalBoundState, IncrementalPlan, RecordBoundState, RecordsDataDep } from "./Computation.js";
-import { EveryInstance, RelationInstance } from "@core";
+import { Every, EveryInstance } from "@core";
 import { Controller } from "../Controller.js";
-import { DataContext } from "./Computation.js";
-import { EtityMutationEvent } from "../Scheduler.js";
-import { AttributeQueryData, AttributeQueryDataItem, AttributeQueryDataRecordItem, LINK_SYMBOL, MatchExp, RecordQueryData } from "@storage";
-import { assert } from "../util.js";
+import { DataContext, GlobalBoundState, PropertyDataContext, RecordBoundState } from "./Computation.js";
+import { GlobalRecordsAggregationHandle, PropertyRelationAggregationHandle } from "./aggregationTemplate.js";
 
-
-export class GlobalEveryHandle implements DataBasedComputation {
+export class GlobalEveryHandle extends GlobalRecordsAggregationHandle<boolean, boolean, EveryInstance> {
     static computationType = Every
     static contextType = 'global' as const
-    callback: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => boolean
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['main']
+    protected readonly itemStateKey = 'isItemMatch'
+    protected readonly emptyItemValue = false
     defaultValue: boolean
-    constructor(public controller: Controller,  public args: EveryInstance,  public dataContext: DataContext, ) {
-        this.callback = this.args.callback.bind(this.controller)
-        assertCallbackAttributeQueryDeclared('Every', dataContext, this.args.attributeQuery)
-        this.dataDeps = {
-            main: {
-                type: 'records',
-                source: this.args.record!,
-                attributeQuery: this.args.attributeQuery
-            },
-            ...(this.args.dataDeps || {})
-        }
+
+    constructor(controller: Controller, args: EveryInstance, dataContext: DataContext) {
+        super(controller, args, dataContext, { computationName: 'Every', requireCallback: true })
         this.defaultValue = !this.args.notEmpty
     }
 
     createState() {
         return {
             aggregate: new GlobalBoundState<Record<string, number>>({ matchCount: 0, totalCount: 0 }),
-            isItemMatch: new RecordBoundState<boolean>(false, this.args.record!.name!)
+            isItemMatch: new RecordBoundState<boolean>(false, this.record.name!)
         }
     }
-    
+
     getInitialValue() {
         return this.defaultValue
     }
 
-    async compute({main: records, ...dataDeps}: {main: any[], [key: string]: any}): Promise<boolean> {
-        const totalCount = records.length
-        let matchCount = 0
-        
-        for (const item of records) {
-            const isMatch = this.callback.call(this.controller, item, dataDeps)
-            if (isMatch) {
-                matchCount++
-            }
-            await this.state.isItemMatch.setInternal(item, isMatch)
-        }
-        
-        await this.state.aggregate.setInternal({ matchCount, totalCount })
-
-        // CAUTION 空集合不能返回 0 === 0 的空真（vacuous truth），必须与 getInitialValue/增量路径
-        //  保持一致地返回 defaultValue，否则 notEmpty: true 的语义在 full recompute 时会被反转。
-        if (totalCount === 0) return this.defaultValue
-        return matchCount === totalCount
+    protected computeItemValue(record: Record<string, unknown>, dataDeps: { [key: string]: unknown }): boolean {
+        return !!this.callback!.call(this.controller, record, dataDeps)
     }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
-    }
-    async incrementalCompute(lastValue: boolean, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<boolean|ComputationResult> {
-        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新，因为可能有自己和自己的关联关系的 dataDep。
-        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
 
-        let totalDelta = 0
-        let matchDelta = 0
-        if (mutationEvent.type === 'create') {
-            totalDelta = 1
-            // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
-            //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
-            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
-                key: 'id',
-                value: ['=', mutationEvent.record!.id]
-            }), undefined, this.args.attributeQuery)
-            if (!newRecord) {
-                return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for global every`)
-            }
-            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps) 
-            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
-            matchDelta = Number(newItemMatch) - Number(!!oldValue)
-        } else if (mutationEvent.type === 'delete') {
-            totalDelta = -1
-            const oldItemMatch = await this.state!.isItemMatch.get(mutationEvent.record)
-            matchDelta = oldItemMatch ? -1 : 0
-            // CAUTION delete 事件可能只是 filtered entity 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则记录再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
-            await this.state!.isItemMatch.setInternal(mutationEvent.record, false)
-        } else if (mutationEvent.type === 'update') {
-            // CAUTION update 事件的 record 只携带本次变更的字段，callback 可能依赖其他字段，
-            //  必须拉取全量的 new record 数据再判断（与 Any/Summation 的 update 路径一致）。
-            const newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
-                key: 'id',
-                value: ['=', mutationEvent.record!.id]
-            }), undefined, this.args.attributeQuery)
-            const newItemMatch = !!this.callback.call(this.controller, newRecord, dataDeps)
-            const { oldValue } = await this.state!.isItemMatch.replace(newRecord, newItemMatch)
-            matchDelta = Number(newItemMatch) - Number(!!oldValue)
-        }
-
+    protected async applyDelta(newValue: boolean | null, oldValue: boolean | null, presenceDelta: 1 | 0 | -1): Promise<boolean> {
         const aggregate = await this.controller.system.storage.atomic.updateGlobalFields(
             {
                 key: this.state.aggregate.key,
                 valueType: 'json',
                 defaultValue: { matchCount: 0, totalCount: 0 }
             },
-            { matchCount: matchDelta, totalCount: totalDelta },
+            { matchCount: Number(!!newValue) - Number(!!oldValue), totalCount: presenceDelta },
             { matchCount: 0, totalCount: 0 }
         )
-        const matchCount = aggregate.matchCount
-        const totalCount = aggregate.totalCount
+        this.assertNonNegative('matchCount', aggregate.matchCount)
+        this.assertNonNegative('totalCount', aggregate.totalCount)
+        // CAUTION 空集合不能返回 0 === 0 的空真（vacuous truth），必须与 getInitialValue/全量路径
+        //  保持一致地返回 defaultValue，否则 notEmpty: true 的语义会被反转。
+        if (aggregate.totalCount === 0) return this.defaultValue
+        return aggregate.matchCount === aggregate.totalCount
+    }
+
+    protected async persistFullResult(values: boolean[]): Promise<boolean> {
+        const matchCount = values.filter(Boolean).length
+        const totalCount = values.length
+        await this.state.aggregate.setInternal({ matchCount, totalCount })
         if (totalCount === 0) return this.defaultValue
         return matchCount === totalCount
     }
 }
 
-
-
-
-export class PropertyEveryHandle implements DataBasedComputation {
+export class PropertyEveryHandle extends PropertyRelationAggregationHandle<boolean, boolean, EveryInstance> {
     static computationType = Every
     static contextType = 'property' as const
-    callback: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => boolean
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['_current']
-    relationAttr: string
-    relation: RelationInstance
-    relatedRecordName: string
-    property: string
-    reverseProperty: string
-    isSource: boolean   
-    relationAttributeQuery: AttributeQueryData
-    relatedAttributeQuery: AttributeQueryData
-    constructor(public controller: Controller,  public args: EveryInstance,  public dataContext: PropertyDataContext ) {
-        this.callback = this.args.callback.bind(this.controller)
-        assertCallbackAttributeQueryDeclared('Every', dataContext, this.args.attributeQuery)
+    protected readonly itemStateKey = 'isItemMatch'
+    protected readonly emptyItemValue = false
+    defaultValue: boolean
 
-        this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
-        this.isSource = this.args.direction ? this.args.direction === 'source' :this.relation.source.name === dataContext.host.name
-        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, 'every computation relation direction error')
-        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
-        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
-        this.property = this.args.property!
-        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
-        const attributeQuery = this.args.attributeQuery || []
-        this.relatedAttributeQuery = this.args.attributeQuery?.filter(item => item[0] !== LINK_SYMBOL) || []
-        const relationQuery: AttributeQueryData|undefined = ((attributeQuery.find(item => item[0] === LINK_SYMBOL)||[])[1] as RecordQueryData)?.attributeQuery
-        this.relationAttributeQuery = [
-            [this.isSource ? 'target' : 'source', {attributeQuery: this.relatedAttributeQuery}],
-            ...(relationQuery ? relationQuery : [])
-        ]
-
-        this.dataDeps = {
-            _current: {
-                type: 'property',
-                // CAUTION 这里注册的依赖是从当前的 record 出发的。
-                attributeQuery: [[this.property, {attributeQuery: this.args.attributeQuery}]]
-            },
-            ...(this.args.dataDeps || {})
-        }
+    constructor(controller: Controller, args: EveryInstance, dataContext: PropertyDataContext) {
+        super(controller, args, dataContext, { computationName: 'Every', requireCallback: true, requireXToMany: true })
+        this.defaultValue = !this.args.notEmpty
     }
 
     createState() {
@@ -177,135 +76,33 @@ export class PropertyEveryHandle implements DataBasedComputation {
             isItemMatch: new RecordBoundState<boolean>(false, this.relation.name!)
         }
     }
-    
+
     getInitialValue() {
-        return !this.args.notEmpty
+        return this.defaultValue
     }
 
-    async compute({_current, ...dataDeps}: {_current: any, [key: string]: any}): Promise<boolean> {
-        const totalCount = await this.state.totalCount.setInternal(_current,_current[this.relationAttr].length)
-        let matchCount = 0
-        for(const item of _current[this.relationAttr]) {
-            const relationStateRecord = item[LINK_SYMBOL] || item['&'] || item
-            const isMatch = this.callback.call(this.controller, item, dataDeps)
-            if (isMatch) {
-                matchCount++
-            }
-            await this.state!.isItemMatch.setInternal(relationStateRecord, isMatch)
-        }
-        await this.state.matchCount.setInternal(_current, matchCount)
+    protected computeItemValue(relatedItem: Record<string, unknown>, dataDeps: { [key: string]: unknown }): boolean {
+        return !!this.callback!.call(this.controller, relatedItem, dataDeps)
+    }
 
-        // 与 getInitialValue/增量路径一致：空集合返回 defaultValue，不产生空真。
-        if (totalCount === 0) return !this.args.notEmpty
+    protected async applyDelta(hostRecord: Record<string, unknown>, newValue: boolean | null, oldValue: boolean | null, presenceDelta: 1 | 0 | -1): Promise<boolean> {
+        const matchCount = await this.state.matchCount.increment(hostRecord, Number(!!newValue) - Number(!!oldValue))
+        const totalCount = await this.state.totalCount.increment(hostRecord, presenceDelta)
+        this.assertNonNegative('matchCount', matchCount)
+        this.assertNonNegative('totalCount', totalCount)
+        if (totalCount === 0) return this.defaultValue
         return matchCount === totalCount
     }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
-    }
 
-    async incrementalCompute(lastValue: boolean, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<boolean|ComputationResult> {
-        // 只能支持通过 args.record 指定的关联关系或者关联实体的增量更新。
-        if (
-            mutationEvent.recordName !== this.dataContext.host.name ||
-            !mutationEvent.relatedAttribute ||
-            mutationEvent.relatedAttribute.length === 0 || 
-            mutationEvent.relatedAttribute.length > 3 ||
-            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
-            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== '&') ||
-            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== (this.isSource ? 'target' : 'source'))
-        ) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-        const relatedMutationEvent = mutationEvent.relatedMutationEvent!
-
-        // TODO 如果未来支持用户可以自定义 dataDeps，那么这里也要支持如果发现是其他 dataDeps 变化，这里要直接返回重算的信号。
-        let matchDelta = 0
-        let totalDelta = 0
-
-        // 关联实体只有更新才会触发到这里来，这是监听时就决定了的。
-        // 关联关系的增删改都会到这里来。
-        if (relatedMutationEvent.type === 'create'&&relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的新建
-            const relationRecord = relatedMutationEvent.record!
-            const newRelationWithEntity = await this.controller.system.storage.findOne(this.relation.name!, MatchExp.atom({
-                key: 'id',
-                value: ['=', relationRecord.id]
-            }), undefined, this.relationAttributeQuery)
-            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃（与 Count/Summation 一致）。
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source']
-            relatedRecord['&'] = relationRecord
-
-            const newItemMatch = !!this.callback.call(this.controller, relatedRecord, dataDeps) 
-            let oldValue: boolean | null
-            try {
-                ;({ oldValue } = await this.state!.isItemMatch.replace(relationRecord, newItemMatch))
-            } catch (error) {
-                if (error instanceof Error && error.message.includes('Atomic replace target not found')) {
-                    return ComputationResult.fullRecompute('relation contribution state target not found')
-                }
-                throw error
-            }
-            matchDelta = Number(newItemMatch) - Number(!!oldValue)
-            totalDelta = 1
-        } else if (relatedMutationEvent.type === 'delete'&&relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的删除
-            const relationRecord = relatedMutationEvent.record!
-            const oldItemMatch = !!await this.state!.isItemMatch.get(relationRecord)
-            matchDelta = oldItemMatch ? -1 : 0
-            totalDelta = -1
-            // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则关系再次进入时 replace 读到陈旧值导致增量错误（与 global 路径保持一致）。
-            await this.state!.isItemMatch.setInternal(relationRecord, false)
-        } else if (relatedMutationEvent.type === 'update'&&(relatedMutationEvent.recordName === this.relation.name!||relatedMutationEvent.recordName === this.relatedRecordName)) {
-            // 关联实体或者关联关系上的字段的更新
-            // 关联关系或者关联实体的更新
-            // relatedAttribute 是从当前 dataContext 出发
-            // 现在要把匹配的 key 改成从关联关系出发。
-        
-            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
-
-            const relationMatch = MatchExp.atom({
-                key: relationMatchKey,
-                value: ['=', relatedMutationEvent!.oldRecord!.id]
-            }) 
-
-            const relationRecord = await this.controller.system.storage.findOne(this.relation.name!, relationMatch, undefined, this.relationAttributeQuery)
-            // 关系记录已不可见（被删除/filtered 成员资格变化竞态）时退回全量重算（与 Count/Summation 一致）。
-            if (!relationRecord) {
-                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = relationRecord[this.isSource ? 'target' : 'source']
-            relatedRecord['&'] = relationRecord
-
-            const newItemMatch = !!this.callback.call(this.controller, relatedRecord, dataDeps)
-            let oldValue: boolean | null
-            try {
-                ;({ oldValue } = await this.state!.isItemMatch.replace(relationRecord, newItemMatch))
-            } catch (error) {
-                if (error instanceof Error && error.message.includes('Atomic replace target not found')) {
-                    return ComputationResult.fullRecompute('relation contribution state target not found')
-                }
-                throw error
-            }
-            matchDelta = Number(newItemMatch) - Number(!!oldValue)
-        } else {
-            return ComputationResult.fullRecompute('mutation is not caused by relation.')
-        }
-        const matchCount = await this.state!.matchCount.increment(mutationEvent.record, matchDelta)
-        const totalCount = await this.state!.totalCount.increment(mutationEvent.record, totalDelta)
-        if (totalCount === 0) return !this.args.notEmpty
+    protected async persistFullResult(hostRecord: Record<string, unknown>, values: boolean[]): Promise<boolean> {
+        const matchCount = values.filter(Boolean).length
+        const totalCount = values.length
+        await this.state.matchCount.setInternal(hostRecord, matchCount)
+        await this.state.totalCount.setInternal(hostRecord, totalCount)
+        if (totalCount === 0) return this.defaultValue
         return matchCount === totalCount
     }
 }
-
-
-
-
-
 
 // Export Every computation handles
 export const EveryHandles = [GlobalEveryHandle, PropertyEveryHandle];

--- a/src/runtime/computations/Summation.ts
+++ b/src/runtime/computations/Summation.ts
@@ -1,273 +1,93 @@
-import { DataContext, PropertyDataContext, RecordBoundState, GlobalBoundState } from "./Computation.js";
 import { Summation } from "@core";
 import { Controller } from "../Controller.js";
-import { SummationInstance, EntityInstance, RelationInstance } from "@core";
-import { buildRelationSideMatchKey, ComputationResult, DataBasedComputation, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep } from "./Computation.js";
-import { EtityMutationEvent } from "../Scheduler.js";
-import { MatchExp, AttributeQueryData, LINK_SYMBOL } from "@storage";
-import { assert } from "../util.js";
-import { RecordQueryData } from "@storage";
+import { SummationInstance } from "@core";
+import { DataContext, GlobalBoundState, PropertyDataContext, RecordBoundState } from "./Computation.js";
+import { GlobalRecordsAggregationHandle, parseAggregationFieldPath, PropertyRelationAggregationHandle } from "./aggregationTemplate.js";
 
-export class GlobalSumHandle implements DataBasedComputation {
+/** null/undefined/NaN/Infinity 一律按 0 计，避免一条脏记录通过 increment 永久污染总和。 */
+function resolveSumField(record: Record<string, unknown>, sumFieldPath: string[]): number {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let base: any = record
+    for (const attr of sumFieldPath) {
+        base = base[attr]
+        if (base === undefined || base === null) return 0
+    }
+    return (Number.isNaN(base) || !Number.isFinite(base)) ? 0 : base
+}
+
+export class GlobalSumHandle extends GlobalRecordsAggregationHandle<number, number, SummationInstance> {
     static computationType = Summation
     static contextType = 'global' as const
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['main']
-    record: (EntityInstance|RelationInstance)
+    protected readonly itemStateKey = 'itemValue'
+    protected readonly emptyItemValue = 0
     sumFieldPath: string[]
-    constructor(public controller: Controller, public args: SummationInstance, public dataContext: DataContext) {
-        this.record = this.args.record!
-        
-        // 获取 attributeQuery 的第一个字段作为求和字段
-        if (!this.args.attributeQuery || this.args.attributeQuery.length === 0) {
-            throw new Error('Sum computation requires attributeQuery with at least one field')
-        }
 
-        this.sumFieldPath = []
-        let attrPointer:any = this.args.attributeQuery
-        while(attrPointer) {
-            this.sumFieldPath.push(Array.isArray(attrPointer[0]) ? attrPointer[0][0]: attrPointer[0])
-            attrPointer = Array.isArray(attrPointer[0]) ? attrPointer[0][1].attributeQuery : null
-        }
-
-        this.dataDeps = {
-            main: {
-                type: 'records',
-                source: this.record,
-                attributeQuery:this.args.attributeQuery
-            }
-        }
+    constructor(controller: Controller, args: SummationInstance, dataContext: DataContext) {
+        super(controller, args, dataContext, { computationName: 'Summation', requireAttributeQueryField: true })
+        this.sumFieldPath = parseAggregationFieldPath(this.args.attributeQuery!)
     }
-    
+
     createState() {
         return {
             sum: new GlobalBoundState<number>(0),
             itemValue: new RecordBoundState<number>(0, this.record.name!)
-        }   
+        }
     }
-    
+
     getInitialValue() {
         return 0
     }
 
-    resolveSumField(record:any, sumFieldPath = this.sumFieldPath) {
-        let base:any = record
-        for(let attr of sumFieldPath) {
-            base = base[attr]
-            if (base === undefined||base === null) return 0
-        }
-        return (Number.isNaN(base)||!Number.isFinite(base) ) ? 0: base
+    protected computeItemValue(record: Record<string, unknown>): number {
+        return resolveSumField(record, this.sumFieldPath)
     }
-    async compute({main: records}: {main: any[]}): Promise<number> {
-        let sum = 0;
-        
-        for (const record of records) {
-            const value = this.resolveSumField(record) || 0;
-            sum += value;
-            await this.state.itemValue.setInternal(record, value);
-        }
-        
+
+    protected async applyDelta(newValue: number | null, oldValue: number | null): Promise<number> {
+        return this.state.sum.increment((newValue ?? 0) - (oldValue ?? 0))
+    }
+
+    protected async persistFullResult(values: number[]): Promise<number> {
+        const sum = values.reduce((acc, value) => acc + value, 0)
         await this.state.sum.setInternal(sum)
-        return sum;
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
-    }
-
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新，因为可能有自己和自己的关联关系的 dataDep。
-        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-        let delta = 0
-        
-        if (mutationEvent.type === 'create') {
-            const newRecord = await this.controller.system.storage.findOne(this.record.name!, MatchExp.atom({key:'id', value:['=', mutationEvent.record!.id]}), undefined, this.args.attributeQuery)
-            const value = this.resolveSumField(newRecord);
-            const { oldValue } = await this.state.itemValue.replace(newRecord, value)
-            delta = value - (oldValue ?? 0)
-        } else if (mutationEvent.type === 'delete') {
-            const oldValue = await this.state.itemValue.get(mutationEvent.record);
-            delta = -(oldValue ?? 0)
-            // CAUTION delete 事件可能只是 filtered entity 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则记录再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
-            await this.state.itemValue.setInternal(mutationEvent.record, 0)
-        } else if (mutationEvent.type === 'update') {
-            const newRecord = await this.controller.system.storage.findOne(this.record.name!, MatchExp.atom({key:'id', value:['=', mutationEvent.record!.id]}), undefined, this.args.attributeQuery)
-            const newValue = this.resolveSumField(newRecord);
-            const { oldValue } = await this.state.itemValue.replace(newRecord, newValue)
-            delta = newValue - (oldValue ?? 0)
-        }
-        
-        return this.state.sum.increment(delta);
+        return sum
     }
 }
 
-export class PropertySumHandle implements DataBasedComputation {
+export class PropertySumHandle extends PropertyRelationAggregationHandle<number, number, SummationInstance> {
     static computationType = Summation
     static contextType = 'property' as const
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['_current']
-    relationAttr: string
-    relatedRecordName: string
-    isSource: boolean
-    relation: RelationInstance
-    property: string
-    reverseProperty: string
-    relationAttributeQuery: AttributeQueryData
-    relatedAttributeQuery: AttributeQueryData
+    protected readonly itemStateKey = 'itemResult'
+    protected readonly emptyItemValue = 0
     sumFieldPath: string[]
 
-    constructor(public controller: Controller, public args: SummationInstance, public dataContext: PropertyDataContext) {
-        // Find relation by property name or fall back to record
-        this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
-        assert(this.relation, 'summation computation must specify either property or record')
-        this.isSource = this.args.direction ? this.args.direction === 'source' : this.relation.source.name === dataContext.host.name
-        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, 'summation computation relation direction error')
-        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
-        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
-        this.property = this.args.property!
-        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
-        
-        const attributeQuery = this.args.attributeQuery || []
-        this.relatedAttributeQuery = this.args.attributeQuery?.filter(item => item[0] !== LINK_SYMBOL) || []
-        const relationQuery: AttributeQueryData|undefined = ((attributeQuery.find(item => item[0] === LINK_SYMBOL)||[])[1] as RecordQueryData)?.attributeQuery
-        this.relationAttributeQuery = [
-            [this.isSource ? 'target' : 'source', {attributeQuery: this.relatedAttributeQuery}],
-            ...(relationQuery ? relationQuery : [])
-        ]
-        
-        // 解析 attributeQuery 获取求和字段
-        
-        this.sumFieldPath = []
-        let attrPointer:any = attributeQuery
-        while(attrPointer) {
-            this.sumFieldPath.push(Array.isArray(attrPointer[0]) ? attrPointer[0][0]: attrPointer[0])
-            attrPointer = Array.isArray(attrPointer[0]) ? attrPointer[0][1].attributeQuery : null
-        }
-        
-        this.dataDeps = {
-            _current: {
-                type: 'property',
-                attributeQuery: [[this.relationAttr, {attributeQuery: this.args.attributeQuery}]]
-            }
-        }
+    constructor(controller: Controller, args: SummationInstance, dataContext: PropertyDataContext) {
+        super(controller, args, dataContext, { computationName: 'Summation', requireAttributeQueryField: true })
+        this.sumFieldPath = parseAggregationFieldPath(this.args.attributeQuery!)
     }
 
     createState() {
         return {
             sum: new RecordBoundState<number>(0, this.dataContext.host.name),
             itemResult: new RecordBoundState<number>(0, this.relation.name!)
-        }    
+        }
     }
-    
+
     getInitialValue() {
         return 0
     }
-    resolveSumField(record:any, sumFieldPath = this.sumFieldPath) {
-        let base:any = record
-        for(let attr of sumFieldPath) {
-            base = base[attr]
-            if (base === undefined||base === null) return 0
-        }
-        return (Number.isNaN(base)||!Number.isFinite(base) ) ? 0: base
+
+    protected computeItemValue(relatedItem: Record<string, unknown>): number {
+        return resolveSumField(relatedItem, this.sumFieldPath)
     }
 
-    async compute({_current}: {_current: any}): Promise<number> {
-        const relations = _current[this.relationAttr] || [];
-        let sum = 0;
-        
-        for (const relatedItem of relations) {
-            const relationStateRecord = relatedItem[LINK_SYMBOL] || relatedItem['&'] || relatedItem
-            const value = this.resolveSumField(relatedItem, this.sumFieldPath) || 0;
-            sum += value;
-            await this.state.itemResult.setInternal(relationStateRecord, value);
-        }
-        
-        await this.state.sum.setInternal(_current, sum)
-        return sum;
-    }
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected async applyDelta(hostRecord: Record<string, unknown>, newValue: number | null, oldValue: number | null): Promise<number> {
+        return this.state.sum.increment(hostRecord, (newValue ?? 0) - (oldValue ?? 0))
     }
 
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 只能支持通过 args.record 指定的关联关系或者关联实体的增量更新。
-        if (
-            mutationEvent.recordName !== this.dataContext.host.name ||
-            !mutationEvent.relatedAttribute ||
-            mutationEvent.relatedAttribute.length === 0 || 
-            mutationEvent.relatedAttribute.length > 3 ||
-            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
-            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== '&') ||
-            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== (this.isSource ? 'target' : 'source'))
-        ) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-        const relatedMutationEvent = mutationEvent.relatedMutationEvent;
-        if (!relatedMutationEvent) {
-            return ComputationResult.fullRecompute('No related mutation event')
-        }
-        
-        let delta = 0
-
-        if (relatedMutationEvent.type === 'create' && relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的新建
-            const relationRecord = relatedMutationEvent.record!;
-            const newRelationWithEntity = await this.controller.system.storage.findOne(
-                this.relation.name!,
-                MatchExp.atom({key: 'id', value: ['=', relationRecord.id]}), 
-                undefined, 
-                this.relationAttributeQuery
-            );
-            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃。
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record ${relationRecord.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source'];
-            relatedRecord['&'] = newRelationWithEntity;
-            const value = this.resolveSumField(relatedRecord) || 0;
-            const { oldValue } = await this.state.itemResult.replace(newRelationWithEntity, value);
-            delta = value - (oldValue ?? 0);
-        } else if (relatedMutationEvent.type === 'delete' && relatedMutationEvent.recordName === this.relation.name!) {
-             // 关联关系的删除
-             const oldResult = await this.state!.itemResult.get(relatedMutationEvent.record);
-             delta = -(oldResult ?? 0);
-             // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
-             //  否则关系再次进入时 replace 读到陈旧值导致增量错误（与 global 路径保持一致）。
-             await this.state!.itemResult.setInternal(relatedMutationEvent.record, 0);
-        } else if (relatedMutationEvent.type === 'update') {
-            // relatedAttribute 是从当前 dataContext 出发
-            // 现在要把匹配的 key 改成从关联关系出发。
-            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
-            
-            const newRelationWithEntity = await this.controller.system.storage.findOne(
-                this.relation.name!, 
-                MatchExp.atom({key: relationMatchKey, value: ['=', relatedMutationEvent.oldRecord!.id]}), 
-                undefined, 
-                this.relationAttributeQuery
-            );
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source'];
-            relatedRecord['&'] = newRelationWithEntity;
-            const newValue = this.resolveSumField(relatedRecord) || 0;
-            const { oldValue } = await this.state.itemResult.replace(newRelationWithEntity, newValue);
-            delta = newValue - (oldValue ?? 0);
-        } else {
-            // 与 Count/Any/Every 保持一致：未知的 related 事件形态必须退回全量重算，
-            //  静默 delta=0 会让聚合悄悄停滞（漂移类 bug 的温床）。
-            return ComputationResult.fullRecompute(`unknown related mutation event for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-        }
-
-        return this.state.sum.increment(mutationEvent.record, delta);
+    protected async persistFullResult(hostRecord: Record<string, unknown>, values: number[]): Promise<number> {
+        const sum = values.reduce((acc, value) => acc + value, 0)
+        await this.state.sum.setInternal(hostRecord, sum)
+        return sum
     }
 }
 

--- a/src/runtime/computations/WeightedSummation.ts
+++ b/src/runtime/computations/WeightedSummation.ts
@@ -2,7 +2,7 @@ import { DataContext, PropertyDataContext } from "./Computation.js";
 import { WeightedSummation } from "@core";
 import { Controller } from "../Controller.js";
 import { WeightedSummationInstance, EntityInstance, RelationInstance } from "@core";
-import { buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep, RecordBoundState, GlobalBoundState } from "./Computation.js";
+import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep, RecordBoundState, GlobalBoundState } from "./Computation.js";
 import { DataBasedComputation } from "./Computation.js";
 import { EtityMutationEvent } from "../Scheduler.js";
 import { AttributeQueryData, MatchExp, LINK_SYMBOL, RecordQueryData } from "@storage";
@@ -29,7 +29,7 @@ export class GlobalWeightedSummationHandle implements DataBasedComputation {
     constructor(public controller: Controller, public args: WeightedSummationInstance, public dataContext: DataContext) {
         this.matchRecordToWeight = this.args.callback.bind(this.controller)
         this.record = this.args.record!
-        
+        assertCallbackAttributeQueryDeclared('WeightedSummation', dataContext, this.args.attributeQuery)
         
         this.dataDeps = {
             main: {
@@ -74,7 +74,15 @@ export class GlobalWeightedSummationHandle implements DataBasedComputation {
         }
         let delta = 0
         if (mutationEvent.type === 'create') {
-            const newItem = mutationEvent.record;
+            // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
+            //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
+            const newItem = await this.controller.system.storage.findOne(this.record.name!, MatchExp.atom({
+                key: 'id',
+                value: ['=', mutationEvent.record!.id]
+            }), undefined, (this.dataDeps.main as RecordsDataDep).attributeQuery);
+            if (!newItem) {
+                return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for global weighted summation`)
+            }
             const weightAndValue = this.matchRecordToWeight.call(this.controller, newItem, dataDeps);
             const newResult = resolveWeightedResult(weightAndValue);
             const { oldValue } = await this.state.itemResult.replace(newItem, newResult);
@@ -119,6 +127,7 @@ export class PropertyWeightedSummationHandle implements DataBasedComputation {
 
     constructor(public controller: Controller, public args: WeightedSummationInstance, public dataContext: PropertyDataContext) {
         this.matchRecordToWeight = this.args.callback.bind(this.controller)
+        assertCallbackAttributeQueryDeclared('WeightedSummation', dataContext, this.args.attributeQuery)
 
         // Find relation by property name
         this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!

--- a/src/runtime/computations/WeightedSummation.ts
+++ b/src/runtime/computations/WeightedSummation.ts
@@ -1,12 +1,7 @@
-import { DataContext, PropertyDataContext } from "./Computation.js";
-import { WeightedSummation } from "@core";
+import { WeightedSummation, WeightedSummationInstance } from "@core";
 import { Controller } from "../Controller.js";
-import { WeightedSummationInstance, EntityInstance, RelationInstance } from "@core";
-import { assertCallbackAttributeQueryDeclared, buildRelationSideMatchKey, ComputationResult, DataDep, DataDepEventContext, defaultDataBasedIncrementalPlan, IncrementalPlan, RecordsDataDep, RecordBoundState, GlobalBoundState } from "./Computation.js";
-import { DataBasedComputation } from "./Computation.js";
-import { EtityMutationEvent } from "../Scheduler.js";
-import { AttributeQueryData, MatchExp, LINK_SYMBOL, RecordQueryData } from "@storage";
-import { assert } from "../util.js";
+import { DataContext, GlobalBoundState, PropertyDataContext, RecordBoundState } from "./Computation.js";
+import { GlobalRecordsAggregationHandle, PropertyRelationAggregationHandle } from "./aggregationTemplate.js";
 
 // CAUTION 与 Summation.resolveSumField 的语义对齐：null/undefined/NaN/Infinity 一律按 0 计。
 //  否则一条脏记录产生的 NaN 会通过 increment 永久污染总和，且无法通过后续增量恢复。
@@ -16,35 +11,16 @@ function resolveWeightedResult(weightAndValue: { weight: number; value: number }
     return Number.isFinite(result) ? result : 0
 }
 
-export class GlobalWeightedSummationHandle implements DataBasedComputation {
+export class GlobalWeightedSummationHandle extends GlobalRecordsAggregationHandle<number, number, WeightedSummationInstance> {
     static computationType = WeightedSummation
     static contextType = 'global' as const
-    matchRecordToWeight: (this: Controller, item: any, dataDeps?: {[key: string]: unknown}) => { weight: number; value: number }
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['main']
-    record: (EntityInstance|RelationInstance)
+    protected readonly itemStateKey = 'itemResult'
+    protected readonly emptyItemValue = 0
 
-    constructor(public controller: Controller, public args: WeightedSummationInstance, public dataContext: DataContext) {
-        this.matchRecordToWeight = this.args.callback.bind(this.controller)
-        this.record = this.args.record!
-        assertCallbackAttributeQueryDeclared('WeightedSummation', dataContext, this.args.attributeQuery)
-        
-        this.dataDeps = {
-            main: {
-                type: 'records',
-                source: this.record,
-                attributeQuery: this.args.attributeQuery
-            },
-            ...(this.args.dataDeps || {})
-        }
+    constructor(controller: Controller, args: WeightedSummationInstance, dataContext: DataContext) {
+        super(controller, args, dataContext, { computationName: 'WeightedSummation', requireCallback: true })
     }
 
-    
-    getInitialValue() {
-        return 0
-    }
     createState() {
         return {
             total: new GlobalBoundState<number>(0),
@@ -52,208 +28,58 @@ export class GlobalWeightedSummationHandle implements DataBasedComputation {
         }
     }
 
-    async compute({main: records, ...dataDeps}: {main: any[], [key: string]: any}): Promise<number> {
-        let summation = 0;
-        
-        for (const record of records) {
-            const weightAndValue = this.matchRecordToWeight.call(this.controller, record, dataDeps);
-            summation += await this.state.itemResult.setInternal(record, resolveWeightedResult(weightAndValue));
-        }
-        await this.state.total.setInternal(summation)
-        return summation;
+    getInitialValue() {
+        return 0
     }
 
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected computeItemValue(record: Record<string, unknown>, dataDeps: { [key: string]: unknown }): number {
+        return resolveWeightedResult(this.callback!.call(this.controller, record, dataDeps))
     }
 
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, _record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新，因为可能有自己和自己的关联关系的 dataDep。
-        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-        let delta = 0
-        if (mutationEvent.type === 'create') {
-            // CAUTION create 事件的 record 只携带写入时的字段（defaultValues + payload），callback 可能
-            //  依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量 new record 再判断（与 update 路径一致）。
-            const newItem = await this.controller.system.storage.findOne(this.record.name!, MatchExp.atom({
-                key: 'id',
-                value: ['=', mutationEvent.record!.id]
-            }), undefined, (this.dataDeps.main as RecordsDataDep).attributeQuery);
-            if (!newItem) {
-                return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on create for global weighted summation`)
-            }
-            const weightAndValue = this.matchRecordToWeight.call(this.controller, newItem, dataDeps);
-            const newResult = resolveWeightedResult(weightAndValue);
-            const { oldValue } = await this.state.itemResult.replace(newItem, newResult);
-            delta = newResult - (oldValue ?? 0);
-        } else if (mutationEvent.type === 'delete') {
-            const oldResult = await this.state.itemResult.get(mutationEvent.record);
-            delta = -(oldResult ?? 0);
-            // CAUTION delete 事件可能只是 filtered entity 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则记录再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
-            await this.state.itemResult.setInternal(mutationEvent.record, 0)
-        } else if (mutationEvent.type === 'update') {
-            const newRecord = await this.controller.system.storage.findOne(this.record.name!, MatchExp.atom({
-                key: 'id',
-                value: ['=', mutationEvent.record!.id]
-            }), undefined, (this.dataDeps.main as RecordsDataDep).attributeQuery);
-            const newWeightAndValue = this.matchRecordToWeight.call(this.controller, newRecord, dataDeps);
-            const newResult = resolveWeightedResult(newWeightAndValue);
-            const { oldValue } = await this.state.itemResult.replace(newRecord, newResult);
-            delta = newResult - (oldValue ?? 0);
-        }
+    protected async applyDelta(newValue: number | null, oldValue: number | null): Promise<number> {
+        return this.state.total.increment((newValue ?? 0) - (oldValue ?? 0))
+    }
 
-        return this.state.total.increment(delta);
+    protected async persistFullResult(values: number[]): Promise<number> {
+        const total = values.reduce((acc, value) => acc + value, 0)
+        await this.state.total.setInternal(total)
+        return total
     }
 }
 
-export class PropertyWeightedSummationHandle implements DataBasedComputation {
+export class PropertyWeightedSummationHandle extends PropertyRelationAggregationHandle<number, number, WeightedSummationInstance> {
     static computationType = WeightedSummation
     static contextType = 'property' as const
-    matchRecordToWeight: (this: Controller, item: any, dataDeps: {[key: string]: unknown}) => { weight: number; value: number }
-    state!: ReturnType<typeof this.createState>
-    useLastValue: boolean = false
-    dataDeps: {[key: string]: DataDep} = {}
-    primaryDataDepKeys = ['_current']
-    relationAttr: string
-    relatedRecordName: string
-    isSource: boolean
-    relation: RelationInstance
-    property: string
-    reverseProperty: string
-    relationAttributeQuery: AttributeQueryData
-    relatedAttributeQuery: AttributeQueryData
+    protected readonly itemStateKey = 'itemResult'
+    protected readonly emptyItemValue = 0
 
-    constructor(public controller: Controller, public args: WeightedSummationInstance, public dataContext: PropertyDataContext) {
-        this.matchRecordToWeight = this.args.callback.bind(this.controller)
-        assertCallbackAttributeQueryDeclared('WeightedSummation', dataContext, this.args.attributeQuery)
-
-        // Find relation by property name
-        this.relation = this.controller.relations.find(r => (r.source === dataContext.host && r.sourceProperty === this.args.property) || (r.target === dataContext.host && r.targetProperty === this.args.property))!
-        assert(this.relation, 'weighted summation computation must specify property')
-        this.isSource = this.args.direction ? this.args.direction === 'source' : this.relation.source.name === dataContext.host.name
-        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, 'weighted summation computation relation direction error')
-        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
-        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
-        this.property = this.args.property || this.relationAttr
-        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
-        
-        const attributeQuery = this.args.attributeQuery || []
-        this.relatedAttributeQuery = this.args.attributeQuery?.filter(item => item[0] !== LINK_SYMBOL) || []
-        const relationQuery: AttributeQueryData|undefined = ((attributeQuery.find(item => item[0] === LINK_SYMBOL)||[])[1] as RecordQueryData)?.attributeQuery
-        this.relationAttributeQuery = [
-            [this.isSource ? 'target' : 'source', {attributeQuery: this.relatedAttributeQuery}],
-            ...(relationQuery ? relationQuery : [])
-        ]
-        
-        this.dataDeps = {
-            _current: {
-                type: 'property',
-                attributeQuery: [[this.relationAttr, {attributeQuery: this.args.attributeQuery}]]
-            },
-            ...(this.args.dataDeps || {})
-        }
+    constructor(controller: Controller, args: WeightedSummationInstance, dataContext: PropertyDataContext) {
+        super(controller, args, dataContext, { computationName: 'WeightedSummation', requireCallback: true })
     }
 
     createState() {
         return {
             total: new RecordBoundState<number>(0, this.dataContext.host.name),
             itemResult: new RecordBoundState<number>(0, this.relation.name!)
-        }   
+        }
     }
-    
+
     getInitialValue() {
         return 0
     }
 
-    async compute({_current, ...dataDeps}: {_current: any, [key: string]: any}): Promise<number> {
-        const relations = _current[this.relationAttr] || [];
-        let summation = 0;
-        
-        for (const relatedItem of relations) {
-            const relationStateRecord = relatedItem[LINK_SYMBOL] || relatedItem['&'] || relatedItem
-            const valueAndWeight = this.matchRecordToWeight.call(this.controller, relatedItem, dataDeps);
-            const result = resolveWeightedResult(valueAndWeight);
-            await this.state.itemResult.setInternal(relationStateRecord, result);
-            summation += result;
-        }
-        
-        await this.state.total.setInternal(_current, summation);
-        return summation;
+    protected computeItemValue(relatedItem: Record<string, unknown>, dataDeps: { [key: string]: unknown }): number {
+        return resolveWeightedResult(this.callback!.call(this.controller, relatedItem, dataDeps))
     }
 
-    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
-        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    protected async applyDelta(hostRecord: Record<string, unknown>, newValue: number | null, oldValue: number | null): Promise<number> {
+        return this.state.total.increment(hostRecord, (newValue ?? 0) - (oldValue ?? 0))
     }
 
-    async incrementalCompute(lastValue: number, mutationEvent: EtityMutationEvent, record: any, dataDeps: {[key: string]: unknown}): Promise<number|ComputationResult> {
-        // 只能支持通过 args.record 指定的关联关系或者关联实体的增量更新。
-        if (
-            mutationEvent.recordName !== this.dataContext.host.name ||
-            !mutationEvent.relatedAttribute ||
-            mutationEvent.relatedAttribute.length === 0 || 
-            mutationEvent.relatedAttribute.length > 3 ||
-            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
-            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== '&') ||
-            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== (this.isSource ? 'target' : 'source'))
-        ) {
-            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
-        }
-
-
-        let delta = 0;
-        const relatedMutationEvent = mutationEvent.relatedMutationEvent!;
-
-        if (relatedMutationEvent.type === 'create' && relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的新建
-            const newRelationWithEntity = await this.controller.system.storage.findOne(this.relation.name!, MatchExp.atom({
-                key: 'id',
-                value: ['=', relatedMutationEvent.record!.id]
-            }), undefined, this.relationAttributeQuery);
-            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃。
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record ${relatedMutationEvent.record!.id} not found for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source'];
-            relatedRecord['&'] = newRelationWithEntity;
-            const valueAndWeight = this.matchRecordToWeight.call(this.controller, relatedRecord, dataDeps);
-            const result = resolveWeightedResult(valueAndWeight);
-            const { oldValue } = await this.state!.itemResult.replace(newRelationWithEntity, result);
-            delta = result - (oldValue ?? 0);
-        } else if (relatedMutationEvent.type === 'delete' && relatedMutationEvent.recordName === this.relation.name!) {
-            // 关联关系的删除
-            const oldResult = await this.state!.itemResult.get(relatedMutationEvent.record);
-            delta = -(oldResult ?? 0);
-            // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
-            //  否则关系再次进入时 replace 读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
-            await this.state!.itemResult.setInternal(relatedMutationEvent.record, 0);
-        } else if (relatedMutationEvent.type === 'update') {
-            // relatedAttribute 是从当前 dataContext 出发
-            // 现在要把匹配的 key 改成从关联关系出发。
-            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.isSource ? 'target' : 'source')
-            
-            const newRelationWithEntity = await this.controller.system.storage.findOne(
-                this.relation.name!, 
-                MatchExp.atom({key: relationMatchKey, value: ['=', relatedMutationEvent.oldRecord!.id]}), 
-                undefined, 
-                this.relationAttributeQuery
-            );
-            if (!newRelationWithEntity) {
-                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-            }
-            const relatedRecord = newRelationWithEntity[this.isSource ? 'target' : 'source'];
-            relatedRecord['&'] = newRelationWithEntity;
-            const newValueAndWeight = this.matchRecordToWeight.call(this.controller, relatedRecord, dataDeps);
-            const newResult = resolveWeightedResult(newValueAndWeight);
-            const { oldValue } = await this.state!.itemResult.replace(newRelationWithEntity, newResult);
-            delta = newResult - (oldValue ?? 0);
-        } else {
-            // 与 Count/Any/Every 保持一致：未知的 related 事件形态必须退回全量重算。
-            return ComputationResult.fullRecompute(`unknown related mutation event for ${this.dataContext.host.name}.${this.dataContext.id.name}`)
-        }
-
-        return this.state.total.increment(mutationEvent.record, delta);
+    protected async persistFullResult(hostRecord: Record<string, unknown>, values: number[]): Promise<number> {
+        const total = values.reduce((acc, value) => acc + value, 0)
+        await this.state.total.setInternal(hostRecord, total)
+        return total
     }
 }
 

--- a/src/runtime/computations/aggregationTemplate.ts
+++ b/src/runtime/computations/aggregationTemplate.ts
@@ -1,0 +1,449 @@
+import { EntityInstance, RelationInstance } from "@core";
+import { Controller } from "../Controller.js";
+import { AttributeQueryData, LINK_SYMBOL, MatchExp, RecordQueryData } from "@storage";
+import { assert } from "../util.js";
+import {
+    assertCallbackAttributeQueryDeclared,
+    buildRelationSideMatchKey,
+    ComputationResult,
+    DataBasedComputation,
+    DataContext,
+    DataDep,
+    DataDepEventContext,
+    defaultDataBasedIncrementalPlan,
+    describeDataContext,
+    GlobalBoundState,
+    IncrementalPlan,
+    PropertyDataContext,
+    RecordBoundState,
+    RecordsDataDep
+} from "./Computation.js";
+import { EtityMutationEvent } from "../ComputationSourceMap.js";
+import { ComputationError } from "../errors/ComputationErrors.js";
+
+/**
+ * 六个内置聚合（Count / Summation / Average / Every / Any / WeightedSummation）的共享增量模板。
+ *
+ * 背景：六个聚合的 global / property 两个 handle 此前各自手写「事件守卫 → 拉全记录 →
+ * 逐项贡献状态维护 → 聚合增量应用」的骨架，历轮 review 累计 15+ 个缺陷全部源于
+ * 六份骨架的手工同步漂移（create 路径用局部事件 record、update 不注册监听、
+ * 负值无守卫、空集合语义、`&` 挂载不一致……）。模板把骨架收敛为单一实现：
+ *
+ * - 统一的 mutation 事件守卫（recordName / relatedAttribute 形态检查）；
+ * - create/update 一律先按 attributeQuery 拉全记录再计算贡献（增量与全量重算同一取数口径）；
+ * - 统一的「记录已不可见 → fullRecompute」竞态防御与 `Atomic replace target not found` 防御；
+ * - 统一的逐项贡献绑定状态维护（delete/成员资格退出时复位，避免重入读到陈旧值）；
+ * - 统一的负值守卫入口（计数类聚合状态为负说明状态与事件流失步，必须 fail-fast）。
+ *
+ * 各聚合只声明三件事：单条记录的贡献值（computeItemValue）、一次贡献变化如何应用到
+ * 聚合状态（applyDelta）、全量重算如何落盘（persistFullResult）。绑定状态的名字与形状
+ * 由各 handle 自持（createState），保证与既有部署的状态列/dict key 兼容。
+ */
+
+export type AggregationItemValue = number | boolean
+
+export type AggregationArgs = {
+    record?: EntityInstance | RelationInstance
+    property?: string
+    direction?: string
+    attributeQuery?: AttributeQueryData
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- 与 core 的 CreateArgs 声明对齐；各聚合 callback 形态不同（boolean / {weight, value}）
+    callback?: Function
+    // 与 core 的 DataDependencies 声明对齐（索引值为 unknown），运行时按 DataDep 消费。
+    dataDeps?: { [key: string]: unknown }
+}
+
+export type AggregationOptions = {
+    /** 用于错误信息与校验定位，如 'Count' */
+    computationName: string
+    /** callback 是必填（Every/Any/WeightedSummation） */
+    requireCallback?: boolean
+    /** attributeQuery 必须至少声明一个字段（Summation/Average：聚合字段来自 attributeQuery） */
+    requireAttributeQueryField?: boolean
+    /** 允许 args.record 直接指定 relation（Count 的历史用法） */
+    allowRecordFallback?: boolean
+    /** 宿主侧必须是 x:n 关系（Every/Any：对单值关系做全称/存在量词没有意义） */
+    requireXToMany?: boolean
+}
+
+/** 从 attributeQuery 解析聚合字段路径（Summation/Average 共用） */
+export function parseAggregationFieldPath(attributeQuery: AttributeQueryData): string[] {
+    const path: string[] = []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- attributeQuery 是递归的异构结构
+    let attrPointer: any = attributeQuery
+    while (attrPointer) {
+        path.push(Array.isArray(attrPointer[0]) ? attrPointer[0][0] : attrPointer[0])
+        attrPointer = Array.isArray(attrPointer[0]) ? attrPointer[0][1].attributeQuery : null
+    }
+    return path
+}
+
+function validateAggregationArgs(args: AggregationArgs, dataContext: DataContext, options: AggregationOptions) {
+    if (options.requireCallback) {
+        assert(typeof args.callback === 'function', `${options.computationName} computation of ${describeDataContext(dataContext)} requires a callback`)
+    }
+    if (args.callback) {
+        assertCallbackAttributeQueryDeclared(options.computationName, dataContext, args.attributeQuery)
+    }
+    if (options.requireAttributeQueryField && (!args.attributeQuery || args.attributeQuery.length === 0)) {
+        throw new Error(`${options.computationName} computation requires attributeQuery with at least one field`)
+    }
+}
+
+/**
+ * Global（records 源）聚合模板。
+ */
+export abstract class GlobalRecordsAggregationHandle<V extends AggregationItemValue, TResult, TArgs extends AggregationArgs = AggregationArgs> implements DataBasedComputation {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- 状态形状由子类 createState 决定
+    state!: any
+    useLastValue: boolean = false
+    dataDeps: { [key: string]: DataDep } = {}
+    primaryDataDepKeys = ['main']
+    record: EntityInstance | RelationInstance
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    callback?: (this: Controller, item: any, dataDeps?: { [key: string]: unknown }) => any
+    protected readonly options: AggregationOptions
+
+    constructor(public controller: Controller, public args: TArgs, public dataContext: DataContext, options: AggregationOptions) {
+        this.options = options
+        validateAggregationArgs(args, dataContext, options)
+        this.record = args.record!
+        if (args.callback) {
+            this.callback = args.callback.bind(this.controller)
+        }
+        this.dataDeps = {
+            main: {
+                type: 'records',
+                source: this.record,
+                attributeQuery: args.attributeQuery
+            },
+            ...((args.dataDeps || {}) as { [key: string]: DataDep })
+        }
+    }
+
+    /** this.state 里逐项贡献绑定状态的 key */
+    protected abstract readonly itemStateKey: string
+    /** 贡献复位值（delete/成员资格退出时写回，防重入读到陈旧值） */
+    protected abstract readonly emptyItemValue: V
+    /** 计算单条记录的贡献值。record 已按 attributeQuery 拉全（与全量重算同一口径）。 */
+    protected abstract computeItemValue(record: Record<string, unknown>, dataDeps: { [key: string]: unknown }): V
+    /** 把一次贡献变化应用到聚合状态并返回计算结果。presenceDelta：create=1 / update=0 / delete=-1。 */
+    protected abstract applyDelta(newValue: V | null, oldValue: V | null, presenceDelta: 1 | 0 | -1): Promise<TResult>
+    /** 全量重算：把所有贡献写入聚合状态并返回计算结果。 */
+    protected abstract persistFullResult(values: V[]): Promise<TResult>
+    /** 增量 create/update 是否需要按 attributeQuery 拉全记录。默认 true；仅 Count 无 callback 时可跳过。 */
+    protected requiresItemFetch(): boolean { return true }
+
+    abstract createState(): { [key: string]: RecordBoundState<unknown> | GlobalBoundState<unknown> }
+    abstract getInitialValue(): unknown
+
+    protected get itemState(): RecordBoundState<V> {
+        return this.state[this.itemStateKey] as RecordBoundState<V>
+    }
+
+    protected assertNonNegative(name: string, value: number): void {
+        if (value < 0) {
+            throw new ComputationError(
+                `${this.options.computationName} ${name} became negative for ${describeDataContext(this.dataContext)} — bound state and event stream are out of sync`,
+                { computationName: this.options.computationName, dataContext: this.dataContext }
+            )
+        }
+    }
+
+    protected async replaceItemState(record: Record<string, unknown>, value: V): Promise<{ oldValue: V | null } | ComputationResult> {
+        try {
+            return await this.itemState.replace(record, value)
+        } catch (error) {
+            // 竞态防御：目标行在事件与增量计算之间被物理删除（级联等），退回全量重算而不是崩溃。
+            if (error instanceof Error && error.message.includes('Atomic replace target not found')) {
+                return ComputationResult.fullRecompute(`${this.options.computationName} item state target not found`)
+            }
+            throw error
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async compute({ main: records, ...dataDeps }: { main: any[], [key: string]: any }): Promise<TResult> {
+        const values: V[] = []
+        for (const record of records) {
+            const value = this.computeItemValue(record, dataDeps)
+            await this.itemState.setInternal(record, value)
+            values.push(value)
+        }
+        return this.persistFullResult(values)
+    }
+
+    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
+        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async incrementalCompute(lastValue: unknown, mutationEvent: EtityMutationEvent, record: any, dataDeps: { [key: string]: unknown }): Promise<TResult | ComputationResult> {
+        // 注意要同时检测名字和 relatedAttribute 才能确定是不是自己的更新，因为可能有自己和自己的关联关系的 dataDep。
+        if (mutationEvent.recordName !== (this.dataDeps.main as RecordsDataDep).source!.name || mutationEvent.relatedAttribute?.length) {
+            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
+        }
+
+        if (mutationEvent.type === 'create' || mutationEvent.type === 'update') {
+            // CAUTION mutation 事件的 record 只携带写入时的字段（defaultValues + payload / 本次变更字段），
+            //  贡献计算可能依赖计算列或 attributeQuery 声明的关联数据，必须拉取全量记录（与全量重算同一口径）。
+            let newRecord = mutationEvent.record as Record<string, unknown>
+            if (this.requiresItemFetch()) {
+                newRecord = await this.controller.system.storage.findOne(mutationEvent.recordName, MatchExp.atom({
+                    key: 'id',
+                    value: ['=', mutationEvent.record!.id]
+                }), undefined, this.args.attributeQuery)
+                if (!newRecord) {
+                    return ComputationResult.fullRecompute(`record ${mutationEvent.record!.id} not found on ${mutationEvent.type} for ${describeDataContext(this.dataContext)}`)
+                }
+            }
+            const value = this.computeItemValue(newRecord, dataDeps)
+            const replaced = await this.replaceItemState(newRecord, value)
+            if (replaced instanceof ComputationResult) return replaced
+            return this.applyDelta(value, replaced.oldValue, mutationEvent.type === 'create' ? 1 : 0)
+        }
+
+        if (mutationEvent.type === 'delete') {
+            // CAUTION delete 事件不一定意味着物理行删除：filtered entity 的成员资格退出事件里底层行仍然存在，
+            //  必须复位绑定状态，否则记录再次进入时读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
+            const oldValue = await this.itemState.get(mutationEvent.record)
+            await this.itemState.setInternal(mutationEvent.record, this.emptyItemValue)
+            return this.applyDelta(null, oldValue ?? null, -1)
+        }
+
+        return ComputationResult.fullRecompute(`unknown mutation event type for ${describeDataContext(this.dataContext)}`)
+    }
+}
+
+/**
+ * Property（关系源）聚合模板。
+ * 宿主实体的属性 = 对关联关系集合的聚合。增量事件的形态是宿主 update 事件 +
+ * relatedAttribute 定位到关系/关联实体上的 create/delete/update。
+ */
+export abstract class PropertyRelationAggregationHandle<V extends AggregationItemValue, TResult, TArgs extends AggregationArgs = AggregationArgs> implements DataBasedComputation {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    state!: any
+    useLastValue: boolean = false
+    dataDeps: { [key: string]: DataDep } = {}
+    primaryDataDepKeys = ['_current']
+    relation!: RelationInstance
+    isSource: boolean
+    relationAttr: string
+    relatedRecordName: string
+    property: string
+    reverseProperty: string
+    relationAttributeQuery: AttributeQueryData
+    relatedAttributeQuery: AttributeQueryData
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    callback?: (this: Controller, item: any, dataDeps?: { [key: string]: unknown }) => any
+    protected readonly options: AggregationOptions
+
+    constructor(public controller: Controller, public args: TArgs, public dataContext: PropertyDataContext, options: AggregationOptions) {
+        this.options = options
+        validateAggregationArgs(args, dataContext, options)
+        if (args.callback) {
+            this.callback = args.callback.bind(this.controller)
+        }
+
+        if (args.property) {
+            this.relation = this.controller.relations.find(r =>
+                (r.source === dataContext.host && r.sourceProperty === args.property) ||
+                (r.target === dataContext.host && r.targetProperty === args.property)
+            )!
+        } else if (options.allowRecordFallback) {
+            this.relation = args.record as RelationInstance
+        }
+        assert(!!this.relation, `cannot find relation for property "${args.property}" of ${describeDataContext(dataContext)} in ${options.computationName} computation`)
+
+        this.isSource = args.direction ? args.direction === 'source' : this.relation.source.name === dataContext.host.name
+        assert(this.isSource ? this.relation.source === dataContext.host : this.relation.target === dataContext.host, `${options.computationName.toLowerCase()} computation relation direction error`)
+
+        if (options.requireXToMany) {
+            let baseRelation = this.relation.baseRelation || this.relation
+            while (baseRelation.baseRelation) {
+                baseRelation = baseRelation.baseRelation
+            }
+            const relType = baseRelation.type.split(':')
+            assert(relType[this.isSource ? 1 : 0] === 'n', `property-level ${options.computationName} computation argument must be an x:n relation. ${dataContext.host.name}.${args.property}" is a ${this.isSource ? relType.join(':') : relType.slice().reverse().join(':')} relation`)
+        }
+
+        this.relationAttr = this.isSource ? this.relation.sourceProperty : this.relation.targetProperty
+        this.relatedRecordName = this.isSource ? this.relation.target.name! : this.relation.source.name!
+        this.property = args.property || this.relationAttr
+        this.reverseProperty = this.isSource ? this.relation.targetProperty : this.relation.sourceProperty
+
+        const attributeQuery = args.attributeQuery || []
+        this.relatedAttributeQuery = attributeQuery.filter(item => item && item[0] !== LINK_SYMBOL)
+        const relationQuery: AttributeQueryData | undefined = ((attributeQuery.find(item => item && item[0] === LINK_SYMBOL) || [])[1] as RecordQueryData)?.attributeQuery
+        this.relationAttributeQuery = [
+            [this.isSource ? 'target' : 'source', { attributeQuery: this.relatedAttributeQuery }],
+            ...(relationQuery ? relationQuery : [])
+        ]
+
+        this.dataDeps = {
+            _current: {
+                type: 'property',
+                attributeQuery: [[this.relationAttr, { attributeQuery: attributeQuery.length > 0 ? attributeQuery : ['id'] }]]
+            },
+            ...((args.dataDeps || {}) as { [key: string]: DataDep })
+        }
+    }
+
+    /**
+     * this.state 里逐项贡献绑定状态的 key；null 表示不维护逐项状态
+     * （Count 无 callback 时贡献恒为「存在即 1」，无需状态）。
+     */
+    protected abstract readonly itemStateKey: string | null
+    protected abstract readonly emptyItemValue: V
+    /** 无逐项状态时，「存在性」贡献值（Count 无 callback：true）。 */
+    protected presenceItemValue(): V { return this.emptyItemValue }
+    /** 计算单条关联记录的贡献值。relatedItem 已挂 `&`（关系记录，按 relationAttributeQuery 拉全）。 */
+    protected abstract computeItemValue(relatedItem: Record<string, unknown>, dataDeps: { [key: string]: unknown }): V
+    /** 把一次贡献变化应用到宿主聚合状态并返回计算结果。 */
+    protected abstract applyDelta(hostRecord: Record<string, unknown>, newValue: V | null, oldValue: V | null, presenceDelta: 1 | 0 | -1): Promise<TResult>
+    /** 全量重算：把所有贡献写入宿主聚合状态并返回计算结果。 */
+    protected abstract persistFullResult(hostRecord: Record<string, unknown>, values: V[]): Promise<TResult>
+
+    abstract createState(): { [key: string]: RecordBoundState<unknown> | GlobalBoundState<unknown> }
+    abstract getInitialValue(): unknown
+
+    protected get itemState(): RecordBoundState<V> | null {
+        return this.itemStateKey ? this.state[this.itemStateKey] as RecordBoundState<V> : null
+    }
+
+    protected get relationSide(): 'source' | 'target' {
+        return this.isSource ? 'target' : 'source'
+    }
+
+    protected assertNonNegative(name: string, value: number): void {
+        if (value < 0) {
+            throw new ComputationError(
+                `${this.options.computationName} ${name} became negative for ${describeDataContext(this.dataContext)} — bound state and event stream are out of sync`,
+                { computationName: this.options.computationName, dataContext: this.dataContext }
+            )
+        }
+    }
+
+    protected async replaceItemState(relationRecord: Record<string, unknown>, value: V): Promise<{ oldValue: V | null } | ComputationResult> {
+        try {
+            return await this.itemState!.replace(relationRecord, value)
+        } catch (error) {
+            // 竞态防御：关系行在事件与增量计算之间被物理删除，退回全量重算而不是崩溃。
+            if (error instanceof Error && error.message.includes('Atomic replace target not found')) {
+                return ComputationResult.fullRecompute(`${this.options.computationName} relation contribution state target not found`)
+            }
+            throw error
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async compute({ _current, ...dataDeps }: { _current: any, [key: string]: any }): Promise<TResult> {
+        const relations = _current[this.relationAttr] || []
+        const values: V[] = []
+        for (const relatedItem of relations) {
+            const relationStateRecord = relatedItem[LINK_SYMBOL] || relatedItem
+            const value = this.computeItemValue(relatedItem, dataDeps)
+            if (this.itemState) {
+                await this.itemState.setInternal(relationStateRecord, value)
+            }
+            values.push(value)
+        }
+        return this.persistFullResult(_current, values)
+    }
+
+    planIncremental(_event: EtityMutationEvent, _record: unknown, context: DataDepEventContext): IncrementalPlan {
+        return defaultDataBasedIncrementalPlan(this.dataDeps, this.primaryDataDepKeys, context)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async incrementalCompute(lastValue: unknown, mutationEvent: EtityMutationEvent, record: any, dataDeps: { [key: string]: unknown }): Promise<TResult | ComputationResult> {
+        // 只能支持通过声明的关联关系或者关联实体的增量更新。
+        if (
+            mutationEvent.recordName !== this.dataContext.host.name ||
+            !mutationEvent.relatedAttribute ||
+            mutationEvent.relatedAttribute.length === 0 ||
+            mutationEvent.relatedAttribute.length > 3 ||
+            mutationEvent.relatedAttribute[0] !== this.relationAttr ||
+            (mutationEvent.relatedAttribute[1] && mutationEvent.relatedAttribute[1] !== LINK_SYMBOL) ||
+            (mutationEvent.relatedAttribute[2] && mutationEvent.relatedAttribute[2] !== this.relationSide)
+        ) {
+            return ComputationResult.fullRecompute('mutationEvent.recordName not match')
+        }
+
+        const relatedMutationEvent = mutationEvent.relatedMutationEvent
+        if (!relatedMutationEvent) {
+            return ComputationResult.fullRecompute('No related mutation event')
+        }
+        const hostRecord = mutationEvent.record as Record<string, unknown>
+
+        if (relatedMutationEvent.type === 'create' && relatedMutationEvent.recordName === this.relation.name!) {
+            // 关联关系的新建
+            if (!this.itemState) {
+                // 无逐项状态（Count 无 callback）：贡献 = 存在即 presenceItemValue，无需回查关系。
+                return this.applyDelta(hostRecord, this.presenceItemValue(), null, 1)
+            }
+            const relationRecordId = relatedMutationEvent.record!.id
+            // CAUTION create 事件的 record 只携带写入时的字段，贡献计算可能依赖计算列或关联数据，
+            //  必须按 relationAttributeQuery 回查全量（与全量重算同一口径）。
+            const relationWithEntity = await this.controller.system.storage.findOne(
+                this.relation.name!,
+                MatchExp.atom({ key: 'id', value: ['=', relationRecordId] }),
+                undefined,
+                this.relationAttributeQuery
+            )
+            // 关系记录在事件与增量计算之间可能已被删除（级联/竞态），退回全量重算而不是裸解引用崩溃。
+            if (!relationWithEntity) {
+                return ComputationResult.fullRecompute(`relation record ${relationRecordId} not found for ${describeDataContext(this.dataContext)}`)
+            }
+            const relatedRecord = relationWithEntity[this.relationSide]
+            relatedRecord[LINK_SYMBOL] = relationWithEntity
+            const value = this.computeItemValue(relatedRecord, dataDeps)
+            const replaced = await this.replaceItemState(relationWithEntity, value)
+            if (replaced instanceof ComputationResult) return replaced
+            return this.applyDelta(hostRecord, value, replaced.oldValue, 1)
+        }
+
+        if (relatedMutationEvent.type === 'delete' && relatedMutationEvent.recordName === this.relation.name!) {
+            // 关联关系的删除。
+            // CAUTION delete 事件可能只是 filtered relation 的成员资格退出（行仍存在），必须复位绑定状态，
+            //  否则关系再次进入时读到陈旧值导致增量错误。物理删除场景 setInternal 会安全忽略。
+            let oldValue: V | null
+            if (this.itemState) {
+                oldValue = await this.itemState.get(relatedMutationEvent.record)
+                await this.itemState.setInternal(relatedMutationEvent.record, this.emptyItemValue)
+            } else {
+                oldValue = this.presenceItemValue()
+            }
+            return this.applyDelta(hostRecord, null, oldValue ?? null, -1)
+        }
+
+        if (relatedMutationEvent.type === 'update') {
+            // 关联关系或关联实体上的字段更新。
+            if (!this.itemState) {
+                // 无逐项状态（Count 无 callback）：字段更新不改变存在性贡献。
+                return this.applyDelta(hostRecord, this.presenceItemValue(), this.presenceItemValue(), 0)
+            }
+            // relatedAttribute 是从当前 dataContext 出发，转换成从关联关系出发的 match key 反查关系记录。
+            const relationMatchKey = buildRelationSideMatchKey(mutationEvent.relatedAttribute, this.relationSide)
+            const relationWithEntity = await this.controller.system.storage.findOne(
+                this.relation.name!,
+                MatchExp.atom({ key: relationMatchKey, value: ['=', relatedMutationEvent.oldRecord!.id] }),
+                undefined,
+                this.relationAttributeQuery
+            )
+            // 关系记录已不可见（被删除/filtered 成员资格变化竞态）时退回全量重算。
+            if (!relationWithEntity) {
+                return ComputationResult.fullRecompute(`relation record not found by ${relationMatchKey} for ${describeDataContext(this.dataContext)}`)
+            }
+            const relatedRecord = relationWithEntity[this.relationSide]
+            relatedRecord[LINK_SYMBOL] = relationWithEntity
+            const value = this.computeItemValue(relatedRecord, dataDeps)
+            const replaced = await this.replaceItemState(relationWithEntity, value)
+            if (replaced instanceof ComputationResult) return replaced
+            return this.applyDelta(hostRecord, value, replaced.oldValue, 0)
+        }
+
+        // 未知的 related 事件形态必须退回全量重算，静默 delta=0 会让聚合悄悄停滞。
+        return ComputationResult.fullRecompute(`unknown related mutation event for ${describeDataContext(this.dataContext)}`)
+    }
+}

--- a/src/runtime/migration.ts
+++ b/src/runtime/migration.ts
@@ -3318,7 +3318,12 @@ class MigrationScheduler {
                     if (event) events.push(event);
                     continue;
                 }
-                const dirtyRecordsAndEvents = await this.controller.scheduler.computeDataBasedDirtyRecordsAndEvents(source as DataBasedEntityEventsSourceMap, mutationEvent);
+                // 与 live Scheduler 的事件路由保持同一守卫：filtered 源的 update 监听挂在物理 base 名上，
+                //  必须做成员资格判定并把事件名改写回 filtered 名，否则链式 rebuild 会把
+                //  「成员资格事件 + 字段 update」双计，或把 stay-out 记录的更新错误路由进聚合。
+                const routedEvent = await this.controller.scheduler.resolveFilteredUpdateEvent(source, mutationEvent, mutationEvents);
+                if (!routedEvent) continue;
+                const dirtyRecordsAndEvents = await this.controller.scheduler.computeDataBasedDirtyRecordsAndEvents(source as DataBasedEntityEventsSourceMap, routedEvent);
                 for (const [record, event] of dirtyRecordsAndEvents) {
                     events.push(...await this.runOneDirtyComputation(computation as DataBasedComputation, event, record));
                 }

--- a/src/storage/erstorage/DeletionExecutor.ts
+++ b/src/storage/erstorage/DeletionExecutor.ts
@@ -282,18 +282,21 @@ export class DeletionExecutor {
                 key: `${info.getReverseInfo()?.attributeName!}.id`,
                 value: ['in', records.map(r => r.id)]
             })
+            // 删除关系时，要增加上当前 record 的引用。
+            // 只需要回填本次 deleteRecord 追加的事件（记录起点），避免每层 reliance 都全量扫描
+            // 共享事件数组（深级联 + 事件多的场景会退化成 O(n×m)）。
+            const eventsLengthBeforeDelete = events?.length ?? 0
             await this.deleteRecord(info.recordName, matchInIds, events)
             if (events) {
-                // 删除关系时，要增加上当前 record 的引用。
-                // TODO 这里需要更加高效的方法
-                events.forEach(event => {
+                for (let i = eventsLengthBeforeDelete; i < events.length; i++) {
+                    const event = events[i]
                     if (event.recordName === info.linkName) {
                         const record = recordsById!.get(event.record![info.isRecordSource() ? 'source' : 'target'].id)
                         if (record) {
                             event.record![info.isRecordSource() ? 'source' : 'target'] = record
                         }
                     }
-                })
+                }
             }
         }
     }

--- a/src/storage/erstorage/EntityToTableMap.ts
+++ b/src/storage/erstorage/EntityToTableMap.ts
@@ -395,13 +395,15 @@ export class EntityToTableMap {
             assert(!!recordAttribute?.linkName, `${entityName}.${attribute} is not a record attribute`)
             const relationName = recordAttribute.linkName
             const relationData = this.data.links[relationName]
-            if (relationData.sourceRecord === entityName && relationData.sourceProperty === attribute) {
+            // CAUTION 端点可能是 filtered entity（属性同时登记在 resolved base record 上），
+            //  此时 link 的 sourceRecord/targetRecord 是 filtered 名，与 entityName（base 名）不相等，
+            //  所以用属性自身的 isSource 判定方向，而不是端点名字符串匹配。
+            if (recordAttribute.isSource) {
+                assert(relationData.sourceProperty === attribute, `wrong relation data ${entityName}.${attribute}`)
                 return relationData.targetProperty!
-            } else if (relationData.targetRecord === entityName && relationData.targetProperty === attribute) {
-                return relationData.sourceProperty
             } else {
-                assert(false, `wrong relation data ${entityName}.${attribute}`)
-                return ''
+                assert(relationData.targetProperty === attribute, `wrong relation data ${entityName}.${attribute}`)
+                return relationData.sourceProperty
             }
         }
         

--- a/src/storage/erstorage/LinkInfo.ts
+++ b/src/storage/erstorage/LinkInfo.ts
@@ -99,8 +99,14 @@ export class LinkInfo {
     isSymmetric() {
         return this.data.sourceRecord === this.data.targetRecord && this.data.sourceProperty === this.data.targetProperty
     }
+    // CAUTION link 的端点可能是 filtered entity（如 Relation.create({ source: ActiveUser, ... })），
+    //  而调用方（删除级联/更新 unlink 等）经常拿的是 resolved base 名（'User'）。filtered 与 base
+    //  共享同一属性命名空间（Setup.validateRelations 保证家族内属性名唯一），所以按 resolved 名比较。
+    private resolveRecordName(recordName: string) {
+        return this.map.data.records[recordName]?.resolvedBaseRecordName || recordName
+    }
     isRelationSource(recordName: string, attribute: string) {
-        return this.data.sourceRecord === recordName && this.data.sourceProperty === attribute
+        return this.resolveRecordName(this.data.sourceRecord) === this.resolveRecordName(recordName) && this.data.sourceProperty === attribute
     }
 
     getAttributeName(recordName: string, attribute: string) {

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -26,11 +26,14 @@ export class MatchExp {
         assert(condition.value[1] !== undefined, `${condition.key} value cannot be undefined`)
         return BoolExp.atom<MatchAtom>(condition)
     }
-    // TODO 支持更复杂的格式
-    // object 表达批量的 and
-    public static fromObject(condition: { [key: string]: MatchAtom }) {
+    // object 表达批量的 and：每个键值对编译为 `key = value` 的相等匹配。
+    // CAUTION 值是原始比较值（不是 MatchAtom）：旧签名声明 MatchAtom 会诱导调用方传入
+    //  { key, value } 对象并被嵌成 ['=', {key,...}] 的错误 RHS。需要其他操作符时用 atom()/and() 组合。
+    public static fromObject(condition: { [key: string]: unknown }) {
+        const entries = Object.entries(condition)
+        assert(entries.length > 0, 'MatchExp.fromObject requires at least one key')
         let root: BoolExp<MatchAtom> | undefined
-        Object.entries(condition).forEach(([key, value]) => {
+        entries.forEach(([key, value]) => {
               if (!root) {
                   root = MatchExp.atom({key, value: ['=', value]})
               }  else {

--- a/src/storage/erstorage/RecordQueryAgent.ts
+++ b/src/storage/erstorage/RecordQueryAgent.ts
@@ -96,6 +96,11 @@ export class RecordQueryAgent implements RecordOperationAgent {
     /**
      * 处理合并记录和关系的闪出
      * 用于创建和更新场景中处理合并记录的数据迁移
+     *
+     * CAUTION 事件语义（tests/storage/combinedRecordEvents.spec.ts 固化）：
+     *  内部的 deleteRecordSameRowData 是**物理行搬迁**——被抢夺实体的逻辑身份（id）全程不变，
+     *  所以刻意不产生实体级 delete/create 事件（否则下游聚合会被虚假地减/加一次）。
+     *  事件流只反映关系层面的事实：旧 link delete + 新 link create（见下方 events?.push）。
      */
     async flashOutCombinedRecordsAndMergedLinks(newEntityData: NewRecordData, events?: RecordMutationEvent[], reason = ''): Promise<{ [k: string]: RawEntityData }> {
         const result: { [k: string]: RawEntityData } = {}
@@ -200,6 +205,12 @@ export class RecordQueryAgent implements RecordOperationAgent {
     /**
      * 重定位合并记录数据用于链接
      * 用于 unlink 场景中处理合并记录的数据迁移
+     *
+     * CAUTION 事件语义（tests/storage/combinedRecordEvents.spec.ts 固化）：
+     *  「删旧行 + 插新行」是**物理行搬迁**——被搬迁实体的逻辑身份（id）全程不变，
+     *  所以刻意不产生实体级 delete/create 事件；事件流只反映 link delete 这一业务事实。
+     *  注意该路径只对非 reliance 的 combined link 可达（reliance unlink 是业务级 fail-fast），
+     *  即目前只有 DBSetup 的 mergeLinks 配置能触达。
      */
     async relocateCombinedRecordDataForLink(linkName: string, matchExpressionData: MatchExpressionData, moveSource = false, events?: RecordMutationEvent[]): Promise<Record[]> {
         const attributeQuery: AttributeQueryData = AttributeQuery.getAttributeQueryDataForRecord(linkName, this.map, true, true, true, true)

--- a/src/storage/erstorage/Setup.ts
+++ b/src/storage/erstorage/Setup.ts
@@ -473,6 +473,18 @@ export class DBSetup {
     }
 
     /**
+     * 解析 endpoint（entity 或 relation）沿 base 链的最底层 record 名。
+     * 普通 entity/relation 返回自己的名字。
+     */
+    private resolveEndpointRootName(endpoint: EntityInstance | RelationInstance): string {
+        let current: EntityInstance | RelationInstance = endpoint
+        while ((current as EntityInstance).baseEntity || (current as RelationInstance).baseRelation) {
+            current = ((current as EntityInstance).baseEntity || (current as RelationInstance).baseRelation)!
+        }
+        return current.name!
+    }
+
+    /**
      * 验证 relations
      * 
      * 检查 filtered entity 上的关系属性名是否与其 base entity 的关系属性名冲突。
@@ -528,6 +540,40 @@ export class DBSetup {
                 }
             }
         })
+
+        // 家族级冲突检查：关系属性最终都登记到 resolved base record 上（filtered entity 与 base
+        //  共享同一张表和同一个属性命名空间），所以同一 base 家族里（base 自身 + 全部 filtered 变体）
+        //  不同 relation 不能声明相同的属性名。上面的链式检查只覆盖 filtered-vs-base-chain，
+        //  这里补齐兄弟 filtered entity 之间、以及 base 在 filtered 之后声明的同名冲突。
+        const familyProps = new Map<string, Map<string, { relations: Set<RelationInstance>, declarers: Set<string> }>>()
+        const registerFamilyProp = (endpoint: EntityInstance | RelationInstance, prop: string | undefined, relation: RelationInstance) => {
+            if (!prop) return
+            const rootName = this.resolveEndpointRootName(endpoint)
+            let props = familyProps.get(rootName)
+            if (!props) familyProps.set(rootName, props = new Map())
+            let entry = props.get(prop)
+            if (!entry) props.set(prop, entry = { relations: new Set(), declarers: new Set() })
+            entry.relations.add(relation)
+            entry.declarers.add(endpoint.name!)
+        }
+        this.relations.forEach(relation => {
+            registerFamilyProp(relation.source, relation.sourceProperty, relation)
+            registerFamilyProp(relation.target, relation.targetProperty, relation)
+        })
+        familyProps.forEach((props, rootName) => {
+            props.forEach((entry, prop) => {
+                // 同一个 relation 的对称两端共用同一属性名是合法的（symmetric relation）。
+                const hasFilteredDeclarer = Array.from(entry.declarers).some(name => name !== rootName)
+                if (entry.relations.size > 1 && hasFilteredDeclarer) {
+                    throw new Error(
+                        `Relation property name conflict: property '${prop}' is declared by multiple relations ` +
+                        `within the same base record family '${rootName}' (declared on: ${Array.from(entry.declarers).join(', ')}). ` +
+                        `Filtered entities share the base entity's attribute namespace, ` +
+                        `so each relation property name must be unique across the base entity and all its filtered entities.`
+                    )
+                }
+            })
+        })
     }
 
     /**
@@ -579,7 +625,7 @@ export class DBSetup {
             const sourceLink = isFilteredRelation ? this.map.links[relationRecord.baseRelationName!]! : undefined
             
 
-            this.map.records[relationData.sourceRecord].attributes[relationData.sourceProperty] = {
+            const sourceAttribute = {
                 type: 'id',
                 isRecord:true,
                 relType: relationData.relType,
@@ -596,11 +642,21 @@ export class DBSetup {
                 resolvedMatchExpression: isFilteredRelation? relationRecord.resolvedMatchExpression: undefined,
                 resolvedBaseRecordName: isFilteredRelation? relationRecord?.resolvedBaseRecordName: undefined
             } as RecordAttribute
+            this.map.records[relationData.sourceRecord].attributes[relationData.sourceProperty] = sourceAttribute
+            // CAUTION 端点是 filtered entity/relation 时，属性必须同时登记到 resolved base record 上：
+            //  查询编译（RecordQuery.create）统一按 resolvedBaseRecordName 解析属性，删除级联也遍历
+            //  base record 的属性表。copyAttributesToFilteredEntities（步骤 4.5）随后会把 base 的
+            //  完整属性表复制回全部 filtered 变体（含声明该关系的这个）。
+            //  虚拟 link（isSourceRelation，即 relation 记录自身的 source/target 属性）除外：
+            //  filtered relation 的 source/target 属性由 copy 阶段统一继承 base relation 的虚拟 link。
+            if (!relationData.isSourceRelation) {
+                this.registerAttributeOnResolvedBase(relationData.sourceRecord, relationData.sourceProperty, sourceAttribute)
+            }
 
             // CAUTION 关联查询时，不可能出现从实体来获取一个关系的情况，语义不正确。
             assert(!(relationData.isSourceRelation && relationData.targetProperty), 'virtual relation should not have targetProperty')
             if (relationData.targetProperty) {
-                this.map.records[relationData.targetRecord].attributes[relationData.targetProperty] = {
+                const targetAttribute = {
                     type: 'id',
                     isRecord:true,
                     // CAUTION 这里翻转了！在 AttributeInfo 中方便判断。不能用 Array.reverse()，因为不会返回新数组。
@@ -614,6 +670,9 @@ export class DBSetup {
                     matchExpression: isFilteredRelation?relationData.matchExpression: undefined,
                     baseRelationAttributeName: isFilteredRelation? sourceLink?.targetProperty: undefined
                 } as RecordAttribute
+                this.map.records[relationData.targetRecord].attributes[relationData.targetProperty] = targetAttribute
+                // 同 source 侧：filtered 端点的属性同步登记到 resolved base record。
+                this.registerAttributeOnResolvedBase(relationData.targetRecord, relationData.targetProperty, targetAttribute)
             }
         })
     }
@@ -629,6 +688,20 @@ export class DBSetup {
                 this.validateFilteredEntityPaths(entityWithProps.baseEntity.name, entityWithProps.matchExpression);
             }
         });
+    }
+
+    /**
+     * 把 filtered entity/relation 端点上声明的关系属性同步登记到 resolved base record。
+     * 见 populateRecordAttributes 中的 CAUTION 注释。
+     */
+    private registerAttributeOnResolvedBase(recordName: string, attributeName: string, attribute: RecordAttribute) {
+        const record = this.map.records[recordName]
+        const resolvedName = record?.resolvedBaseRecordName
+        if (resolvedName && resolvedName !== recordName) {
+            const baseRecord = this.map.records[resolvedName]
+            assert(!!baseRecord, `resolved base record ${resolvedName} not found for ${recordName}`)
+            baseRecord.attributes[attributeName] = { ...attribute }
+        }
     }
 
     /**

--- a/tests/builtins/serialization-r8.spec.ts
+++ b/tests/builtins/serialization-r8.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * r8 显著改进项回归：序列化往返收尾（r1 I-10 遗留）。
+ *
+ * - Payload.stringify / PayloadItem.stringify 走统一 stringifyInstance 管线：
+ *   items/base/itemRef 编码为 uuid:: 引用，graph round-trip 保持实例身份；
+ *   itemRef 不再被手写字段清单静默丢弃。
+ * - DataPolicy.stringify 编码 match 函数（func::），round-trip 后过滤语义保留。
+ * - EventSource 注册进 core 的 KlassByName；stringify/parse 走统一管线，
+ *   guard/resolve 等回调 round-trip 后可用。
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import { clearAllInstances, createInstances, KlassByName, Entity, Property, EventSource, EventSourceInstance } from '@core';
+import { Interaction, InteractionInstance } from '../../src/builtins/interaction/Interaction.js';
+import { Action } from '../../src/builtins/interaction/Action.js';
+import { Payload, PayloadInstance } from '../../src/builtins/interaction/Payload.js';
+import { PayloadItem, PayloadItemInstance } from '../../src/builtins/interaction/PayloadItem.js';
+import { Attributive, AttributiveInstance } from '../../src/builtins/interaction/Attributive.js';
+import { DataPolicy, DataPolicyInstance } from '../../src/builtins/interaction/Data.js';
+import '../../src/builtins/init.js';
+
+const allKlasses = [Interaction, Action, Payload, PayloadItem, Attributive, DataPolicy, Entity, Property, EventSource];
+
+beforeEach(() => {
+    clearAllInstances(...allKlasses);
+});
+
+function roundTrip(jsons: string[]) {
+    const serialized = `[${jsons.join(',')}]`;
+    clearAllInstances(...allKlasses);
+    return createInstances(JSON.parse(serialized));
+}
+
+describe('r8 serialization fixes', () => {
+    test('Payload/PayloadItem round-trip keeps item identity, base reference and itemRef', () => {
+        const Post = Entity.create({
+            name: 'SerPost',
+            properties: [Property.create({ name: 'title', type: 'string' })]
+        });
+        const authorRef = Attributive.create({ name: 'SerAuthorRef', content: function() { return true } });
+        const item = PayloadItem.create({
+            name: 'post',
+            type: 'object',
+            base: Post,
+            isRef: true,
+            required: true,
+            itemRef: authorRef
+        });
+        const payload = Payload.create({ items: [item] });
+        const interaction = Interaction.create({
+            name: 'SerCreatePost',
+            action: Action.create({ name: 'serCreatePost' }),
+            payload
+        });
+
+        const jsons = [
+            Entity.stringify(Post),
+            ...Post.properties.map(p => Property.stringify(p)),
+            Attributive.stringify(authorRef),
+            PayloadItem.stringify(item),
+            Payload.stringify(payload),
+            Action.stringify(interaction.action!),
+            Interaction.stringify(interaction),
+        ];
+        const instances = roundTrip(jsons);
+
+        const parsedPayload = instances.get(payload.uuid) as PayloadInstance;
+        expect(parsedPayload.items).toHaveLength(1);
+        const parsedItem = parsedPayload.items[0];
+        // 修复前：items 是裸对象（无 Klass 身份），itemRef 被 stringify 丢弃
+        expect(PayloadItem.is(parsedItem)).toBe(true);
+        expect(parsedItem.uuid).toBe(item.uuid);
+        expect(Entity.is(parsedItem.base)).toBe(true);
+        expect(parsedItem.base).toBe(instances.get(Post.uuid));
+        expect(Attributive.is(parsedItem.itemRef)).toBe(true);
+        expect((parsedItem.itemRef as AttributiveInstance).name).toBe('SerAuthorRef');
+
+        const parsedInteraction = instances.get(interaction.uuid) as InteractionInstance;
+        expect(parsedInteraction.payload).toBe(parsedPayload);
+    });
+
+    test('DataPolicy round-trip preserves match function', () => {
+        const policy = DataPolicy.create({
+            match: function(this: unknown, user: { id: string }) {
+                return { key: 'author.id', value: ['=', user.id] };
+            },
+            attributeQuery: ['id', 'title'],
+            modifier: { limit: 10 }
+        });
+        const instances = roundTrip([DataPolicy.stringify(policy)]);
+        const parsed = instances.get(policy.uuid) as DataPolicyInstance;
+        // 修复前：match 函数被 JSON.stringify 丢成 undefined
+        expect(typeof parsed.match).toBe('function');
+        expect(parsed.match({ id: 'u1' })).toEqual({ key: 'author.id', value: ['=', 'u1'] });
+        expect(parsed.attributeQuery).toEqual(['id', 'title']);
+        expect(parsed.modifier).toEqual({ limit: 10 });
+    });
+
+    test('EventSource is registered and round-trips callbacks + entity reference', () => {
+        expect(KlassByName.get('EventSource')).toBe(EventSource);
+
+        const Log = Entity.create({
+            name: 'SerLog',
+            properties: [Property.create({ name: 'message', type: 'string' })]
+        });
+        const source = EventSource.create({
+            name: 'SerCron',
+            entity: Log,
+            guard: async function(args: unknown) { if (!args) throw new Error('no args') },
+            mapEventData: (args: unknown) => ({ message: String(args) })
+        });
+
+        const jsons = [
+            Entity.stringify(Log),
+            ...Log.properties.map(p => Property.stringify(p)),
+            EventSource.stringify(source as EventSourceInstance),
+        ];
+        const instances = roundTrip(jsons);
+
+        const parsed = instances.get(source.uuid) as EventSourceInstance;
+        expect(parsed.name).toBe('SerCron');
+        // 修复前：EventSource 未注册（graph 反序列化直接抛 unknown class）、
+        //  stringify 只序列化 name/entity（guard/mapEventData 全部丢失）。
+        expect(Entity.is(parsed.entity)).toBe(true);
+        expect(parsed.entity).toBe(instances.get(Log.uuid));
+        expect(typeof parsed.guard).toBe('function');
+        expect(typeof parsed.mapEventData).toBe('function');
+        expect((parsed.mapEventData as (args: unknown) => Record<string, unknown>)('hello')).toEqual({ message: 'hello' });
+    });
+});

--- a/tests/runtime/aggregationConsistencyMatrix.spec.ts
+++ b/tests/runtime/aggregationConsistencyMatrix.spec.ts
@@ -41,7 +41,7 @@ type AggKind = {
 const aggKinds: AggKind[] = [
   {
     name: 'count', dictType: 'number',
-    create: (record) => Count.create({ record, callback: () => true }),
+    create: (record) => Count.create({ record, attributeQuery: [], callback: () => true }),
     truth: (rows) => rows.length,
   },
   {
@@ -289,8 +289,8 @@ describe('combinatorial matrix exploration', () => {
       Worker.properties!.push(Property.create({ name: propName, type, computation }));
       propCells.push({ cell: `prop/${propName}`, propName, truth, useFlagged });
     };
-    addProp('cnt', 'number', Count.create({ property: 'jobs', callback: () => true }), ls => ls.length, false);
-    addProp('cntF', 'number', Count.create({ property: 'flaggedJobs', callback: () => true }), ls => ls.length, true);
+    addProp('cnt', 'number', Count.create({ property: 'jobs', attributeQuery: [], callback: () => true }), ls => ls.length, false);
+    addProp('cntF', 'number', Count.create({ property: 'flaggedJobs', attributeQuery: [], callback: () => true }), ls => ls.length, true);
     addProp('sumLink', 'number', Summation.create({ property: 'jobs', attributeQuery: [['&', { attributeQuery: ['rscore'] }]] }),
       ls => ls.reduce((a, l) => a + (l.rscore ?? 0), 0), false);
     addProp('sumLinkF', 'number', Summation.create({ property: 'flaggedJobs', attributeQuery: [['&', { attributeQuery: ['rscore'] }]] }),

--- a/tests/runtime/cascadeFilteredEntityComputations.spec.ts
+++ b/tests/runtime/cascadeFilteredEntityComputations.spec.ts
@@ -105,9 +105,8 @@ describe('Cascade Filtered Entity Computations', () => {
           type: 'number',
           collection: false,
           computation: Count.create({
-            record: userEntity,
-            callback: () => true
-          })
+            record: userEntity
+            })
         }),
         // Count active users
         Dictionary.create({
@@ -115,9 +114,8 @@ describe('Cascade Filtered Entity Computations', () => {
           type: 'number',
           collection: false,
           computation: Count.create({
-            record: activeUsersEntity,
-            callback: () => true
-          })
+            record: activeUsersEntity
+            })
         }),
         // Count tech active users
         Dictionary.create({
@@ -125,9 +123,8 @@ describe('Cascade Filtered Entity Computations', () => {
           type: 'number',
           collection: false,
           computation: Count.create({
-            record: techActiveUsersEntity,
-            callback: () => true
-          })
+            record: techActiveUsersEntity
+            })
         }),
         // Count senior tech active users
         Dictionary.create({
@@ -135,9 +132,8 @@ describe('Cascade Filtered Entity Computations', () => {
           type: 'number',
           collection: false,
           computation: Count.create({
-            record: seniorTechActiveUsersEntity,
-            callback: () => true
-          })
+            record: seniorTechActiveUsersEntity
+            })
         }),
         // Count young active users
         Dictionary.create({
@@ -145,9 +141,8 @@ describe('Cascade Filtered Entity Computations', () => {
           type: 'number',
           collection: false,
           computation: Count.create({
-            record: youngActiveUsersEntity,
-            callback: () => true
-          })
+            record: youngActiveUsersEntity
+            })
         })
       ];
 

--- a/tests/runtime/filteredMembershipMatrix.spec.ts
+++ b/tests/runtime/filteredMembershipMatrix.spec.ts
@@ -75,7 +75,7 @@ describe("filtered membership combination matrix", () => {
             system, entities: [Task, ActiveTask], relations: [],
             dict: [Dictionary.create({
                 name: "mxPlainCount", type: "number", collection: false,
-                computation: Count.create({ record: ActiveTask, callback: () => true }),
+                computation: Count.create({ record: ActiveTask }),
             })],
         });
         await controller.setup(true);
@@ -121,7 +121,7 @@ describe("filtered membership combination matrix", () => {
             system, entities: [Task, ActiveTask], relations: [],
             dict: [Dictionary.create({
                 name: "mxComputedCount", type: "number", collection: false,
-                computation: Count.create({ record: ActiveTask, callback: () => true }),
+                computation: Count.create({ record: ActiveTask }),
             })],
         });
         await controller.setup(true);
@@ -168,7 +168,7 @@ describe("filtered membership combination matrix", () => {
             system, entities: [User, Team, TechUser], relations: [UserTeam],
             dict: [Dictionary.create({
                 name: "mxTechUserCount", type: "number", collection: false,
-                computation: Count.create({ record: TechUser, callback: () => true }),
+                computation: Count.create({ record: TechUser }),
             })],
         });
         await controller.setup(true);
@@ -221,7 +221,7 @@ describe("filtered membership combination matrix", () => {
             system, entities: [User, Post], relations: [UserPost, PinnedPosts],
             dict: [Dictionary.create({
                 name: "mxPinnedCount", type: "number", collection: false,
-                computation: Count.create({ record: PinnedPosts, callback: () => true }),
+                computation: Count.create({ record: PinnedPosts }),
             })],
         });
         await controller.setup(true);
@@ -274,7 +274,7 @@ describe("filtered membership combination matrix", () => {
             system, entities: [User, Post], relations: [UserPost, BigDeals],
             dict: [Dictionary.create({
                 name: "mxBigDealCount", type: "number", collection: false,
-                computation: Count.create({ record: BigDeals, callback: () => true }),
+                computation: Count.create({ record: BigDeals }),
             })],
         });
         await controller.setup(true);
@@ -330,11 +330,11 @@ describe("filtered membership combination matrix", () => {
             dict: [
                 Dictionary.create({
                     name: "mxHighCount", type: "number", collection: false,
-                    computation: Count.create({ record: HighTask, callback: () => true }),
+                    computation: Count.create({ record: HighTask }),
                 }),
                 Dictionary.create({
                     name: "mxHighActiveCount", type: "number", collection: false,
-                    computation: Count.create({ record: HighActiveTask, callback: () => true }),
+                    computation: Count.create({ record: HighActiveTask }),
                 }),
             ],
         });

--- a/tests/runtime/filteredMembershipRuntime.spec.ts
+++ b/tests/runtime/filteredMembershipRuntime.spec.ts
@@ -60,9 +60,8 @@ describe('filtered/merged membership events drive runtime computations', () => {
                     type: 'number',
                     collection: false,
                     computation: Count.create({
-                        record: techTeamUserEntity,
-                        callback: () => true
-                    })
+                        record: techTeamUserEntity
+                        })
                 })
             ]
         });
@@ -113,7 +112,7 @@ describe('filtered/merged membership events drive runtime computations', () => {
             dict: [
                 Dictionary.create({
                     name: 'activeCount', type: 'number', collection: false,
-                    computation: Count.create({ record: activeUserEntity, callback: () => true })
+                    computation: Count.create({ record: activeUserEntity })
                 }),
                 Dictionary.create({
                     name: 'activeSalarySum', type: 'number', collection: false,
@@ -210,13 +209,13 @@ describe('filtered/merged membership events drive runtime computations', () => {
                     name: 'contactCount',
                     type: 'number',
                     collection: false,
-                    computation: Count.create({ record: contactEntity, callback: () => true })
+                    computation: Count.create({ record: contactEntity })
                 }),
                 Dictionary.create({
                     name: 'customerCount',
                     type: 'number',
                     collection: false,
-                    computation: Count.create({ record: customerEntity, callback: () => true })
+                    computation: Count.create({ record: customerEntity })
                 })
             ]
         });

--- a/tests/runtime/review-fixes-2026-07-09-r3.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r3.spec.ts
@@ -74,7 +74,7 @@ describe("review fixes 2026-07-09 r3", () => {
             system, entities: [Task, ActiveTask], relations: [],
             dict: [Dictionary.create({
                 name: "r3FixActiveTaskCount", type: "number", collection: false,
-                computation: Count.create({ record: ActiveTask, callback: () => true }),
+                computation: Count.create({ record: ActiveTask }),
             })],
         });
         await controller.setup(true);

--- a/tests/runtime/review-fixes-2026-07-09-r8.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r8.spec.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "vitest";
+import { Entity, Property, Relation, Count, Every, Any, WeightedSummation, Dictionary, KlassByName } from 'interaqt';
+import { Controller, MonoSystem } from 'interaqt';
+import { MatchExp } from '@storage';
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r8 F-2 回归：Global Count/Every/Any/WeightedSummation 的 create 增量分支
+ * 此前直接把 mutation 事件里的局部 record（defaultValues + payload）喂给 callback，
+ * callback 依赖 attributeQuery 声明的关联数据 / 计算列时增量结果与全量重算漂移。
+ * 修复后 create 与 update 路径一致：先按 attributeQuery 拉取全量 new record。
+ */
+describe('r8 F-2: create incremental path fetches full record before callback', () => {
+    test('Count over relation with callback reading target fields is correct on create', async () => {
+        const User = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'vip', type: 'boolean' })
+            ]
+        })
+        const Post = Entity.create({
+            name: 'Post',
+            properties: [Property.create({ name: 'title', type: 'string' })]
+        })
+        const AuthorRelation = Relation.create({
+            source: Post,
+            sourceProperty: 'author',
+            target: User,
+            targetProperty: 'posts',
+            type: 'n:1'
+        })
+        const dict = Dictionary.create({
+            name: 'vipAuthoredPostCount',
+            type: 'number',
+            collection: false,
+            computation: Count.create({
+                record: AuthorRelation,
+                attributeQuery: [['target', { attributeQuery: ['vip'] }]],
+                callback: (rel: any) => rel.target?.vip === true
+            })
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [User, Post],
+            relations: [AuthorRelation],
+            eventSources: [],
+            dict: [dict]
+        })
+        await controller.setup(true)
+
+        const vipUser = await system.storage.create('User', { name: 'v', vip: true })
+        const normalUser = await system.storage.create('User', { name: 'n', vip: false })
+        // 关系记录的 create 事件只带 source/target 的 id，callback 读 target.vip
+        await system.storage.create('Post', { title: 'p1', author: { id: vipUser.id } })
+        await system.storage.create('Post', { title: 'p2', author: { id: normalUser.id } })
+
+        expect(await system.storage.dict.get('vipAuthoredPostCount')).toBe(1)
+
+        // 后续 update 与 delete 路径保持一致
+        await system.storage.update('User', MatchExp.atom({ key: 'id', value: ['=', normalUser.id] }), { vip: true })
+        expect(await system.storage.dict.get('vipAuthoredPostCount')).toBe(2)
+    })
+
+    test('WeightedSummation with callback reading related data is correct on create', async () => {
+        const Customer = Entity.create({
+            name: 'Customer',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'discount', type: 'number' })
+            ]
+        })
+        const Order = Entity.create({
+            name: 'Order',
+            properties: [Property.create({ name: 'amount', type: 'number' })]
+        })
+        const OrderCustomer = Relation.create({
+            source: Order,
+            sourceProperty: 'customer',
+            target: Customer,
+            targetProperty: 'orders',
+            type: 'n:1'
+        })
+        const dict = Dictionary.create({
+            name: 'discountedTotal',
+            type: 'number',
+            collection: false,
+            computation: WeightedSummation.create({
+                record: Order,
+                attributeQuery: ['amount', ['customer', { attributeQuery: ['discount'] }]],
+                callback: (order: any) => ({
+                    weight: order.customer?.discount ?? 1,
+                    value: order.amount ?? 0
+                })
+            })
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Customer, Order],
+            relations: [OrderCustomer],
+            eventSources: [],
+            dict: [dict]
+        })
+        await controller.setup(true)
+
+        const c = await system.storage.create('Customer', { name: 'c', discount: 0.5 })
+        // Order 的 create 事件带 amount 与 customer 的 id ref，callback 还要读 customer.discount
+        await system.storage.create('Order', { amount: 100, customer: { id: c.id } })
+
+        expect(await system.storage.dict.get('discountedTotal')).toBe(50)
+    })
+
+    test('Every/Any with callback reading computed property is correct on create', async () => {
+        const Task = Entity.create({
+            name: 'Task',
+            properties: [
+                Property.create({ name: 'score', type: 'number' }),
+                // computed 列不在 create payload 里，事件 record 上没有
+                Property.create({
+                    name: 'passed',
+                    type: 'boolean',
+                    computed: (task: any) => (task.score ?? 0) >= 60
+                })
+            ]
+        })
+        const everyDict = Dictionary.create({
+            name: 'allPassed',
+            type: 'boolean',
+            collection: false,
+            computation: Every.create({
+                record: Task,
+                attributeQuery: ['passed'],
+                callback: (task: any) => task.passed === true,
+                notEmpty: true
+            })
+        })
+        const anyDict = Dictionary.create({
+            name: 'anyPassed',
+            type: 'boolean',
+            collection: false,
+            computation: Any.create({
+                record: Task,
+                attributeQuery: ['passed'],
+                callback: (task: any) => task.passed === true
+            })
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Task],
+            relations: [],
+            eventSources: [],
+            dict: [everyDict, anyDict]
+        })
+        await controller.setup(true)
+
+        await system.storage.create('Task', { score: 90 })
+        expect(await system.storage.dict.get('allPassed')).toBe(true)
+        expect(await system.storage.dict.get('anyPassed')).toBe(true)
+
+        await system.storage.create('Task', { score: 30 })
+        expect(await system.storage.dict.get('allPassed')).toBe(false)
+        expect(await system.storage.dict.get('anyPassed')).toBe(true)
+    })
+})
+
+/**
+ * r8 F-3 回归：声明了 callback 却没有 attributeQuery 时，full compute 取数是 id-only、
+ * 字段 update 不注册任何监听——聚合静默错误/永久冻结。现在 setup 期 fail-fast
+ * （与 Custom 的 records dataDep 校验对齐）；显式 attributeQuery: [] 仍然合法。
+ */
+describe('r8 F-3: callback without attributeQuery fails fast at setup', () => {
+    function buildController(computation: any) {
+        const Task = Entity.create({
+            name: 'Task',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'done', type: 'boolean' })
+            ]
+        })
+        const dict = Dictionary.create({
+            name: 'someValue',
+            type: 'number',
+            collection: false,
+            computation: computation(Task)
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        return () => new Controller({
+            system,
+            entities: [Task],
+            relations: [],
+            eventSources: [],
+            dict: [dict]
+        })
+    }
+
+    test('Count with callback but no attributeQuery throws ComputationProtocolError', () => {
+        expect(buildController((Task: any) => Count.create({
+            record: Task,
+            callback: (t: any) => t.done === true
+        }))).toThrow(/Count computation .* declares a callback but no attributeQuery/)
+    })
+
+    test('Every/Any/WeightedSummation with callback but no attributeQuery throw', () => {
+        expect(buildController((Task: any) => Every.create({
+            record: Task,
+            callback: (t: any) => t.done === true
+        }))).toThrow(/Every computation .* declares a callback but no attributeQuery/)
+
+        expect(buildController((Task: any) => Any.create({
+            record: Task,
+            callback: (t: any) => t.done === true
+        }))).toThrow(/Any computation .* declares a callback but no attributeQuery/)
+
+        expect(buildController((Task: any) => WeightedSummation.create({
+            record: Task,
+            callback: () => ({ weight: 1, value: 1 })
+        }))).toThrow(/WeightedSummation computation .* declares a callback but no attributeQuery/)
+    })
+
+    test('explicit attributeQuery: [] remains legal (membership-only callback)', async () => {
+        const Task = Entity.create({
+            name: 'Task',
+            properties: [Property.create({ name: 'title', type: 'string' })]
+        })
+        const dict = Dictionary.create({
+            name: 'taskCount',
+            type: 'number',
+            collection: false,
+            computation: Count.create({
+                record: Task,
+                attributeQuery: [],
+                callback: () => true
+            })
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Task],
+            relations: [],
+            eventSources: [],
+            dict: [dict]
+        })
+        await controller.setup(true)
+        await system.storage.create('Task', { title: 't1' })
+        expect(await system.storage.dict.get('taskCount')).toBe(1)
+    })
+
+    test('Count without callback still requires no attributeQuery', async () => {
+        const Task = Entity.create({
+            name: 'Task',
+            properties: [Property.create({ name: 'title', type: 'string' })]
+        })
+        const dict = Dictionary.create({
+            name: 'plainCount',
+            type: 'number',
+            collection: false,
+            computation: Count.create({ record: Task })
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Task],
+            relations: [],
+            eventSources: [],
+            dict: [dict]
+        })
+        await controller.setup(true)
+        await system.storage.create('Task', { title: 't1' })
+        expect(await system.storage.dict.get('plainCount')).toBe(1)
+    })
+})

--- a/tests/runtime/review-improvements-2026-07-09.spec.ts
+++ b/tests/runtime/review-improvements-2026-07-09.spec.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+import { Controller, Count, Dictionary, Entity, KlassByName, MonoSystem, Property } from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r8 显著改进项回归：生命周期边缘三件套。
+ */
+function createModel() {
+    const Task = Entity.create({
+        name: 'Task',
+        properties: [Property.create({ name: 'title', type: 'string' })]
+    })
+    const dict = Dictionary.create({
+        name: 'taskTotal',
+        type: 'number',
+        collection: false,
+        computation: Count.create({ record: Task })
+    })
+    return { Task, dict }
+}
+
+describe('lifecycle: scheduler.setup atomic listener swap', () => {
+    test('failed re-setup keeps previous listeners active (no silent zero-listener system)', async () => {
+        const { Task, dict } = createModel()
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Task],
+            relations: [],
+            eventSources: [],
+            dict: [dict]
+        })
+        await controller.setup(true)
+
+        await system.storage.create('Task', { title: 't1' })
+        expect(await system.storage.dict.get('taskTotal')).toBe(1)
+
+        // 让重建路径在「构建新 listener」阶段失败（sourceMapManager.initialize 是真实的可抛出路径）。
+        const sourceMapManager = (controller.scheduler as any).sourceMapManager
+        const originalInitialize = sourceMapManager.initialize.bind(sourceMapManager)
+        sourceMapManager.initialize = () => { throw new Error('injected initialize failure') }
+        await expect(controller.scheduler.setup(false)).rejects.toThrow(/injected initialize failure/)
+        sourceMapManager.initialize = originalInitialize
+
+        // 旧 listener 必须仍然生效：增量计算没有被冻结。
+        await system.storage.create('Task', { title: 't2' })
+        expect(await system.storage.dict.get('taskTotal')).toBe(2)
+
+        // 恢复后重跑 setup 仍然幂等（不会双计）。
+        await controller.scheduler.setup(false)
+        await system.storage.create('Task', { title: 't3' })
+        expect(await system.storage.dict.get('taskTotal')).toBe(3)
+    })
+})
+
+describe('lifecycle: install failure recovery guidance', () => {
+    test('scheduler failure during setup(true) throws an error pointing at re-running install', async () => {
+        const { Task, dict } = createModel()
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Task],
+            relations: [],
+            eventSources: [],
+            dict: [dict]
+        })
+        const originalSetup = controller.scheduler.setup.bind(controller.scheduler)
+        controller.scheduler.setup = async () => { throw new Error('injected scheduler failure') }
+
+        await expect(controller.setup(true)).rejects.toThrow(/re-run setup\(true\)/)
+
+        // 修复后按提示重跑 install 即可恢复（install 重建表）。
+        controller.scheduler.setup = originalSetup
+        await controller.setup(true)
+        await system.storage.create('Task', { title: 't1' })
+        expect(await system.storage.dict.get('taskTotal')).toBe(1)
+    })
+})
+
+describe('lifecycle: post-migration scheduler failure guidance', () => {
+    test('scheduler failure after successful migration reports "do NOT retry the migration"', async () => {
+        // v1 install（用 new Entity 绕开全局 registry，与 migration.spec.ts 的多版本建模方式一致）
+        const TaskV1 = new Entity({
+            name: 'MigTask',
+            properties: [new Property({ name: 'title', type: 'string' })]
+        })
+        const db = new PGLiteDB()
+        const systemV1 = new MonoSystem(db)
+        systemV1.conceptClass = KlassByName
+        const controllerV1 = new Controller({ system: systemV1, entities: [TaskV1], relations: [], eventSources: [], dict: [] })
+        await controllerV1.setup(true)
+        await systemV1.storage.create('MigTask', { title: 't1' })
+
+        // v2：新增一个带 defaultValue 的属性（可自动迁移的最小变更）
+        const TaskV2 = new Entity({
+            name: 'MigTask',
+            properties: [
+                new Property({ name: 'title', type: 'string' }),
+                new Property({ name: 'status', type: 'string', defaultValue: () => 'open' })
+            ]
+        })
+        const systemV2 = new MonoSystem(db)
+        systemV2.conceptClass = KlassByName
+        const controllerV2 = new Controller({ system: systemV2, entities: [TaskV2], relations: [], eventSources: [], dict: [] })
+
+        const diff = await controllerV2.generateMigrationDiff({ includeFunctionText: true, includeDestructiveScope: true })
+        const approvedDiff = {
+            ...diff,
+            status: 'approved' as const,
+            decisions: [
+                ...diff.decisions,
+                ...diff.requiredDecisions.map((requirement: any) => ({
+                    ...requirement,
+                    decision: requirement.recommendedDecision,
+                    reason: 'approved by test'
+                }))
+            ]
+        }
+
+        controllerV2.scheduler.setup = async () => { throw new Error('injected post-migration failure') }
+        await expect(controllerV2.migrate({ approvedDiff })).rejects.toThrow(/do NOT retry the migration/)
+
+        // 数据库确实已迁移完成：按提示 setup(false) 可直接恢复。
+        const systemV3 = new MonoSystem(db)
+        systemV3.conceptClass = KlassByName
+        const TaskV3 = new Entity({
+            name: 'MigTask',
+            properties: [
+                new Property({ name: 'title', type: 'string' }),
+                new Property({ name: 'status', type: 'string', defaultValue: () => 'open' })
+            ]
+        })
+        const controllerV3 = new Controller({ system: systemV3, entities: [TaskV3], relations: [], eventSources: [], dict: [] })
+        await controllerV3.setup(false)
+        const created = await systemV3.storage.create('MigTask', { title: 't2' })
+        expect(created.id).toBeTruthy()
+    })
+})

--- a/tests/runtime/runtimeEdgeCases.spec.ts
+++ b/tests/runtime/runtimeEdgeCases.spec.ts
@@ -81,8 +81,12 @@ describe('Scheduler setup error handling', () => {
             await controller.setup(true);
             expect.fail('should have thrown');
         } catch (e: any) {
-            expect(e).toBe(schedulerError);
-            expect(e.schedulingPhase).toBe('custom-phase');
+            // install 路径的 scheduler 失败会被包一层恢复指引（表已建、manifest 未写，
+            // 必须重跑 setup(true)），原始 SchedulerError 完整保留在 causedBy 链上。
+            expect(e instanceof SchedulerError).toBe(true);
+            expect(e.message).toContain('re-run setup(true)');
+            expect(e.causedBy).toBe(schedulerError);
+            expect(e.causedBy.schedulingPhase).toBe('custom-phase');
         } finally {
             try { await system.destroy(); } catch (_) {}
         }

--- a/tests/runtime/weightedSummation.spec.ts
+++ b/tests/runtime/weightedSummation.spec.ts
@@ -200,6 +200,7 @@ describe('WeightedSummation computed handle', () => {
         collection: false,
         computation: WeightedSummation.create({
           record: productEntity,
+          attributeQuery: ['quantity', 'price'],
           callback: (product: any) => {
             return {
               weight: product.quantity || 0,
@@ -256,6 +257,7 @@ describe('WeightedSummation computed handle', () => {
         collection: false,
         computation: WeightedSummation.create({
           record: accountEntity,
+          attributeQuery: ['factor', 'amount'],
           callback: (account: any) => {
             return {
               weight: account.factor || 0,

--- a/tests/storage/combinedRecordEvents.spec.ts
+++ b/tests/storage/combinedRecordEvents.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { Entity, Relation, Property } from '@core';
+import { DBSetup, EntityQueryHandle, EntityToTableMap, MatchExp } from '@storage';
+import { PGLiteDB } from '@drivers';
+import type { RecordMutationEvent } from '@runtime';
+
+/**
+ * r8 显著改进项核实（r2 I-7/I-9 遗留）：combined record（1:1 reliance 自动三表合一）
+ * 的挤出（flash-out）/搬迁（relocate）路径的事件完整性。
+ *
+ * 结论（以本测试固化）：这两条路径内部的 deleteRecordSameRowData / insertSameRowData
+ * 是**物理行搬迁**——实体的逻辑身份（id）全程不变，语义上没有实体的删除/重建，
+ * 所以**不应该**产生实体级 delete/create 事件（否则下游聚合会被虚假地减/加一次）。
+ * 事件流上应该出现且只出现关系层面的事实：旧 link delete（+ 新 link create，抢夺场景）。
+ */
+describe('combined record (1:1 reliance) event completeness', () => {
+    function createModel() {
+        const User = Entity.create({
+            name: 'User',
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        })
+        const Profile = Entity.create({
+            name: 'Profile',
+            properties: [Property.create({ name: 'nickname', type: 'string' })]
+        })
+        const OwnProfile = Relation.create({
+            source: User,
+            sourceProperty: 'profile',
+            target: Profile,
+            targetProperty: 'owner',
+            type: '1:1',
+            isTargetReliance: true
+        })
+        return { User, Profile, OwnProfile }
+    }
+
+    it('stealing a combined profile emits old-link delete + new-link create, and no spurious entity events', async () => {
+        const db = new PGLiteDB()
+        await db.open()
+        const { User, Profile, OwnProfile } = createModel()
+        const setup = new DBSetup([User, Profile], [OwnProfile], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+
+        // A 与 profile P 三表合一同行存储
+        const a = await handle.create('User', { name: 'A', profile: { nickname: 'p1' } })
+        const aWithProfile = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', a.id] }), undefined,
+            ['id', ['profile', { attributeQuery: ['id', 'nickname'] }]])
+        const profileId = aWithProfile.profile.id
+
+        // B 抢夺 P（flash-out 路径）
+        const events: RecordMutationEvent[] = []
+        const b = await handle.create('User', { name: 'B', profile: { id: profileId } }, events)
+
+        // 关系层面的事实完整：旧 link delete + 新 link create
+        const linkDeletes = events.filter(e => e.type === 'delete' && e.recordName === OwnProfile.name)
+        const linkCreates = events.filter(e => e.type === 'create' && e.recordName === OwnProfile.name)
+        expect(linkDeletes.length).toBe(1)
+        expect(linkCreates.length).toBe(1)
+
+        // 实体层面：P 的身份从未消失，不允许出现 Profile 的 delete/create 事件
+        // （只有 B 自己的 create 事件）。
+        expect(events.some(e => e.recordName === 'Profile' && e.type === 'delete')).toBe(false)
+        expect(events.some(e => e.recordName === 'Profile' && e.type === 'create')).toBe(false)
+
+        // 数据完整：P 归属 B，A 不再有 profile
+        const bWithProfile = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', b.id] }), undefined,
+            ['id', ['profile', { attributeQuery: ['id', 'nickname'] }]])
+        expect(bWithProfile.profile?.id).toBe(profileId)
+        expect(bWithProfile.profile?.nickname).toBe('p1')
+        const aAfter = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', a.id] }), undefined,
+            ['id', ['profile', { attributeQuery: ['id'] }]])
+        expect(aAfter.profile?.id).toBeUndefined()
+
+        await db.close()
+    })
+
+    it('unlinking a combined profile relocates the row without spurious entity events', async () => {
+        // relocate 路径只对非 reliance 的 combined link 可达（reliance unlink 是业务级 fail-fast，
+        //  只能删记录）；非 reliance 的三表合一目前只能通过 DBSetup 的 mergeLinks 参数配置。
+        const db = new PGLiteDB()
+        await db.open()
+        const User = Entity.create({
+            name: 'User',
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        })
+        const Profile = Entity.create({
+            name: 'Profile',
+            properties: [Property.create({ name: 'nickname', type: 'string' })]
+        })
+        const OwnProfile = Relation.create({
+            source: User,
+            sourceProperty: 'profile',
+            target: Profile,
+            targetProperty: 'owner',
+            type: '1:1'
+        })
+        const setup = new DBSetup([User, Profile], [OwnProfile], db, ['User.profile'])
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+
+        const a = await handle.create('User', { name: 'A', profile: { nickname: 'p1' } })
+        const aWithProfile = await handle.findOne('User', MatchExp.atom({ key: 'id', value: ['=', a.id] }), undefined,
+            ['id', ['profile', { attributeQuery: ['id'] }]])
+        const profileId = aWithProfile.profile.id
+
+        // 解除关系（relocate 路径：P 的行数据搬到独立行）
+        const events: RecordMutationEvent[] = []
+        await handle.update('User', MatchExp.atom({ key: 'id', value: ['=', a.id] }), { profile: null }, events)
+
+        const linkDeletes = events.filter(e => e.type === 'delete' && e.recordName === OwnProfile.name)
+        expect(linkDeletes.length).toBe(1)
+        expect(events.some(e => e.recordName === 'Profile' && e.type === 'delete')).toBe(false)
+        expect(events.some(e => e.recordName === 'Profile' && e.type === 'create')).toBe(false)
+
+        // P 仍然存在（独立行），数据不丢
+        const profile = await handle.findOne('Profile', MatchExp.atom({ key: 'id', value: ['=', profileId] }), undefined,
+            ['id', 'nickname'])
+        expect(profile?.nickname).toBe('p1')
+
+        await db.close()
+    })
+})

--- a/tests/storage/driverIdAllocation.spec.ts
+++ b/tests/storage/driverIdAllocation.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { SQLiteDB } from '@drivers';
+
+/**
+ * r8 显著改进项回归：SQLite getAutoId 原子化（UPSERT + 唯一索引 + 参数化）。
+ * 此前是「SELECT 再 INSERT/UPDATE」的读-改-写，且 recordName 直接字符串拼接进 SQL。
+ */
+describe('SQLite id allocation', () => {
+    it('allocates strictly sequential unique ids per record name', async () => {
+        const db = new SQLiteDB(':memory:')
+        await db.open()
+
+        const ids: string[] = []
+        for (let i = 0; i < 50; i++) {
+            ids.push(String(await db.getAutoId('Alpha')))
+        }
+        expect(ids).toEqual(Array.from({ length: 50 }, (_, i) => String(i + 1)))
+
+        // 不同 record name 的序列互不影响
+        expect(String(await db.getAutoId('Beta'))).toBe('1')
+        expect(String(await db.getAutoId('Alpha'))).toBe('51')
+
+        await db.close()
+    })
+
+    it('upgrades a legacy _IDS_ table (no unique index) in place', async () => {
+        const db = new SQLiteDB(':memory:')
+        // 先手工建出旧版的无约束表，再走正常 open（IF NOT EXISTS 跳过建表、补建唯一索引）。
+        ;(db as any).db = new (await import('better-sqlite3')).default(':memory:')
+        ;(db as any).db.prepare(`CREATE TABLE _IDS_ (last INTEGER, name TEXT)`).run()
+        ;(db as any).db.prepare(`INSERT INTO _IDS_ (name, last) VALUES ('Legacy', 7)`).run()
+        await (db as any).idSystem.setup()
+
+        expect(String(await db.getAutoId('Legacy'))).toBe('8')
+        expect(String(await db.getAutoId('Legacy'))).toBe('9')
+        expect(String(await db.getAutoId('Fresh'))).toBe('1')
+
+        await db.close()
+    })
+})

--- a/tests/storage/review-fixes-2026-07-09-r8.spec.ts
+++ b/tests/storage/review-fixes-2026-07-09-r8.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { Entity, Relation, Property } from '@core';
+import { DBSetup, EntityQueryHandle, EntityToTableMap, MatchExp } from '@storage';
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r8 F-1 回归：以 filtered entity 为端点的 relation。
+ *
+ * 根因：populateRecordAttributes 只把关系属性写到 filtered entity 的 record 上，
+ * 而查询编译（RecordQuery.create）统一按 resolvedBaseRecordName 解析属性、
+ * copyAttributesToFilteredEntities 又会用 base 的属性表整体覆盖 filtered 的属性表——
+ * 于是该关系属性在 schema map 里彻底消失，任何经由它的查询/级联全部崩溃或静默失效。
+ */
+describe('r8 F-1: relation with filtered entity endpoint survives setup and works end-to-end', () => {
+    function createModel() {
+        const User = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' })
+            ]
+        })
+        const Post = Entity.create({
+            name: 'Post',
+            properties: [Property.create({ name: 'title', type: 'string' })]
+        })
+        const ActiveUser = Entity.create({
+            name: 'ActiveUser',
+            baseEntity: User,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] })
+        })
+        return { User, Post, ActiveUser }
+    }
+
+    it('filtered entity as relation source: attribute registered on base + filtered, query works from both names', async () => {
+        const db = new PGLiteDB()
+        await db.open()
+        const { User, Post, ActiveUser } = createModel()
+        const ActiveUserPostRelation = Relation.create({
+            source: ActiveUser,
+            sourceProperty: 'activePosts',
+            target: Post,
+            targetProperty: 'activeAuthor',
+            type: '1:n'
+        })
+
+        const setup = new DBSetup([User, Post, ActiveUser], [ActiveUserPostRelation], db)
+        await setup.createTables()
+
+        // 属性必须同时登记在 filtered 与 resolved base record 上
+        expect(Object.keys(setup.map.records['ActiveUser'].attributes)).toContain('activePosts')
+        expect(Object.keys(setup.map.records['User'].attributes)).toContain('activePosts')
+
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+        const u1 = await handle.create('User', { name: 'u1', isActive: true })
+        await handle.create('Post', { title: 'p1', activeAuthor: { id: u1.id } })
+
+        // 从 filtered 名查询
+        const viaFiltered = await handle.findOne('ActiveUser',
+            MatchExp.atom({ key: 'id', value: ['=', u1.id] }), undefined,
+            ['id', 'name', ['activePosts', { attributeQuery: ['id', 'title'] }]])
+        expect(viaFiltered.activePosts).toHaveLength(1)
+        expect(viaFiltered.activePosts[0].title).toBe('p1')
+
+        // 从 base 名查询（filtered 与 base 共享同一属性命名空间）
+        const viaBase = await handle.findOne('User',
+            MatchExp.atom({ key: 'id', value: ['=', u1.id] }), undefined,
+            ['id', ['activePosts', { attributeQuery: ['id'] }]])
+        expect(viaBase.activePosts).toHaveLength(1)
+
+        // 反向端也可用
+        const post = await handle.findOne('Post', undefined, undefined,
+            ['id', 'title', ['activeAuthor', { attributeQuery: ['id', 'name'] }]])
+        expect(post.activeAuthor?.id).toBe(u1.id)
+
+        await db.close()
+    })
+
+    it('deleting the base entity cleans up links declared on the filtered endpoint (no orphan links)', async () => {
+        const db = new PGLiteDB()
+        await db.open()
+        const { User, Post, ActiveUser } = createModel()
+        const ActiveUserPostRelation = Relation.create({
+            source: ActiveUser,
+            sourceProperty: 'activePosts',
+            target: Post,
+            targetProperty: 'activeAuthor',
+            type: '1:n'
+        })
+        const setup = new DBSetup([User, Post, ActiveUser], [ActiveUserPostRelation], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+
+        const u1 = await handle.create('User', { name: 'u1', isActive: true })
+        await handle.create('Post', { title: 'p1', activeAuthor: { id: u1.id } })
+
+        await handle.delete('User', MatchExp.atom({ key: 'id', value: ['=', u1.id] }))
+
+        // 删除 base 实体后，经由 filtered 端点声明的关系不能留下孤儿 link
+        const links = await handle.find(ActiveUserPostRelation.name!, undefined, undefined,
+            ['id', ['source', { attributeQuery: ['id'] }], ['target', { attributeQuery: ['id'] }]])
+        expect(links).toHaveLength(0)
+
+        await db.close()
+    })
+
+    it('filtered entity as relation target: targetProperty registered on base record too', async () => {
+        const db = new PGLiteDB()
+        await db.open()
+        const { User, Post, ActiveUser } = createModel()
+        const PostActiveUserRelation = Relation.create({
+            source: Post,
+            sourceProperty: 'reviewer',
+            target: ActiveUser,
+            targetProperty: 'reviewedPosts',
+            type: 'n:1'
+        })
+        const setup = new DBSetup([User, Post, ActiveUser], [PostActiveUserRelation], db)
+        await setup.createTables()
+
+        expect(Object.keys(setup.map.records['User'].attributes)).toContain('reviewedPosts')
+        expect(Object.keys(setup.map.records['ActiveUser'].attributes)).toContain('reviewedPosts')
+
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+        const u1 = await handle.create('User', { name: 'u1', isActive: true })
+        await handle.create('Post', { title: 'p1', reviewer: { id: u1.id } })
+
+        const viaBase = await handle.findOne('User',
+            MatchExp.atom({ key: 'id', value: ['=', u1.id] }), undefined,
+            ['id', ['reviewedPosts', { attributeQuery: ['id', 'title'] }]])
+        expect(viaBase.reviewedPosts).toHaveLength(1)
+
+        await db.close()
+    })
+
+    it('sibling filtered entities declaring the same relation property name fail fast at setup', () => {
+        const db = new PGLiteDB()
+        const { User, Post, ActiveUser } = createModel()
+        const InactiveUser = Entity.create({
+            name: 'InactiveUser',
+            baseEntity: User,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', false] })
+        })
+        const rel1 = Relation.create({
+            source: ActiveUser,
+            sourceProperty: 'taggedPosts',
+            target: Post,
+            targetProperty: 'activeTagger',
+            type: '1:n'
+        })
+        const rel2 = Relation.create({
+            source: InactiveUser,
+            sourceProperty: 'taggedPosts',
+            target: Post,
+            targetProperty: 'inactiveTagger',
+            type: '1:n'
+        })
+        expect(() => {
+            new DBSetup([User, Post, ActiveUser, InactiveUser], [rel1, rel2], db)
+        }).toThrow(/Relation property name conflict.*taggedPosts.*base record family 'User'/)
+    })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

第八轮全代码库深度 review（报告：`agentspace/output/deep-review-2026-07-09-r8.md`）。四路并行深度探查 + 与 r1–r7 报告逐条去重 + 对每个新致命候选编写最小复现测试实际运行。发现并修复 3 个已复现的致命问题，全部落在「声明合法、测试矩阵从未走过的组合」。

## 致命修复（均先在基线上复现确认）

### F-1：以 filtered entity 为端点的 relation 在 setup 中被抹掉（schema 级腐蚀）

`Relation.create({ source: ActiveUser, ... })` 是被 `filteredEntityRelationValidation.spec.ts` 明确断言合法的声明，但：

- `copyAttributesToFilteredEntities` 用 base 的属性表**整体替换** filtered record 的属性表，把刚登记的关系属性抹掉；
- 查询编译（`RecordQuery.create`）统一按 `resolvedBaseRecordName` 解析属性，base record 上根本没有该属性 → `findOne` 直接崩溃（`attribute activePosts not found in User`）；
- `LinkInfo.isRelationSource` 按端点名字符串匹配，删除级联拿 base 名匹配 filtered 端点名恒 false → 删除 base 实体后留下**孤儿 link**。

修复：`populateRecordAttributes` 把 filtered 端点的关系属性同步登记到 resolved base record；`LinkInfo.isRelationSource` 按 resolved 名比较；`getReverseAttribute` 改用属性自身 `isSource` 判向；`validateRelations` 补齐家族级（兄弟 filtered entity 间）属性名冲突 fail-fast。

### F-2：Global Count/Every/Any/WeightedSummation 的 create 增量分支用局部事件 record（聚合漂移）

create 事件的 record 只含 defaultValues + payload（关联端只有 `{id}`，无 computed 列）。callback 读 `attributeQuery` 声明的关联数据时增量结果与全量重算漂移且永不自愈（实测 Count 少计）。update 路径 r2 已修，create 一直漏网（Summation/Average 的 create 一直是 findOne——六 handle 两种策略并存）。

修复：create 与 update 对齐，先按 `attributeQuery` findOne 全量 new record 再调 callback；记录已不在时退回 `fullRecompute`。

### F-3：内置聚合 callback 无 attributeQuery → 取数 id-only + update 零监听（静默冻结）

复现：`Count({ record: Task, callback: t => t.done })` 无 attributeQuery，create 碰巧正确、update 永久冻结。r2/r3 已对 property dataDep 与 Custom 做 fail-fast，内置聚合一直豁免——同族问题第三次出现，本轮收尾。

修复：六个 handle（global + property）setup 期抛 `ComputationProtocolError`；显式 `attributeQuery: []` 仍合法（与 Custom 契约一致）。同步修正 9 处编码了该反模式的既有测试与 14 处知识库示例（这些示例是代码生成模板，每一份都会教下游生成静默冻结的聚合）。

## 报告其余内容

- 4 个重要遗留（精读判定，未修）：MigrationScheduler 缺 filtered update 路由守卫、GlobalAverage/GlobalEvery 负值无守卫、combined record 挤出不发事件（r2 复确）、`computeOldRecord` 占位（S4 复确）；
- 约 15 项 r2–r7 既有遗留复确清单与修复优先级建议（六聚合 handle 模板抽取投入产出比最高，本轮已铺平前置条件）；
- 2 个候选证伪记录。

## 测试

- ✅ `npm run check`
- ✅ `npm test` 全量 **1758 passed / 26 skipped**（基线 1747，净 +11：`tests/storage/review-fixes-2026-07-09-r8.spec.ts` 4 用例 + `tests/runtime/review-fixes-2026-07-09-r8.spec.ts` 7 用例）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed1086a4-6891-42cc-bc2a-5abc599bc6a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed1086a4-6891-42cc-bc2a-5abc599bc6a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

