### PR TITLE
Deep code review r9: fail-fast for silent namespace corruption (filtered properties, relation-property overwrite, __type writes), interior goto cycles, cross-activity activityId

### DIFF
--- a/agent/agentspace/knowledge/generator/api-reference.md
+++ b/agent/agentspace/knowledge/generator/api-reference.md
@@ -1700,6 +1700,16 @@ Custom.create(config: CustomConfig): CustomInstance
 
 If `incrementalCompute` or `incrementalPatchCompute` is provided without `incrementalDataDeps` or `planIncremental`, runtime setup fails with `ComputationProtocolError`. Incremental callbacks receive only the planned partial `dataDeps`, not all declared dependencies.
 
+**Mutation event snapshots**
+
+Snapshot shapes differ by event type:
+
+- `create`: `record` = the written fields (defaults + payload), `oldRecord` = `undefined`
+- `update`: `record` = **only the changed fields** (plus `id`), `oldRecord` = full pre-update snapshot
+- `delete`: `record` = full deleted snapshot, `oldRecord` = `undefined`
+
+Never read a field straight off `mutationEvent.record` on update unless you know it was part of the update — it silently evaluates to `undefined` otherwise and corrupts the incremental result. Reconstruct the full new state with `{ ...mutationEvent.oldRecord, ...mutationEvent.record }`, or re-fetch the record via `this.controller.system.storage.findOne(...)` when computed columns or related data are needed (this is what the built-in aggregations do). The same applies to the third `record` parameter: it is only guaranteed to identify the dirty record, not to carry all of its fields.
+
 **Retry safety**
 
 Custom `compute`, `incrementalCompute`, `incrementalPatchCompute`, and `asyncReturn` callbacks may be replayed after transaction retry. Keep them deterministic and avoid irreversible external IO. Put post-commit external work in `recordMutationSideEffects`.
@@ -1774,9 +1784,20 @@ const counterDict = Dictionary.create({
         },
         incrementalCompute: async function(lastValue, mutationEvent, record, dataDeps) {
             console.log('Previous value:', lastValue);
-            const delta = mutationEvent.type === 'delete'
-                ? -(mutationEvent.oldRecord?.value || 0)
-                : (mutationEvent.record?.value || 0) - (mutationEvent.oldRecord?.value || 0);
+            // CAUTION mutation event snapshot shapes differ by type:
+            // - create: record = written fields (defaults + payload), oldRecord = undefined
+            // - update: record = ONLY the changed fields (+ id), oldRecord = full pre-update snapshot
+            // - delete: record = full deleted snapshot, oldRecord = undefined
+            // Reading a field straight off mutationEvent.record on update silently yields
+            // undefined when that field was not part of the update. Reconstruct the full
+            // new state by overlaying the changed fields on the old snapshot.
+            const newRecord = mutationEvent.type === 'delete'
+                ? undefined
+                : { ...(mutationEvent.oldRecord || {}), ...(mutationEvent.record || {}) };
+            const previousRecord = mutationEvent.type === 'delete'
+                ? mutationEvent.record
+                : mutationEvent.oldRecord;
+            const delta = (newRecord?.value || 0) - (previousRecord?.value || 0);
             const total = (lastValue?.total || 0) + delta;
             
             return {

--- a/agent/agentspace/knowledge/usage/14-api-reference.md
+++ b/agent/agentspace/knowledge/usage/14-api-reference.md
@@ -534,6 +534,7 @@ Custom callbacks may be replayed after retryable transaction failures. Do not pe
 
 **Incremental planning**
 - If `incrementalCompute` or `incrementalPatchCompute` is provided, the computation must also provide `incrementalDataDeps` or `planIncremental`.
+- Mutation event snapshot shapes differ by type: `create` events carry the written fields in `record` (`oldRecord` is `undefined`); `update` events carry **only the changed fields** (+ `id`) in `record` and the full pre-update snapshot in `oldRecord`; `delete` events carry the full deleted snapshot in `record` (`oldRecord` is `undefined`). For updates, reconstruct the full new state with `{ ...mutationEvent.oldRecord, ...mutationEvent.record }` or re-fetch the record — reading unchanged fields off `mutationEvent.record` yields `undefined`.
 - `incrementalDataDeps: string[]` lists exactly which `dataDeps` keys should be resolved for the incremental callback; use `[]` when none are needed.
 - `planIncremental(event, record, context)` is the advanced form. Return `{ type: 'incremental', dataDepKeys, needsLastValue? }`, `{ type: 'fullRecompute', reason }`, or `{ type: 'skip', reason }`.
 - Incremental callbacks receive only planned partial `dataDeps`; the runtime no longer resolves all `dataDeps` before incremental execution.

--- a/agentspace/output/deep-review-2026-07-09-r9.md
+++ b/agentspace/output/deep-review-2026-07-09-r9.md
@@ -1,0 +1,161 @@
+# 全代码库深度 Review 报告（2026-07-09 第九轮）
+
+- 日期：2026-07-09
+- 基线：`main` @ `4ca925d2`（PR #25 合入之后，r1–r8 的致命/重要修复全部落地）
+- 范围：`src/storage/erstorage`（含 r8 从未专项审查过的 `MergedItemProcessor`）、`src/runtime`（r8 新落地的 `aggregationTemplate` / Scheduler 事件路由 / Custom 契约）、`src/builtins`（Activity / 守卫链）、`src/runtime/migration.ts` 纵深、知识库与代码事实的一致性
+- 方法：四路并行深度探查（r8 新代码与 filtered 组合盲区 / storage 写路径与 merged entity / runtime 调度事务与异步计算 / builtins 守卫链与 migration 纵深）→ 与 r1–r8 报告**逐条去重**（本轮候选中近半为既有遗留项的重复发现）→ 对每个新致命候选**编写最小复现测试实际运行**（PGLiteDB）。只有「已运行复现确认」的问题列为致命；复现失败或代码证伪的候选明确记录（见第五节）。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1768 passed / 26 skipped。
+
+> **维护说明（2026-07-09）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r9-3e6d`）全部修复。回归测试：`tests/storage/review-fixes-2026-07-09-r9.spec.ts`（10 用例）+ `tests/runtime/review-fixes-2026-07-09-r9.spec.ts`（2 用例）。修复后 `npm run check` 通过；`npm test` 全量 **1780 passed / 26 skipped**（基线 1768，净 +12 回归用例；顺带修正 1 处编码了 F-2 反模式的测试装置 `tests/runtime/data/leaveRequest.ts`——两个 relation 共用 `User.request` 反向属性名，此前靠"从不经由该属性查询"侥幸通过）。
+
+---
+
+## 一、结论摘要
+
+经八轮修复，读写主路径、增量聚合、对称关系、Activity/序列化、migration 均已高度收敛。本轮延续既往规律：新致命问题依然全部落在「**声明合法、零告警、但从未被测试矩阵走过的组合**」——且四个致命项中有三个属于同一族：**共享命名空间里的静默覆盖/静默丢弃**（filtered 视图的属性命名空间、base 家族的关系属性命名空间、merged 的判别列）。修复方向也一致：按显式控制原则一律 setup 期 / 写入口 fail-fast。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修） | 4 | filtered 自有属性被 setup 静默丢弃、同族 relation 同名属性静默互相覆盖、goto 递归对不经过起点的环无限递归、merged `__type` 判别列可被载荷覆写 |
+| 重要（已复现，已修） | 2 | 跨 Activity activityId 裸 TypeError（潜在授权错绑）、知识库 Custom 增量示例教错误模式（代码生成管线级污染） |
+| 证伪 | 3 | 见第五节 |
+| 重要（精读，高置信度，未修） | 5 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认，本轮已修复）
+
+### F-1 filtered entity/relation 声明自己的新 property：被 setup 静默丢弃（静默数据丢失）
+
+- 位置：`src/storage/erstorage/Setup.ts` `createFilteredEntityRecord`（`attributes: {}`，属性整体忽略）；`copyAttributesToFilteredEntities` 随后用 base 的属性表整体覆盖 filtered 的属性表；写路径 `NewRecordData.groupAttributes` 对未知键静默丢弃。
+- 声明合法性：`Entity.create({ baseEntity, matchExpression, properties: [...] })` 类型系统完全接受，setup 零告警，建表成功。
+- 复现（实测输出）：
+
+```
+// ActiveUser（User 的 filtered entity）声明 Property nickname：
+ActiveUser attributes: [name, isActive, id]                    ❌ nickname 消失
+create('ActiveUser', {..., nickname:'nick'}) → 读回无 nickname  ❌ 写入被静默丢弃
+
+// ActiveUser 声明 Count 计算属性 activePostCount：
+读回 {name, isActive, _ActiveUser_activePostCount_bound_count: 2}  ❌
+// 计算在跑（bound state 落库），可见属性列却根本不存在——applyResult 的写入被静默丢弃
+```
+
+- 影响：三层静默——列不建、写入不报错、computation 只维护内部 bound state 而可见值永远不存在。用户以为「视图上的属性」在工作，实际上任何读取都拿不到值。filtered relation 的自有属性同样中招（`createFilteredRelationRecord` 虽登记了属性，但查询/更新统一按 resolvedBaseRecordName 解析，`update` 载荷里的该属性被静默丢弃）。
+- 修复：新增 `DBSetup.validateFilteredItemProperties`（buildMap 步骤 0.5）——filtered entity/relation 声明了 base 链上不存在的新 property 即抛错，指引声明到 base 上。**与 base 同名的再声明保持合法**（解析到 base 列）——merged item 编译管线会把 input entity rebase 成携带原属性列表的 filtered item，这些属性都已合并进物理 base，不能误伤。
+- 语义决策记录：filtered item 是共享 base 表行的视图，"子集上的新列"结构上等价于"base 上的列"，fail-fast + 指引到 base 是零损失的诚实契约。将来若要支持（等价于自动把列登记到 base + 家族冲突校验 + 属性计算在成员资格进出时的语义定义），应作为显式设计决策而不是隐式行为。
+
+### F-2 同一 base 家族里多个 relation 声明同名属性：后注册者静默覆盖，先注册的 relation 从此不可达
+
+- 位置：`src/storage/erstorage/Setup.ts` `validateRelations` 家族级冲突校验（r8 引入）L563–576——条件带 `hasFilteredDeclarer`，**纯 base 声明的重复完全豁免**；`populateRecordAttributes` 按名写入 `attributes[prop]`，后写覆盖先写。
+- 复现（实测输出）：
+
+```
+Relation.create({ source: User, sourceProperty: 'items', target: Post, ... })
+Relation.create({ source: User, sourceProperty: 'items', target: Task, ... })
+→ setup 成功，User.items 指向 Task   ❌ Post 关系静默不可达（查询走错关系、级联漏删）
+```
+
+- 现有测试盲区：`tests/runtime/data/leaveRequest.ts` 自己就编码了这个反模式（`sendRequestRelation` 与 `reviewerRelation` 都用 `User.request`），因为测试从不经由 `User.request` 查询而侥幸通过——已一并修正为 `sentRequests`/`reviewedRequests`。
+- 修复：家族级校验去掉 `hasFilteredDeclarer` 条件——同族（base + 全部 filtered 变体）多个 relation 声明同名属性一律 setup 期抛错。同一 relation 对称两端共用属性名（symmetric）经 Set 去重后不受影响（有回归用例）。
+
+### F-3 label/goto 递归查询：数据图中不经过起点的环 → 无限递归（挂起/栈溢出）
+
+- 位置：`src/storage/erstorage/QueryExecutor.ts` `findRecords` 环检测（原 L181–185）——只比较 `stack[0].id === stack.at(-1).id`。
+- 复现（实测输出）：自引用 n:n `next` 关系，数据 `A→B→C→D→C`（环 C↔D 不含入栈首节点）：
+
+```
+递归 50 层仍未终止（靠测试注入的 exit 保险丝停住）   ❌ 无 exit 时 = 无限递归
+对照：环回到起点（A→B→A）正常终止                    ✓（旧检测只覆盖这一种）
+```
+
+- 影响：树/图遍历是 label/goto 的目标场景，图数据含环是完全合法的形态。用户没写 `exit`（或 exit 条件不含深度上限）时查询挂死整个请求。现有测试 `queryExecutorEdgeCases.spec.ts` 只覆盖「回到起点」的环。
+- 修复：环检测改为「当前记录在本轮递归路径上**任意位置**出现过」即停止展开（含原栈首行为，两个方向都有回归用例）。
+
+### F-4 merged entity/relation 的 `__type` 判别列可被 create/update 载荷显式覆写（跨视图数据腐蚀）
+
+- 位置：`src/storage/erstorage/MergedItemProcessor.ts` `createTypeProperty`——判别列是带 defaultValue 的普通 value 属性；`NewRecordData` 的 defaultValues 逻辑在 `rawData.hasOwnProperty('__type')` 时跳过 default 闭包，直接落库用户值；update 路径同样直通。
+- 复现（实测输出）：
+
+```
+create('Customer', { name:'x', level:'gold', __type:'Vendor' })
+→ Customer 视图 0 条、Vendor 视图 1 条（携带 Customer 特有列 level）  ❌
+update('Customer', ..., { __type:'Vendor' }) → 记录跨视图漂移           ❌
+```
+
+- 影响：单表继承的判别列是 merged 语义的根基——被覆写后记录静默错标到其他 input 视图（跨视图可见性错乱 + input 特有列交叉污染），订阅 filtered 视图事件的下游计算收到与业务声明不符的成员资格事件。`storage.create/update` 会被 Transform 回调、Interaction resolve 等用户代码直接调用，属于框架信任边界。
+- 修复：`processMergedItems` 返回判别列宿主名集合 → `DBSetup` 标记 `RecordMapItem.hasMergedDiscriminator` → `EntityQueryHandle` 的全部公共写入口（create/update/updateRelationByName/addRelationByNameById/addRelationById）递归校验载荷（含嵌套关联记录与 `&` link 数据），显式携带 `__type` 即抛明确错误。非 merged 家族用户自定义 `__type` 属性不受影响（有回归用例）；框架内部路径（flash-out/搬迁重插全行数据）走 agent 层不经过该入口，不受影响。
+
+---
+
+## 三、重要问题（已复现，本轮已修复）
+
+### R-1 跨 Activity 使用 activityId：裸 TypeError；共享 Interaction 实例时可错绑状态/授权
+
+- 位置：`src/builtins/interaction/activity/ActivityCall.ts` `getActivity`——按 id 查 `_Activity_` 记录后**不校验**记录上的 `uuid`（活动定义标识，create 时已存储）是否属于当前 ActivityCall。
+- 复现（实测输出）：两个 Activity A/B，把 A 的 activityId 传给 B 的交互：
+
+```
+dispatch B:b2 with A's activityId
+→ TypeError: Cannot read properties of undefined (reading 'content')   ❌ 裸内部错误
+```
+
+- 风险面：默认场景 fail-closed 但错误无法定位；若两个 Activity **共用同一 Interaction 实例**（节点 uuid = interaction.uuid，两图 uuid 相同），A 的 state/refs 会被 B 的图成功解释——状态推进与 `isRef` attributive 授权判定错绑到别的流程。
+- 修复：`getActivity` 校验 `activity.uuid === this.activity.uuid`，不匹配即抛「activity instance X belongs to activity "A", not "B"」的业务级错误；本流程内推进不受影响（回归用例覆盖三个方向）。
+
+### K-1 知识库 Custom 增量示例：直接从 `mutationEvent.record` 读字段——update 事件只带变更字段，聚合静默漂移
+
+- 位置：`agent/agentspace/knowledge/generator/api-reference.md` `IncrementalCounter` 示例（原 L1775+）：`(mutationEvent.record?.value || 0) - (mutationEvent.oldRecord?.value || 0)`。
+- 事实：update 事件的 `record` **只携带本次写入的字段（+id）**，`oldRecord` 才是完整旧快照；delete 事件的完整快照在 `record` 上、`oldRecord` 为 undefined。照抄示例的代码在「更新其他字段」时把贡献读成 undefined→0。
+- 复现（实测输出）：`Counter{value:10, active:false}` → `update({active:true})`（record 里没有 value）：
+
+```
+文档模式增量结果: 0     ❌（应为 10，且永不自愈）
+```
+
+- 影响：与 r8 F-3 的知识库连带修正同性质——这些示例是代码生成管线的模板，每一份都会教下游生成静默漂移的 Custom 计算。r8 F-2 只修了内置聚合（改为 findOne 全量拉取），Custom 是「自带逻辑」的 API，框架侧无法代取，正确契约必须由文档承载。
+- 修复：示例改为 `{...oldRecord, ...record}` 重建全量新状态 + delete 分支读 `record`；`generator/api-reference.md` 与 `usage/14-api-reference.md` 新增「Mutation event snapshots」契约小节（三种事件类型的快照形状表）。正确模式以回归用例固化（create/update-部分字段/update-多字段/delete 全路径与真值一致）。
+
+---
+
+## 四、重要问题（精读判定，高置信度，本轮未修）
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | base 宿主的 property 聚合无法引用「声明在 filtered 变体上的 relation」 | `aggregationTemplate.ts` L249–252（`relations.find(r => r.source === host)` 按实例相等） | r8 允许了 filtered 端点 relation，但 `User` 上的 `Count.create({property:'activePosts'})` 找不到 `source: ActiveUser` 的 relation → setup assert。fail-fast 无静默风险，但组合上是「r8 开了声明、rooms 里还没家具」——F-1 的 fail-fast 又把「声明在 ActiveUser 上」的路也封了，当前该 relation 上不能挂任何 property 聚合。需要显式设计：允许 host 解析到自身 filtered 变体端点的 relation，并定义非成员宿主的增量语义（成员资格进出时 full recompute） |
+| I-2 | dispatch 先持久化 InteractionEvent 再执行 resolve：StateMachine 的 trigger 挂在 InteractionEventEntity 上时看不到 resolve 产出 | `Controller.ts` L695–709 | `computeTarget` 依赖 resolve 中才创建的实体 id 时 lock 失败 → 静默 skip，状态永久停在初态。属调度顺序的既定语义（事件先于产出），建议文档化「依赖 resolve 产出的转移应监听产出实体自身的 create 事件」 |
+| I-3 | Entity/Property 改名（即使保留 uuid）被 migration 识别为 remove+add | `migration.ts` `identityKey` L554–555（身份键 = 名称路径，uuid 仅记录不参与身份） | rename decision 在 Phase 1.5 被拒绝（fail-fast，有测试），不会静默丢数据；但「同 uuid 改名 = 安全重构」的直觉不成立，存量数据无搬迁路径。需要 rename 一等支持或文档明确「改名 = 删+建，需自写迁移」 |
+| I-4 | Condition/Attributive 回调返回非 boolean 的 truthy 直接放行 | `Interaction.ts` `checkCondition`/`checkAttributive`；`BoolExp.evaluateAsync` `(result && !inverse)` | 守卫写 `return user.role`（字符串恒 truthy）之类的类型错误静默 fail-open。已拦截 undefined/异常；建议对非 boolean 返回值告警或拒绝（契约变更需评审） |
+| I-5 | 批量化 1:n 子查询静默丢弃无法挂靠父记录的子行 | `QueryExecutor.ts` `findXToManyRelatedRecordsBatched` L436–469（`if (parent)` 无 else） | 需要前置数据腐蚀（悬挂端点）才触发，属防御深度：建议 assert 或 warn，让读路径暴露写路径的腐蚀而不是掩盖 |
+
+## 五、本轮证伪的候选
+
+| 候选 | 证伪依据 |
+|------|----------|
+| 「global 聚合以 filtered 端点 relation 为源：物理 link 全量计入 vs 全量重算按端点谓词过滤 → 漂移」（探查 A#2） | 实测 `Count({record: ActiveUserPostRel})` 对 inactive 用户建 link：dict = 2 == `find(Rel.name)` = 2。该 relation 不是 filtered relation，物理行就是唯一语义，增量与全量口径一致，无漂移 |
+| 「Custom 的 dataDeps 里函数型 match 进不了 modelHash → 迁移不重算」（探查 D#3） | `RecordsDataDep.match` 类型是 `MatchExpressionData`（声明式 BoolExp，非函数）；args 里任何位置的函数由 `collectFunctionText` 深遍历收进 `functionSignature.hash`（`migration.ts` L768–800），函数体变更会触发 needs-review |
+| 「PropertyRelationAggregation 对 filtered 端点 relation 的非成员宿主 +1」（探查 A#1） | 该形态的前提（property 聚合声明在 filtered entity 宿主上）被本轮 F-1 的 fail-fast 在 setup 期阻断；声明在 base 宿主上则命中 I-1 的 setup assert——两条路都 fail-closed，无静默错值路径存活 |
+
+## 六、既有遗留项复确（r2–r8 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4 I-1）；x:n 谓词分页内存化 / orderBy 代表行（r3 I-2 / r1 I-7）；dispatch 默认吞错返回 `{error}`；payload 弱校验族 / `userRef` / `itemRef` 死 API（r7 I-11~I-14）；StateMachine 单事件单跳 / 宿主 delete-trigger 静默 skip / 同 current 多 transfer 取声明序（r2 R-4 / r7 I-5 / I-8）。
+- **性能/资源**：global dict 变更触发宿主全表扫描（S3）；async task 表只增不减（r2 I-6）；级联无深度上限（r2 I-5）；迁移锁无租约（r2 I-13）。
+- **驱动**：MySQL 事务文档化不支持；number 类型映射 SQLite/MySQL `INT` vs PG `DOUBLE PRECISION`（r2，r8 已核实 SQLite 侧非问题）；boolean 写侧不归一化（r1 R-6 写侧遗留）。
+- **信任边界**：`func::` + `new Function` 反序列化即代码执行（r3 I-16，r8 已文档化）。
+- **combined record**：挤出/搬迁不发实体级事件（r8 R-3 已按预言机固化为正确语义，`mergeLinks` 去留仍是产品决策）。
+
+## 七、修复优先级建议（遗留项）
+
+1. **I-1 filtered 端点 relation 的 property 聚合语义补全**——r8/r9 两轮 fail-fast 把静默错值全部封死了，但也意味着这个合法声明组合目前没有任何可用路径，是功能空洞而不只是债务；
+2. I-3 migration rename 一等支持（或文档明确契约）；
+3. I-2 dispatch 时序契约文档化 + I-4 守卫返回值类型收紧（同属「契约明确化」家族，改动小）；
+4. 六聚合模板抽取后的下一个模板化目标：`EntityQueryHandle` 写入口的载荷校验（本轮 `__type` 保护是第一个成员，未知属性静默丢弃是同族问题——r7 I-13 Klass 工厂未知参数的 storage 版）。
+
+## 附录：复现要点（验证用）
+
+- F-1：`Entity.create({ baseEntity, matchExpression, properties: [新属性] })` → setup 应抛 `Filtered entity ... cannot declare its own property`；同名再声明应通过。
+- F-2：两个 relation 同 `source`+`sourceProperty` → setup 应抛 `Relation property name conflict`；对称自引用（单 relation 双端同名）应通过。
+- F-3：自引用 n:n，数据 `A→B→C→D→C`，label/goto 递归 + 恒 false 的 exit → 应正常返回（旧代码无限递归）。
+- F-4：merged entity 的 input 名下 `create/update` 显式携带 `__type` → 应抛 discriminator 错误；嵌套载荷（`contact: {id, __type}`）同样拦截。
+- R-1：跨 Activity 传 activityId → 应得到 `belongs to activity "A", not "B"` 的业务级错误。
+- K-1：Custom 增量读 update 事件未变更字段 → 文档模式漂移；`{...oldRecord, ...record}` 模式与真值一致。

--- a/src/builtins/interaction/activity/ActivityCall.ts
+++ b/src/builtins/interaction/activity/ActivityCall.ts
@@ -297,7 +297,18 @@ export class ActivityCall {
             value: ['=', activityId],
         })
         const results = await storage.system.storage.find(ActivityCall.ACTIVITY_RECORD, match, undefined, ['*'])
-        return results.map((a: any) => ({ ...a, state: a.state, refs: a.refs }))[0]
+        const activity = results.map((a: any) => ({ ...a, state: a.state, refs: a.refs }))[0]
+        // fail-fast：activityId 是 API 边界输入，可能属于另一个 Activity 定义。
+        //  不校验归属会用本 Activity 的图去解释别的流程的 state/refs——轻则在深处抛
+        //  "Cannot read properties of undefined" 的裸 TypeError，重则（两个 Activity 共用
+        //  同一个 Interaction 实例、节点 uuid 相同时）把状态推进/授权判定错绑到别的流程上。
+        if (activity && activity.uuid !== this.activity.uuid) {
+            throw new Error(
+                `activity instance ${activityId} belongs to activity "${activity.name}", ` +
+                `not "${this.activity.name}" — check the activityId passed to this dispatch`
+            )
+        }
+        return activity
     }
     async setActivity(storage: StorageAccess, activityId: string, value: any) {
         const match = BoolExp.atom({

--- a/src/storage/erstorage/EntityQueryHandle.ts
+++ b/src/storage/erstorage/EntityQueryHandle.ts
@@ -1,14 +1,15 @@
-import { EntityToTableMap, RecordMapItem } from "./EntityToTableMap.js";
+import { EntityToTableMap, RecordMapItem, RecordAttribute } from "./EntityToTableMap.js";
 import { MatchExp, MatchExpressionData } from "./MatchExp.js";
 import { ModifierData } from "./Modifier.js";
 import { AttributeQueryData } from "./AttributeQuery.js";
 import { assert } from "../utils.js";
-import { RecordQuery } from "./RecordQuery.js";
+import { RecordQuery, LINK_SYMBOL } from "./RecordQuery.js";
 import { NewRecordData, RawEntityData } from "./NewRecordData.js";
 import { RecordQueryAgent } from "./RecordQueryAgent.js";
 import { EntityIdRef, Database, RecordMutationEvent, ID_ATTR } from "@runtime";
 import { Record } from "./RecordQueryAgent.js";
 import { RecordInfo } from "./RecordInfo.js";
+import { MERGED_TYPE_ATTR } from "./MergedItemProcessor.js";
 
 export class EntityQueryHandle {
     agent: RecordQueryAgent
@@ -55,15 +56,52 @@ export class EntityQueryHandle {
         return this.agent.lockRecords(entityQuery, `locking ${entityName} from handle`)
     }
 
+    /**
+     * merged entity/relation 的 `__type` 判别列由框架管理（创建时按使用的名字写入），
+     * 显式覆写会把记录静默错标到其他 input 视图（跨视图可见性错乱 + 特有列交叉污染）。
+     * 公共写入口在此 fail-fast；递归检查嵌套的关联记录载荷（含 `&` link 数据）。
+     */
+    private assertNoDiscriminatorWrite(recordName: string, rawData?: RawEntityData | RawEntityData[] | null) {
+        if (!rawData || typeof rawData !== 'object') return
+        if (Array.isArray(rawData)) {
+            rawData.forEach(item => this.assertNoDiscriminatorWrite(recordName, item))
+            return
+        }
+        const record = this.map.getRecord(recordName)
+        if (!record) return
+        if (Object.prototype.hasOwnProperty.call(rawData, MERGED_TYPE_ATTR)) {
+            const resolvedName = record.resolvedBaseRecordName || recordName
+            if (this.map.getRecord(resolvedName)?.hasMergedDiscriminator) {
+                throw new Error(
+                    `'${MERGED_TYPE_ATTR}' is the discriminator column of merged record '${resolvedName}' and is managed by the framework — ` +
+                    `it is written once at creation based on the name the record is created as, and cannot be set or changed through create/update. ` +
+                    `To move a record between input views, change the data its membership conditions depend on instead.`
+                )
+            }
+        }
+        for (const [key, value] of Object.entries(rawData)) {
+            if (!value || typeof value !== 'object') continue
+            const attribute = record.attributes[key] as RecordAttribute | undefined
+            if (!attribute?.isRecord) continue
+            this.assertNoDiscriminatorWrite(attribute.recordName, value as RawEntityData | RawEntityData[])
+            const linkData = (value as RawEntityData)[LINK_SYMBOL]
+            if (linkData && attribute.linkName) {
+                this.assertNoDiscriminatorWrite(attribute.linkName, linkData as RawEntityData)
+            }
+        }
+    }
+
     async create(entityName: string, rawData: RawEntityData, events?: RecordMutationEvent[]): Promise<EntityIdRef> {
         // 支持使用外部 id。
         // assert(rawData[ID_ATTR] === null || rawData[ID_ATTR] === undefined, `${ID_ATTR} should be null or undefined when creating new record`)
+        this.assertNoDiscriminatorWrite(entityName, rawData)
         const newEntityData = new NewRecordData(this.map, entityName, rawData)
         return this.agent.createRecord(newEntityData, `create record ${entityName} from handle`, events)
     }
 
     // CAUTION 不能递归更新 relate entity 的 value，如果传入了 related entity 的值，说明是建立新的联系。
     async update(entity: string, matchExpressionData: MatchExpressionData, rawData: RawEntityData, events?: RecordMutationEvent[]) {
+        this.assertNoDiscriminatorWrite(entity, rawData)
         const newEntityData = new NewRecordData(this.map, entity, rawData)
         return this.agent.updateRecord(entity, matchExpressionData, newEntityData, events)
     }
@@ -74,15 +112,18 @@ export class EntityQueryHandle {
 
     async addRelationByNameById(relationName: string, sourceEntityId: string, targetEntityId: string, rawData: RawEntityData = {}, events?: RecordMutationEvent[]) {
         assert(!!relationName && !!sourceEntityId && targetEntityId!!, `relationName: ${relationName} sourceEntityId:${sourceEntityId} targetEntityId:${targetEntityId} all cannot be empty`)
+        this.assertNoDiscriminatorWrite(relationName, rawData)
         return this.agent.addLink(relationName, sourceEntityId, targetEntityId, rawData, false, events)
     }
 
     async addRelationById(entity: string, attribute: string, entityId: string, attributeEntityId: string, relationData?: RawEntityData, events?: RecordMutationEvent[]) {
+        this.assertNoDiscriminatorWrite(this.map.getInfo(entity, attribute).linkName, relationData)
         return this.agent.addLinkFromRecord(entity, attribute, entityId, attributeEntityId, relationData, events)
     }
 
     async updateRelationByName(relationName: string, matchExpressionData: MatchExpressionData, rawData: RawEntityData, events?: RecordMutationEvent[]) {
         assert(!rawData.source && !rawData.target, 'Relation can only update attributes. Use addRelation/removeRelation to update source/target.')
+        this.assertNoDiscriminatorWrite(relationName, rawData)
         return this.agent.updateRecord(relationName, matchExpressionData, new NewRecordData(this.map, relationName, rawData), events)
     }
 

--- a/src/storage/erstorage/EntityToTableMap.ts
+++ b/src/storage/erstorage/EntityToTableMap.ts
@@ -68,6 +68,9 @@ export type RecordMapItem = {
     // CAUTION merged item 是抽象联合类型（union），不允许以它的名义直接创建记录（explicit control）。
     //  同样地，以 merged item 为 base 的 filtered entity 也无法确定具体的 __type，禁止创建。
     isMergedAbstract?: boolean
+    // 该 record 是 merged item 编译出的物理 base，持有框架管理的 __type 判别列。
+    // 判别列的值只能由"创建时使用的名字"决定，公共写入口必须拒绝显式写入。
+    hasMergedDiscriminator?: boolean
 }
 
 type RecordMap = {

--- a/src/storage/erstorage/MergedItemProcessor.ts
+++ b/src/storage/erstorage/MergedItemProcessor.ts
@@ -25,6 +25,11 @@ export interface ProcessMergedItemsResult {
      * 以及内部生成的虚拟 base 名。
      */
     abstractNames: Set<string>;
+    /**
+     * 持有 `__type` 判别列的物理 base 名集合（merged item 自身或其虚拟 base）。
+     * 判别列由框架管理（记录创建时按使用的名字写入），公共写入口据此拒绝显式覆写。
+     */
+    discriminatorHostNames: Set<string>;
 }
 
 function isEntity(item: MergedItem): item is EntityInstance {
@@ -120,6 +125,7 @@ export function processMergedItems(
 ): ProcessMergedItemsResult {
     const refContainer = new RefContainer(entities, relations);
     const abstractNames = new Set<string>();
+    const discriminatorHostNames = new Set<string>();
 
     // 1. 基于原始（克隆前的）图计算每个名字的具体类型值：
     //    typeValue(name) = 沿 base 链走到根的名字；根是 merged item 时该名字是抽象的（不可创建）。
@@ -145,14 +151,14 @@ export function processMergedItems(
     const relationTree = buildItemTree(relations);
 
     for (const mergedEntity of mergedEntities) {
-        processSingleMergedItem(mergedEntity, refContainer, 'entity', entityTree, typeValueByName, compiledByName, abstractNames);
+        processSingleMergedItem(mergedEntity, refContainer, 'entity', entityTree, typeValueByName, compiledByName, abstractNames, discriminatorHostNames);
     }
     for (const mergedRelation of mergedRelations) {
-        processSingleMergedItem(mergedRelation, refContainer, 'relation', relationTree, typeValueByName, compiledByName, abstractNames);
+        processSingleMergedItem(mergedRelation, refContainer, 'relation', relationTree, typeValueByName, compiledByName, abstractNames, discriminatorHostNames);
     }
 
     const result = refContainer.getAll();
-    return { ...result, abstractNames };
+    return { ...result, abstractNames, discriminatorHostNames };
 }
 
 /**
@@ -238,6 +244,7 @@ function processSingleMergedItem<T extends MergedItem>(
     typeValueByName: Map<string, string>,
     compiledByName: Map<string, CompiledMergedInfo>,
     abstractNames: Set<string>,
+    discriminatorHostNames: Set<string>,
 ): void {
     const isEntityType = itemType === 'entity';
     const itemName = getItemName(mergedItem);
@@ -312,6 +319,7 @@ function processSingleMergedItem<T extends MergedItem>(
         hostedTypes,
         physicalBaseName: getItemName(registeredBaseItem),
     });
+    discriminatorHostNames.add(getItemName(registeredBaseItem));
 
     // 4. 把每个 input 替换成物理 base 上的 filtered item
     //    rootBaseName -> 该 root base 承载的类型集合，用于保持 root base 的可查询性（IS-A 语义）。

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -178,8 +178,12 @@ export class QueryExecutor {
         }
 
         // 检查一下是否已经产生了循环。因为所有的子查询都会以这个函数为入口，所以可以再这里判断。
+        // CAUTION 环不一定回到起点：A→B→C→B 这样的环里，栈首（A/B）永远不等于栈尾，
+        //  只比较 stack[0] 会导致无限递归（栈溢出/挂起）。只要当前记录在本轮递归路径上
+        //  出现过（任意位置）就说明进入了环，停止展开。
         if (entityQuery.label && context.label === entityQuery.label && context.stack.length > 1) {
-            if ((context.stack[0] as Record).id === (context.stack.at(-1) as Record).id) {
+            const lastRecord = context.stack.at(-1) as Record
+            if (context.stack.slice(0, -1).some(record => (record as Record).id === lastRecord.id)) {
                 return []
             }
         }

--- a/src/storage/erstorage/Setup.ts
+++ b/src/storage/erstorage/Setup.ts
@@ -485,6 +485,53 @@ export class DBSetup {
     }
 
     /**
+     * 验证 filtered entity / filtered relation 不能声明自己的新 value property。
+     *
+     * filtered item 是 base 之上的视图，与 base 共享同一张物理表和同一个属性命名空间：
+     * DBSetup 不会（也不应该）为 filtered item 单独建列，查询编译统一按 resolvedBaseRecordName
+     * 解析属性。历史行为是把这些属性静默丢弃——列不存在、写入被悄悄忽略、挂在其上的
+     * computation 只维护 bound state 而可见值永远不落库（静默数据丢失）。
+     * 这里改为声明期 fail-fast，指引用户把属性声明到 base 上。
+     *
+     * 与 base 链上同名的 property 声明仍然合法（解析到 base 列）：merged item 编译管线
+     * 会把 input entity rebase 成携带原属性列表的 filtered item，这些属性都已合并进物理 base。
+     */
+    private validateFilteredItemProperties() {
+        const collectBaseChainPropertyNames = (item: EntityInstance | RelationInstance): Set<string> => {
+            const names = new Set<string>()
+            let current: EntityInstance | RelationInstance | undefined =
+                (item as EntityInstance).baseEntity || (item as RelationInstance).baseRelation
+            while (current) {
+                for (const property of current.properties || []) {
+                    names.add(property.name)
+                }
+                current = (current as EntityInstance).baseEntity || (current as RelationInstance).baseRelation
+            }
+            return names
+        }
+
+        const validateItem = (item: EntityInstance | RelationInstance, kind: 'entity' | 'relation') => {
+            const isFiltered = !!((item as EntityInstance).baseEntity || (item as RelationInstance).baseRelation)
+            if (!isFiltered || !item.properties?.length) return
+            const baseNames = collectBaseChainPropertyNames(item)
+            const newProperties = item.properties.filter(property => !baseNames.has(property.name))
+            if (newProperties.length) {
+                const rootName = this.resolveEndpointRootName(item)
+                throw new Error(
+                    `Filtered ${kind} '${item.name}' cannot declare its own propert${newProperties.length > 1 ? 'ies' : 'y'} ` +
+                    `${newProperties.map(p => `'${p.name}'`).join(', ')}. ` +
+                    `Filtered ${kind === 'entity' ? 'entities' : 'relations'} are views sharing the base ${kind}'s table row, ` +
+                    `so new properties (including computed/computation properties) must be declared on the base ${kind} '${rootName}'. ` +
+                    `Re-declaring a property name that already exists on the base is allowed and resolves to the base column.`
+                )
+            }
+        }
+
+        this.entities.forEach(entity => validateItem(entity, 'entity'))
+        this.relations.forEach(relation => validateItem(relation, 'relation'))
+    }
+
+    /**
      * 验证 relations
      * 
      * 检查 filtered entity 上的关系属性名是否与其 base entity 的关系属性名冲突。
@@ -562,14 +609,16 @@ export class DBSetup {
         })
         familyProps.forEach((props, rootName) => {
             props.forEach((entry, prop) => {
-                // 同一个 relation 的对称两端共用同一属性名是合法的（symmetric relation）。
-                const hasFilteredDeclarer = Array.from(entry.declarers).some(name => name !== rootName)
-                if (entry.relations.size > 1 && hasFilteredDeclarer) {
+                // 同一个 relation 的对称两端共用同一属性名是合法的（symmetric relation，Set 去重后 size 为 1）。
+                // 除此之外，同一 base record 家族里（base 自身 + 全部 filtered 变体）多个 relation 声明
+                // 同一属性名必然互相覆盖：属性表按名登记，后注册者静默赢得该名字，先注册的 relation
+                // 从此不可达（查询走错关系、级联漏删）。无论声明方是否 filtered，一律 fail-fast。
+                if (entry.relations.size > 1) {
                     throw new Error(
                         `Relation property name conflict: property '${prop}' is declared by multiple relations ` +
                         `within the same base record family '${rootName}' (declared on: ${Array.from(entry.declarers).join(', ')}). ` +
-                        `Filtered entities share the base entity's attribute namespace, ` +
-                        `so each relation property name must be unique across the base entity and all its filtered entities.`
+                        `Each relation property name must be unique across the base entity and all its filtered entities — ` +
+                        `otherwise the relations silently overwrite each other in the shared attribute namespace.`
                     )
                 }
             })
@@ -781,7 +830,10 @@ export class DBSetup {
 
         // 0. 预处理：将 merged entity 和 merged relation 转化为 filtered entity/relation
         this.processMergedItems();
-        
+
+        // 0.5. 验证：filtered entity/relation 不能声明 base 上不存在的新 property（视图无独立列）
+        this.validateFilteredItemProperties();
+
         // 1. 验证：不允许 filtered entity 作为 relation 的 source 或 target
         this.validateRelations();
         
@@ -816,6 +868,7 @@ export class DBSetup {
      * 统一处理 merged entities 和 merged relations
      */
     private mergedAbstractNames: Set<string> = new Set()
+    private mergedDiscriminatorHostNames: Set<string> = new Set()
     private processMergedItems() {
         const result = processMergedItems(
             this.entities,
@@ -825,6 +878,7 @@ export class DBSetup {
         this.entities = result.entities;
         this.relations = result.relations;
         this.mergedAbstractNames = result.abstractNames;
+        this.mergedDiscriminatorHostNames = result.discriminatorHostNames;
     }
 
     /**
@@ -836,6 +890,11 @@ export class DBSetup {
         for (const name of this.mergedAbstractNames) {
             if (this.map.records[name]) {
                 this.map.records[name].isMergedAbstract = true
+            }
+        }
+        for (const name of this.mergedDiscriminatorHostNames) {
+            if (this.map.records[name]) {
+                this.map.records[name].hasMergedDiscriminator = true
             }
         }
     }

--- a/tests/runtime/data/leaveRequest.ts
+++ b/tests/runtime/data/leaveRequest.ts
@@ -96,7 +96,9 @@ const sendRequestRelation = Relation.create({
     source: RequestEntity,
     sourceProperty: 'from',
     target: UserEntity,
-    targetProperty: 'request',
+    // CAUTION 同一实体上不同 relation 的反向属性名必须唯一（r9 起 setup 期强制校验），
+    //  否则后注册的 relation 会在共享属性命名空间里静默覆盖先注册的。
+    targetProperty: 'sentRequests',
     type: 'n:1',
     computation:  
     Transform.create({
@@ -291,7 +293,7 @@ const reviewerRelation = Relation.create({
     source: RequestEntity,
     sourceProperty: 'to',
     target: UserEntity,
-    targetProperty: 'request',
+    targetProperty: 'reviewedRequests',
     type: 'n:1',
     properties: [
         Property.create({

--- a/tests/runtime/review-fixes-2026-07-09-r9.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r9.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+import {
+    Entity, Property, Dictionary, Custom, KlassByName,
+    Controller, MonoSystem,
+    Interaction, Action, Activity, Transfer, ActivityManager,
+} from 'interaqt';
+import { MatchExp } from '@storage';
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r9 review 回归（runtime/builtins 侧）。
+ *
+ * R-1: activityId 是 API 边界输入，此前 getActivity 不校验记录归属——把 Activity A 的
+ *      activityId 传给 Activity B 的交互时，B 的图去解释 A 的 state/refs，在深处抛
+ *      "Cannot read properties of undefined (reading 'content')" 的裸 TypeError；
+ *      两个 Activity 共用同一 Interaction 实例（节点 uuid 相同）时更会把状态推进/
+ *      isRef 授权判定错绑到别的流程上。现在 fail-fast 给出指明两个流程名的业务级错误。
+ *
+ * K-1: 知识库 Custom 增量示例此前直接从 mutationEvent.record 读字段——update 事件的
+ *      record 只带本次写入的字段（+id），未变更字段读出 undefined，聚合静默漂移。
+ *      本用例固化正确写法（{...oldRecord, ...record} 重建全量新状态）的行为。
+ */
+describe('r9 R-1: activityId is validated against the activity definition', () => {
+    function makeInteraction(name: string) {
+        return Interaction.create({ name, action: Action.create({ name }) })
+    }
+
+    test('dispatching activity B interactions with activity A activityId gives a clear error', async () => {
+        const a1 = makeInteraction('a1')
+        const a2 = makeInteraction('a2')
+        const b1 = makeInteraction('b1')
+        const b2 = makeInteraction('b2')
+        const activityA = Activity.create({
+            name: 'A',
+            interactions: [a1, a2],
+            transfers: [Transfer.create({ name: 'ta', source: a1, target: a2 })]
+        })
+        const activityB = Activity.create({
+            name: 'B',
+            interactions: [b1, b2],
+            transfers: [Transfer.create({ name: 'tb', source: b1, target: b2 })]
+        })
+        const User = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const activityManager = new ActivityManager([activityA, activityB])
+        const out = activityManager.getOutput()
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [User, ...out.entities],
+            relations: [...out.relations],
+            eventSources: [...out.eventSources],
+        })
+        await controller.setup(true)
+        const user = await system.storage.create('User', { name: 'u' })
+
+        const esA1 = out.eventSources.find((es: any) => es.name === 'A:a1')!
+        const resA = await controller.dispatch(esA1, { user })
+        expect(resA.error).toBeUndefined()
+        const activityIdOfA = (resA as any).context?.activityId
+        expect(activityIdOfA).toBeTruthy()
+
+        // 跨流程使用 activityId：必须是指明两个流程名的业务级错误，而不是裸 TypeError
+        const esB2 = out.eventSources.find((es: any) => es.name === 'B:b2')!
+        const resB2 = await controller.dispatch(esB2, { user, activityId: activityIdOfA })
+        expect(String(resB2.error)).toMatch(/belongs to activity "A", not "B"/)
+
+        const esB1 = out.eventSources.find((es: any) => es.name === 'B:b1')!
+        const resB1 = await controller.dispatch(esB1, { user, activityId: activityIdOfA })
+        expect(String(resB1.error)).toMatch(/belongs to activity "A", not "B"/)
+
+        // 本流程内继续推进不受影响
+        const esA2 = out.eventSources.find((es: any) => es.name === 'A:a2')!
+        const resA2 = await controller.dispatch(esA2, { user, activityId: activityIdOfA })
+        expect(resA2.error).toBeUndefined()
+    })
+})
+
+describe('r9 K-1: Custom incremental pattern over partial update-event records', () => {
+    test('overlaying changed fields on oldRecord keeps the aggregate consistent', async () => {
+        const Counter = Entity.create({
+            name: 'Counter',
+            properties: [
+                Property.create({ name: 'label', type: 'string' }),
+                Property.create({ name: 'value', type: 'number' }),
+                Property.create({ name: 'active', type: 'boolean' })
+            ]
+        })
+        const totalDict = Dictionary.create({
+            name: 'activeCounterTotal',
+            type: 'number',
+            collection: false,
+            computation: Custom.create({
+                name: 'ActiveCounterTotal',
+                useLastValue: true,
+                dataDeps: {
+                    counters: { type: 'records', source: Counter, attributeQuery: ['value', 'active'] }
+                },
+                incrementalDataDeps: [],
+                compute: async function (dataDeps: any) {
+                    return dataDeps.counters
+                        .filter((c: any) => c.active)
+                        .reduce((s: number, c: any) => s + (c.value || 0), 0)
+                },
+                // 知识库固化的正确模式（事件快照形状因类型而异）：
+                // create: record=写入字段, oldRecord=undefined
+                // update: record=仅变更字段(+id), oldRecord=完整旧快照 → 用 {...old, ...record} 重建全量新状态
+                // delete: record=完整被删快照, oldRecord=undefined
+                incrementalCompute: async function (lastValue: any, mutationEvent: any) {
+                    const contribution = (r: any) => (r?.active ? (r?.value || 0) : 0)
+                    const newRecord = mutationEvent.type === 'delete'
+                        ? undefined
+                        : { ...(mutationEvent.oldRecord || {}), ...(mutationEvent.record || {}) }
+                    const previousRecord = mutationEvent.type === 'delete'
+                        ? mutationEvent.record
+                        : mutationEvent.oldRecord
+                    const delta = contribution(newRecord) - contribution(previousRecord)
+                    return (lastValue || 0) + delta
+                },
+                getInitialValue: () => 0
+            })
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [Counter],
+            relations: [],
+            eventSources: [],
+            dict: [totalDict]
+        })
+        await controller.setup(true)
+
+        const c = await system.storage.create('Counter', { label: 'x', value: 10, active: false })
+        expect(await system.storage.dict.get('activeCounterTotal')).toBe(0)
+
+        // 只更新 active 一个字段：update 事件的 record 里没有 value。
+        // 旧文档模式（直接读 mutationEvent.record.value）在这里会得到 0 而不是 10。
+        await system.storage.update('Counter', MatchExp.atom({ key: 'id', value: ['=', c.id] }), { active: true })
+        expect(await system.storage.dict.get('activeCounterTotal')).toBe(10)
+
+        await system.storage.update('Counter', MatchExp.atom({ key: 'id', value: ['=', c.id] }), { label: 'renamed', value: 25 })
+        expect(await system.storage.dict.get('activeCounterTotal')).toBe(25)
+
+        await system.storage.delete('Counter', MatchExp.atom({ key: 'id', value: ['=', c.id] }))
+        expect(await system.storage.dict.get('activeCounterTotal')).toBe(0)
+    })
+})

--- a/tests/storage/review-fixes-2026-07-09-r9.spec.ts
+++ b/tests/storage/review-fixes-2026-07-09-r9.spec.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "vitest";
+import { Entity, Property, Relation } from '@core';
+import { DBSetup, EntityQueryHandle, EntityToTableMap, MatchExp, RecursiveContext } from "@storage";
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r9 review 回归（storage 侧）。
+ *
+ * F-1: filtered entity/relation 声明自己的新 property 此前被 setup 静默丢弃——
+ *      列不建、写入被悄悄忽略、挂在其上的 computation 只维护 bound state 而可见值
+ *      永远不落库（静默数据丢失）。现在 setup 期 fail-fast，指引声明到 base 上。
+ * F-2: 同一 base record 家族里多个 relation 声明同名属性此前静默互相覆盖
+ *      （后注册者赢得属性名，先注册的 relation 从此不可达）。现在无论声明方是否
+ *      filtered 一律 setup 期 fail-fast（r8 只拦截了含 filtered declarer 的情况）。
+ * F-3: label/goto 递归查询的环检测只比较"栈首 == 栈尾"，数据图中不经过起点的环
+ *      （A→B→C→D→C）会无限递归（栈溢出/挂起）。现在检测递归路径上任意位置的重复记录。
+ * F-4: merged entity/relation 的 __type 判别列可被 create/update 载荷显式覆写，
+ *      记录被静默错标到其他 input 视图（跨视图可见性错乱 + 特有列交叉污染）。
+ *      现在公共写入口 fail-fast（含嵌套关联载荷与 & link 数据）。
+ */
+describe('r9 F-1: filtered item declaring its own new property fails fast at setup', () => {
+    test('filtered entity with a new value property is rejected', async () => {
+        const User = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' })
+            ]
+        })
+        const ActiveUser = Entity.create({
+            name: 'ActiveUser',
+            baseEntity: User,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }),
+            properties: [Property.create({ name: 'nickname', type: 'string' })]
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        expect(() => new DBSetup([User, ActiveUser], [], db))
+            .toThrowError(/Filtered entity 'ActiveUser' cannot declare its own property 'nickname'/)
+        await db.close()
+    })
+
+    test('filtered relation with a new property is rejected', async () => {
+        const User = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Team = Entity.create({ name: 'Team', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Membership = Relation.create({
+            source: User, sourceProperty: 'teams', target: Team, targetProperty: 'members', type: 'n:n',
+            properties: [Property.create({ name: 'role', type: 'string' })]
+        })
+        const LeadMembership = Relation.create({
+            name: 'LeadMembership',
+            baseRelation: Membership,
+            sourceProperty: 'leadTeams',
+            targetProperty: 'leads',
+            matchExpression: MatchExp.atom({ key: 'role', value: ['=', 'lead'] }),
+            properties: [Property.create({ name: 'extra', type: 'string' })]
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        expect(() => new DBSetup([User, Team], [Membership, LeadMembership], db))
+            .toThrowError(/Filtered relation 'LeadMembership' cannot declare its own property 'extra'/)
+        await db.close()
+    })
+
+    test('re-declaring a base property name on a filtered entity is still allowed (resolves to base column)', async () => {
+        const User = Entity.create({
+            name: 'User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' })
+            ]
+        })
+        const ActiveUser = Entity.create({
+            name: 'ActiveUser',
+            baseEntity: User,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }),
+            // merged item 编译管线会产生这种"与 base 同名"的属性声明，必须保持合法
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([User, ActiveUser], [], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+        const u = await handle.create('ActiveUser', { name: 'u', isActive: true })
+        const read = await handle.findOne('ActiveUser', MatchExp.atom({ key: 'id', value: ['=', u.id] }), undefined, ['*'])
+        expect(read.name).toBe('u')
+        await db.close()
+    })
+})
+
+describe('r9 F-2: duplicate relation property names within one base family fail fast', () => {
+    test('two base relations sharing the same sourceProperty are rejected', async () => {
+        const User = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Post = Entity.create({ name: 'Post', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const Task = Entity.create({ name: 'Task', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const R1 = Relation.create({ source: User, sourceProperty: 'items', target: Post, targetProperty: 'owner', type: '1:n' })
+        const R2 = Relation.create({ source: User, sourceProperty: 'items', target: Task, targetProperty: 'owner', type: '1:n' })
+        const db = new PGLiteDB()
+        await db.open()
+        expect(() => new DBSetup([User, Post, Task], [R1, R2], db))
+            .toThrowError(/Relation property name conflict: property 'items'/)
+        await db.close()
+    })
+
+    test('symmetric self-relation (same property on both sides of ONE relation) is still legal', async () => {
+        const User = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Friendship = Relation.create({
+            source: User, sourceProperty: 'friends', target: User, targetProperty: 'friends', type: 'n:n'
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([User], [Friendship], db)
+        await setup.createTables()
+        await db.close()
+    })
+})
+
+describe('r9 F-3: goto recursion terminates on cycles that do not pass through the start record', () => {
+    test('A→B→C→D→C cycle terminates instead of recursing forever', { timeout: 15000 }, async () => {
+        const Node = Entity.create({
+            name: 'Node',
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        })
+        const Edge = Relation.create({
+            source: Node, sourceProperty: 'next', target: Node, targetProperty: 'prev', type: 'n:n'
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([Node], [Edge], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+
+        const a = await handle.create('Node', { name: 'A' })
+        const b = await handle.create('Node', { name: 'B' })
+        const c = await handle.create('Node', { name: 'C' })
+        const d = await handle.create('Node', { name: 'D' })
+        await handle.addRelationById('Node', 'next', a.id, b.id)
+        await handle.addRelationById('Node', 'next', b.id, c.id)
+        await handle.addRelationById('Node', 'next', c.id, d.id)
+        await handle.addRelationById('Node', 'next', d.id, c.id)
+
+        // 保险丝：环检测失效时通过 exit 停住递归让断言失败，而不是让测试进程挂死
+        let exitCalls = 0
+        const exit = async (_context: RecursiveContext) => (++exitCalls) > 50
+
+        const found = await handle.find('Node',
+            MatchExp.atom({ key: 'name', value: ['=', 'A'] }),
+            undefined,
+            ['*', ['next', { label: 'walk', attributeQuery: ['*', ['next', { goto: 'walk', exit }]] }]]
+        )
+        expect(exitCalls).toBeLessThan(50)
+        expect(found[0].next[0].name).toBe('B')
+        await db.close()
+    })
+
+    test('cycle back to the start record still terminates (original behavior preserved)', async () => {
+        const Node = Entity.create({
+            name: 'Node2',
+            properties: [Property.create({ name: 'name', type: 'string' })]
+        })
+        const Edge = Relation.create({
+            source: Node, sourceProperty: 'next', target: Node, targetProperty: 'prev', type: 'n:n'
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([Node], [Edge], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+        const a = await handle.create('Node2', { name: 'A' })
+        const b = await handle.create('Node2', { name: 'B' })
+        await handle.addRelationById('Node2', 'next', a.id, b.id)
+        await handle.addRelationById('Node2', 'next', b.id, a.id)
+        const exit = async (_context: RecursiveContext) => false
+        const found = await handle.find('Node2',
+            MatchExp.atom({ key: 'name', value: ['=', 'A'] }),
+            undefined,
+            ['*', ['next', { label: 'walk2', attributeQuery: ['*', ['next', { goto: 'walk2', exit }]] }]]
+        )
+        expect(found[0].next[0].name).toBe('B')
+        await db.close()
+    })
+})
+
+describe('r9 F-4: merged discriminator column __type cannot be written through the public API', () => {
+    function createMergedModel() {
+        const Customer = Entity.create({
+            name: 'Customer',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'level', type: 'string' })
+            ]
+        })
+        const Vendor = Entity.create({
+            name: 'Vendor',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'rating', type: 'number' })
+            ]
+        })
+        const Contact = Entity.create({ name: 'Contact', inputEntities: [Customer, Vendor] })
+        return { Customer, Vendor, Contact }
+    }
+
+    test('create/update with explicit __type is rejected; normal creation keeps working', async () => {
+        const { Customer, Vendor, Contact } = createMergedModel()
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([Customer, Vendor, Contact], [], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+
+        await expect(handle.create('Customer', { name: 'x', level: 'gold', __type: 'Vendor' }))
+            .rejects.toThrowError(/'__type' is the discriminator column of merged record 'Contact'/)
+
+        const c = await handle.create('Customer', { name: 'y', level: 'silver' })
+        await expect(handle.update('Customer', MatchExp.atom({ key: 'id', value: ['=', c.id] }), { __type: 'Vendor' }))
+            .rejects.toThrowError(/'__type' is the discriminator column/)
+
+        // 正常创建路径不受影响，判别列由框架按创建名写入
+        const customers = await handle.find('Customer', undefined, undefined, ['*'])
+        expect(customers).toHaveLength(1)
+        expect(customers[0].__type).toBe('Customer')
+        const vendors = await handle.find('Vendor', undefined, undefined, ['*'])
+        expect(vendors).toHaveLength(0)
+        await db.close()
+    })
+
+    test('nested related payload carrying __type is also rejected', async () => {
+        const { Customer, Vendor, Contact } = createMergedModel()
+        const Order = Entity.create({
+            name: 'Order',
+            properties: [Property.create({ name: 'no', type: 'string' })]
+        })
+        const OrderContact = Relation.create({
+            source: Order, sourceProperty: 'contact', target: Contact, targetProperty: 'orders', type: 'n:1'
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([Customer, Vendor, Contact, Order], [OrderContact], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+
+        const customer = await handle.create('Customer', { name: 'c', level: 'gold' })
+        await expect(handle.create('Order', { no: '1', contact: { id: customer.id, __type: 'Vendor' } }))
+            .rejects.toThrowError(/'__type' is the discriminator column/)
+        await db.close()
+    })
+
+    test('a plain entity property named __type on a non-merged entity is unaffected', async () => {
+        // 非 merged 家族没有判别列，用户自定义 __type 属性（不推荐但合法）不受写保护影响
+        const Legacy = Entity.create({
+            name: 'Legacy',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: '__type', type: 'string' })
+            ]
+        })
+        const db = new PGLiteDB()
+        await db.open()
+        const setup = new DBSetup([Legacy], [], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map), db)
+        const r = await handle.create('Legacy', { name: 'l', __type: 'custom' })
+        const read = await handle.findOne('Legacy', MatchExp.atom({ key: 'id', value: ['=', r.id] }), undefined, ['*'])
+        expect(read.__type).toBe('custom')
+        await db.close()
+    })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

第九轮全代码库深度 review（报告：`agentspace/output/deep-review-2026-07-09-r9.md`）。四路并行探查 + 与 r1–r8 报告逐条去重 + 对每个致命候选编写最小复现测试实际运行（PGLiteDB）。本轮 4 个致命 + 2 个重要问题全部复现确认并修复；3 个候选被复现/代码证伪并记录在案。

本轮致命项中有三个属于同一族：**共享命名空间里的静默覆盖/静默丢弃**。修复方向统一：按显式控制原则 setup 期 / 写入口 fail-fast。

## 致命（已复现，已修）

- **F-1 filtered entity/relation 自有属性被 setup 静默丢弃**：`Entity.create({baseEntity, matchExpression, properties:[...]})` 声明合法、建表成功，但列不建、写入被悄悄忽略、挂在其上的 computation 只维护 bound state 而可见值永远不落库（三层静默数据丢失）。现在 `DBSetup.validateFilteredItemProperties` 在 setup 期拒绝 base 链上不存在的新属性并指引到 base；与 base 同名的再声明保持合法（merged 编译管线依赖）。
- **F-2 同一 base 家族多个 relation 声明同名属性静默互相覆盖**：两个 relation 共用 `User.items` 时后注册者赢得属性名，先注册的 relation 从此不可达（查询走错关系、级联漏删）。r8 的家族校验只拦含 filtered declarer 的情况，现在无条件 fail-fast（对称自引用单 relation 不受影响）。测试装置 `leaveRequest.ts` 自己编码了该反模式，已一并修正。
- **F-3 label/goto 递归对不经过起点的环无限递归**：环检测只比较栈首==栈尾，数据 `A→B→C→D→C` 时查询挂死。现在检测递归路径上任意位置的重复记录。
- **F-4 merged `__type` 判别列可被 create/update 载荷覆写**：`create('Customer', {__type:'Vendor'})` 把记录静默错标到其他 input 视图（跨视图可见性错乱 + 特有列交叉污染）。现在 `EntityQueryHandle` 全部公共写入口递归校验载荷（含嵌套关联与 `&` link 数据）并 fail-fast；非 merged 家族的用户自定义 `__type` 属性不受影响。

## 重要（已复现，已修）

- **R-1 跨 Activity activityId**：`getActivity` 不校验记录归属，跨流程传 activityId 抛裸 TypeError；两个 Activity 共用同一 Interaction 实例时更会把状态推进/isRef 授权错绑到别的流程。现在校验 activity 定义 uuid 并给出指明两个流程名的业务级错误。
- **K-1 知识库 Custom 增量示例教错误模式**：示例直接从 `mutationEvent.record` 读字段，而 update 事件的 record 只带变更字段（+id）——照抄示例的下游代码聚合静默漂移（实测 update 单字段后 dict 停在 0，真值 10）。修正示例（`{...oldRecord, ...record}` 重建全量新状态）并在 `generator/api-reference.md` 与 `usage/14-api-reference.md` 补「Mutation event snapshots」契约小节。

## 测试

- 新增 `tests/storage/review-fixes-2026-07-09-r9.spec.ts`（10 用例）+ `tests/runtime/review-fixes-2026-07-09-r9.spec.ts`（2 用例）
- ✅ `npm run check`
- ✅ `npm test` 全量 **1780 passed / 26 skipped**（基线 1768，净 +12）

## 未修但已记录（报告第四节）

filtered 端点 relation 的 property 聚合语义空洞（r8/r9 fail-fast 封死静默错值后该合法声明组合暂无可用路径，建议下轮补全）、migration rename 契约、dispatch 时序文档化、守卫 truthy 返回值收紧、batch 1:n 防御性 assert。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ea80458-c17d-45c1-9cc7-758221903e6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ea80458-c17d-45c1-9cc7-758221903e6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

