### PR TITLE
fix: tenth-round deep review — fail-fast for silent-failure paths (empty group deadlock, merged cross-input pollution, unknown-key drop, json match)

### DIFF
--- a/agent/agentspace/knowledge/usage/13-testing.md
+++ b/agent/agentspace/knowledge/usage/13-testing.md
@@ -26,7 +26,8 @@ storage.create('Entity', data)                       // ✅ Create record
 
 ```typescript
 import { describe, test, expect, beforeEach } from 'vitest'
-import { Controller, MonoSystem, KlassByName, PGLiteDB, MatchExp } from 'interaqt'
+import { Controller, MonoSystem, KlassByName, MatchExp } from 'interaqt'
+import { PGLiteDB } from 'interaqt/drivers'
 import { entities, relations, interactions, activities } from '../backend'
 // If you need UUID, install and import it:
 // npm install uuid @types/uuid
@@ -675,7 +676,8 @@ Permission testing is an important component of interaqt application testing, re
 
 ```typescript
 import { describe, test, expect, beforeEach } from 'vitest';
-import { Controller, MonoSystem, KlassByName, PGLiteDB } from 'interaqt';
+import { Controller, MonoSystem, KlassByName } from 'interaqt';
+import { PGLiteDB } from 'interaqt/drivers';
 
 describe('Permission Testing', () => {
   let system: MonoSystem;

--- a/agent/agentspace/knowledge/usage/18-api-exports-reference.md
+++ b/agent/agentspace/knowledge/usage/18-api-exports-reference.md
@@ -69,16 +69,18 @@ import {
   // Special Entities
   InteractionEventEntity,  // NOT InteractionEvent
   
-  // Database Drivers
-  PGLiteDB,
-  SQLiteDB,
-  PostgreSQLDB,
-  MysqlDB,
-  
   // Class Reference
   KlassByName
   
 } from 'interaqt';
+
+// Database drivers are a separate subpath entry (NOT exported from the main package):
+import {
+  PGLiteDB,
+  SQLiteDB,
+  PostgreSQLDB,
+  MysqlDB,
+} from 'interaqt/drivers';
 ```
 
 ## What is NOT Exported
@@ -167,9 +169,9 @@ import {
 import { 
   Controller, 
   MonoSystem, 
-  PGLiteDB,
   KlassByName 
 } from 'interaqt';
+import { PGLiteDB } from 'interaqt/drivers';
 
 const system = new MonoSystem(new PGLiteDB());
 system.conceptClass = KlassByName;
@@ -202,7 +204,7 @@ const controller = new Controller({
 
 4. **Filtered Entities**: Created using `Entity.create()` with `baseEntity` and `filterCondition`, not a separate import.
 
-5. **Database Drivers**: Choose one based on your needs - PGLiteDB for in-memory testing, PostgreSQLDB for production, etc. `ScopedSequence` is production-safe for cross-connection/cross-process allocation on PostgreSQL; PGLiteDB and SQLiteDB are local/test-level only for scoped sequence concurrency.
+5. **Database Drivers**: Imported from the `interaqt/drivers` subpath (not the main package). Choose one based on your needs - PGLiteDB for in-memory testing, PostgreSQLDB for production, etc. `ScopedSequence` is production-safe for cross-connection/cross-process allocation on PostgreSQL; PGLiteDB and SQLiteDB are local/test-level only for scoped sequence concurrency.
 
 6. **Transaction helpers**: `runWithTransactionRetry`, `isRetryableTransactionError`, and `isRequireSerializableRetry` are exported for advanced runtime integrations and tests. Most application code should use `Controller.dispatch()` or `system.storage.runInTransaction()` instead of calling retry helpers directly.
 

--- a/agentspace/output/deep-review-2026-07-09-r10.md
+++ b/agentspace/output/deep-review-2026-07-09-r10.md
@@ -1,0 +1,174 @@
+# 全代码库深度 Review 报告（2026-07-09 第十轮）
+
+- 日期：2026-07-09
+- 基线：`main` @ `9eabcab6`（v2.0.1，r1–r9 的致命/重要修复全部落地）
+- 范围：四路并行深度探查历史盲区——storage 写路径冷区与 r9 守卫的绕过面 / runtime 调度与 aggregationTemplate / builtins 执行链与 core 声明校验 / drivers 与 migration 纵深、打包导出面
+- 方法：与 r1–r9 报告**逐条去重**（四路探查候选中约三分之一为既有遗留项的重复发现，已剔除）→ 对每个致命/重要候选**编写最小复现测试实际运行**（PGLiteDB）。只有「已运行复现确认」的问题列为致命/重要；复现失败或代码证伪的候选明确记录（见第五节）。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1780 passed / 26 skipped。
+
+> **维护说明（2026-07-09）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r10-f03a`）全部修复。回归测试：`tests/storage/review-fixes-2026-07-09-r10.spec.ts`（8 用例）+ `tests/runtime/review-fixes-2026-07-09-r10.spec.ts`（7 用例）。修复后 `npm run check` 通过；`npm test` 全量 **1795 passed / 26 skipped**。顺带修正 7 处被新 fail-fast 暴露的既有测试反模式（详见 F-2 的「测试矩阵连带修正」）。
+
+---
+
+## 一、结论摘要
+
+经九轮修复，读写主路径、聚合增量、对称关系、filtered/merged 编译、Activity 状态机、migration 均已高度收敛。本轮的新致命项延续既往规律，且进一步向两类收缩：
+
+1. **共享命名空间里的静默丢弃/污染**（r9 主题的直接延续）——merged input 视图共享物理表属性命名空间导致的跨视图列污染，以及所有写入口对未声明键的静默丢弃（r9 报告第七节明确预告的「下一个模板化目标」，本轮落地）。
+2. **声明合法、永不可用的死路径**——空 ActivityGroup（声明期零告警 → 运行期永久死锁）、json 字段等值匹配（写路径序列化 / 读路径不序列化的不对称）。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修） | 3 | 空 ActivityGroup 死锁、merged 跨 input 属性污染 + 未知键静默丢弃、json 字段 =/!= 匹配断裂 |
+| 重要（已复现，已修） | 6 + 文档 1 | 见第三节 |
+| 证伪 | 4 | 见第五节 |
+| 重要（精读/探查，高置信度，未修） | 9 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认，本轮已修复）
+
+### F-1 `activities: []` 的空 ActivityGroup：进入即永久死锁，声明期零告警
+
+- 位置：`src/builtins/interaction/activity/ActivityCall.ts` `buildGraph`（原先不校验 group 子分支数）；`InteractionState.createInitialState` 对空 childSeqs 生成 `children: []`；`Every/Any/Race` 的完成语义全部由子分支 `transferToNext → parent.onChange` 触发。
+- 复现（实测输出）：`start → emptyGroup(type:'every') → end`，dispatch start 成功进入 group 后：
+
+```
+dispatch end → Error: interaction id_29 not available   ❌ 永久不可达（无任何子分支能触发 onChange）
+```
+
+- 影响：与 r4 F-1（group 作起点栈溢出）、r7 F-5（`program` 类型无完成语义）同族——「类型系统接受但运行时死锁」的 Activity 图形态。`isGroupCompleted()` 对空集 vacuous true，但没有任何入口会调用它，activity 卡死且无任何错误。
+- 修复：`buildGraph` 对 `!group.activities?.length` 声明期抛出「empty group can never complete, the activity would deadlock」。
+
+### F-2 merged input 视图的跨 input 属性写入静默污染 + 全写入口未知键静默丢弃
+
+两个问题同根（`groupAttributes` 只挑 map 认识的键、其余静默忽略；merged 编译把全部 input 属性合并进物理 base 的共享 attributes 表），一并修复。
+
+- 位置：`src/storage/erstorage/MergedItemProcessor.ts` `mergeProperties`（全部 input 属性并入物理 base）；`EntityToTableMap.groupAttributes`（未知键静默跳过）；`EntityQueryHandle` 各写入口（此前仅有 r9 的 `__type` 判别列校验）。
+- 复现（实测输出）：
+
+```
+// vendorCode 仅声明在 Vendor input 上：
+create('Customer', { name:'c', level:'g', vendorCode:'SHOULD-NOT-BE-HERE' })
+→ 静默落库，Customer 视图读回携带 vendorCode          ❌ 跨视图列污染
+
+// 拼写错误：
+create('User', { nmae: 'Alice' }) → 无报错，读回只有 id  ❌ 零告警数据丢失
+```
+
+- 影响：前者是 r9 F-2/F-4「共享命名空间静默覆盖」家族的最后一个成员——input 视图声明面之外的列被静默写入，Vendor 视图的列被 Customer 名义的写入污染；后者是 r7 I-13（Klass 工厂未知参数静默丢弃）的 storage 版，r9 报告第七节已明确列为「下一个模板化目标」。
+- 修复（一个统一的写入口校验 `EntityQueryHandle.validateWritePayload`，吸收 r9 的判别列校验）：
+  1. 未知键（不在 record attributes 表内）一律 fail-fast，错误信息附声明面清单；
+  2. merged input 视图按「声明面」裁剪：`MergedItemProcessor` 在 rebase 前沿 base 链收集各 input 名下可写属性集合（含 commonProperties 同名再声明与 bound-state 注入列）→ `DBSetup` 写入 `RecordMapItem.writablePropertyNames` → 写入口对 value 属性校验归属；
+  3. **携带 id 的嵌套 ref 载荷豁免**未知键/归属检查（ref 的语义是「按 id 建立关系」，快照残留字段被写路径显式忽略；把 `event.user` 等完整记录对象直接用作关系端点是既有合法形态）；`_rowId` 出现在框架返回的记录上，round-trip 回写保持合法。判别列检查对 ref 同样生效。
+- 测试矩阵连带修正（新 fail-fast 暴露的既有反模式，7 处）：`activity.spec` 写未声明的 `roles`（guard 检查的是内存 user 对象，改为内存补齐）；`every.spec` 写错属性名 `everyRequestHandled`（实为 `everyRequestHasTwoItems`，**真实拼写错误**，此前静默丢弃侥幸通过）；`transformInteraction.spec` 写未声明的 `age`；`symmetricRelation.spec` 写未声明的关系属性 `level`；`longColumnNames.spec` 把关系属性内联在 ref 对象上（正确形态是 `'&'`，此前被静默丢弃且测试从未断言其持久化）；`versionControlHardDeleteExample2.spec` 两处 Transform 回调用 `{...style}` 展开把源实体的 `_isDeleted_` / bound-state 列带进目标实体载荷（改为显式拷贝声明面）。
+
+### F-3 json/collection 字段的 `=` / `!=` 匹配：写路径序列化、读路径不序列化——PG 系裸数据库错误，文本型存储恒零命中
+
+- 位置：`src/storage/erstorage/MatchExp.ts` `getFinalFieldValue` simpleOp 分支（参数原样绑定）；对照 `SQLBuilder.prepareFieldValue`（INSERT/UPDATE 一律 `JSON.stringify`）；各驱动 `parseMatchExpression` 只处理 `contains`。
+- 复现（实测输出）：
+
+```
+Property.create({ name:'tags', type:'string', collection:true })
+create('Doc', { tags:['x','y'] })
+find('Doc', MatchExp.atom({ key:'tags', value:['=', ['x','y']] }))
+→ PGLite: error: operator does not exist: json = unknown   ❌ 裸数据库错误
+→ SQLite: （参数为 JS 数组，文本比较恒不等）零命中          ❌ 静默错误结果
+```
+
+- 影响：json 列的全链路是「写 stringify / 读 parse / 匹配裸绑定」，三方不对齐。`contains` 之外的等值匹配（如按 tag 集合精确查、按 object 字段快照查）完全不可用，且 SQLite/MySQL 上是静默零命中而非报错。
+- 修复：`MatchExp` 对 json 字段的 `=`/`!=` 先给驱动方言机会、否则退化为与写路径一致的序列化文本比较；PG/PGLite `parseMatchExpression` 新增 `::jsonb` 语义相等比较（键序不敏感），MySQL 新增 `CAST(? AS JSON)`。NULL 行不参与 `=`/`!=` 匹配，与标量列语义一致。PGLite 与 SQLite 双驱动回归用例。
+
+---
+
+## 三、重要问题（已复现，本轮已修复）
+
+### R-1 StateMachine `computeTarget` 端点形态缺 id：静默 skip，转移无声失效
+
+- 位置：`src/runtime/computations/StateMachine.ts` `normalizeComputeTargetResult` L107–109——端点双重循环里 `if (!source?.id || !target?.id) continue`，与同函数「无法识别形态一律 fail-fast」的注释和 L119 的 `ComputationProtocolError` 直接矛盾。
+- 复现：relation 宿主 property StateMachine，`computeTarget` 返回 `{source:{}, target:{id}}` → 实测 flag 永远停在 `idle`，零报错。
+- 修复：端点形态中缺 id 一律抛 `ComputationProtocolError`（消息指明缺的是 source 还是 target，并说明「显式 skip 请整体返回 undefined」）；正确端点形态的转移有正向回归用例。
+
+### R-2 `Conditions.create({})` / `Attributives.create({})` 挂上守卫链：每次 dispatch 抛 BoolExp 内部错误
+
+- 位置：`src/builtins/interaction/Interaction.ts` `checkCondition`（`new BoolExp(content)`）/ `checkUser`（`BoolExp.fromValue(content!)`）；`Conditions/Attributives` 的 `content` 声明为 optional。
+- 复现：`dispatch → Error: BoolExp raw data cannot be undefined`（fail-closed 但与声明处完全脱节）。
+- 修复：`Interaction.create` 声明期校验 conditions/userAttributives 容器必须有 content；`checkConceptAttributive`（payload 概念检查路径）对空 content 返回业务级错误信息。`Conditions.create({})` 本身保持合法（序列化 round-trip 测试在用），只在挂上守卫链时拒绝。
+
+### R-3 `Relation.create` 不校验 `type`：畸形值静默流入 `relType.split(':')`
+
+- 复现：`type:'bogus'` → setup 成功、create 成功，基数语义完全未定义（实测按某种默认行为建了表）。
+- 修复：`type` 白名单 `'1:1' | '1:n' | 'n:1' | 'n:n'`（filtered/merged relation 的 type 继承自 base/inputs，不受影响）。
+
+### R-4 filtered entity/relation 声明 `baseEntity/baseRelation` 但无 `matchExpression`：裸 TypeError
+
+- 复现：`Entity.create({ name:'AllUsers', baseEntity: User })` → setup/查询抛 `Cannot read properties of undefined (reading 'and')`。
+- 修复：声明期 fail-fast（`Entity.create` / `Relation` 构造器 filtered 分支）。内部管线（merged rebase、transformMergedItem）全部携带 matchExpression 或在 create 后赋值，不受影响。
+
+### R-5 match/attributeQuery 路径越过值属性继续深入：裸 TypeError
+
+- 位置：`src/storage/erstorage/EntityToTableMap.ts` `computeInfoByPath`——值属性使 `currentEntity=''`，下一段对 `records['']`（undefined）取 `attributes` 直接 TypeError。
+- 复现：`MatchExp.atom({ key:'owner.name.extra', ... })` → `Cannot read properties of undefined (reading 'attributes')`。
+- 修复：给出指明路径与违规段的明确错误（`"name" is a value attribute and cannot be traversed further`）。
+
+### R-6 同一 source 的多条 Transfer：后写静默覆盖先写
+
+- 位置：`ActivityCall.buildGraph`——每个节点单 `next` 指针，`sourceNode.next = targetNode` 无重复检测；部分双出边图形（如 A→B、A→C、B→D、C→D）能通过 start/end 唯一性校验，构建出与声明不一致的图。
+- 修复：重复出边声明期抛错，指引用 ActivityGroup 建模分支。
+
+### K-1 知识库：驱动导入路径教错（npm 消费者照抄即失败）
+
+- 位置：`agent/agentspace/knowledge/usage/18-api-exports-reference.md`（把 `PGLiteDB` 等列在主包 import 清单里）、`usage/13-testing.md` 两处测试模板。
+- 事实：r4 F-3 把驱动拆到 `interaqt/drivers` 子入口后主包不再导出驱动（`src/index.ts` 实测无驱动导出），文档未同步——这些文件是代码生成管线的模板，与 r5 R-7 / r9 K-1 同性质的管线级污染。
+- 修复：三处改为 `import { PGLiteDB } from 'interaqt/drivers'` 并在「Database Drivers」注记子路径。顺带修正 `Scheduler.ts` 错误消息拼写（"shuold not has" → "should not have"）。
+
+---
+
+## 四、重要问题（探查/精读判定，高置信度，本轮未修）
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | 迁移阶段顺序：`recomputeFilteredMemberships` 先于 computation 重算，谓词依赖「本轮将重算的 computed 列」时基于旧值/NULL 产出错误成员资格事件 | `migration.ts` L3346–3404、`Controller.ts` L480–485 | 需要「谓词变更 + 同批 computation 变更」组合触发；建议成员资格 diff 延后到依赖列重算之后，或对该组合 fail-fast 要求分两次迁移 |
+| I-2 | merged 家族**移除 input**：物理表/判别列不变、无 blocking，存量 `__type='X'` 行成为声明式 API 不可达的孤儿数据 | `migration.ts` `getStorageBlockingChanges`（无 merged/input 专项） | 与 r9 F-4 正交（写侧已堵、声明收缩侧未审阅）；需要产品决策（blocking + 显式数据处置 or 文档化） |
+| I-3 | MySQL legacy `__interaqt_migration_log` 升级：`ADD COLUMN IF NOT EXISTS` 为 PG 语法，MySQL 上 ALTER 失败被空 catch 吞掉，后续 `beginMigration` 在远离根因处硬错 | `MonoSystem.ts` L1311–1328 | 按驱动分支或探测列存在性 |
+| I-4 | PGLite 与 PostgreSQL 的 entity `id` 策略根本不同（UUID+uuidv7 vs INT+sequence），同一模型无跨驱动迁移路径且未文档化 | `PGLite.ts` L10–12 / `PostgreSQL.ts` L83–94 | manifest 的 fieldType 差异会 blocking（fail-closed），但「测试 PGLite / 生产 PG」是被知识库推荐的组合，语义鸿沟应显式文档化 |
+| I-5 | Global StateMachine 的 `initialState.computeValue` 在 setup 期收到 `event=undefined`，与 property 路径（传入 create record）不对称、契约未声明 | `StateMachine.ts` `getInitialValue` / `Scheduler.ts` `setupGlobalComputationDefaultValue` | 文档化或对齐 |
+| I-6 | global dict 扇出合成事件 `oldRecord` 仅顶层浅拷贝，嵌套对象与 `record` 共享引用——用户 incremental 回调 in-place 修改会反向污染 | `Scheduler.ts` L527–536 | 已知「顶层同引用」问题（r7 I-7）的嵌套版；深拷贝或文档化「事件快照只读」契约 |
+| I-7 | property 级聚合（targetPath 非空）不经过 `resolveFilteredUpdateEvent` 同批去重守卫，filtered relation 端点的成员资格+字段更新同批时口径弱于 global 路径 | `Scheduler.ts` L433–441 / `aggregationTemplate.ts` L358–448 | 多数路径有 findOne 失败→fullRecompute 兜底；守卫对称化 |
+| I-8 | group-head Activity 多个分支 head 都不带 activityId dispatch：各自 `create()` 出独立 activity 实例，流程状态分裂 | `ActivityManager.ts` L105–111 / `ActivityCall.isActivityHead` | r4 测试已固化「第二个 head 必须传 activityId」的用法，但不阻止误用；建议 head 集合中第一个之外的裸 dispatch 给出警告性错误或文档化 |
+| I-9 | 以 merged **union 名**（如 `Contact`）update 携带 input 特有属性仍不受 F-2 归属校验（union 名可匹配到任意 input 的行） | `EntityQueryHandle.validateWritePayload`（writablePropertyNames 只登记在 input 视图名上） | union 名的合法写入面是 commonProperties；收紧需评估「按 id 跨类型更新公共字段」的既有用法，本轮保守未动 |
+
+## 五、本轮证伪的候选
+
+| 候选 | 证伪依据 |
+|------|----------|
+| 「merged base 与 1:1 伙伴合表时部分删除把 `__type` 置 NULL = 判别列腐蚀」（storage 探查 C-1） | 实测：`delete('Customer')` 后 Customer/Vendor/Contact 视图均查不到该行、Extension 伙伴数据完整保留——`__type IS NULL` 恰是「merged 实体已删、伙伴列保留」的正确表达，无腐蚀 |
+| 「`interaqt/drivers` 的 types 路径与构建产物不一致」（drivers 探查 I-1） | 实测 `npm run build`：vite-plugin-dts `rollupTypes:false` 按源码结构产出 `dist/drivers/index.d.ts`（与 `package.json` exports 一致），同时 `insertTypesEntry` 产出 `dist/drivers.d.ts`，双路径均存在 |
+| 「filtered base 指向 merged entity 应声明期拒绝」（builtins 探查 I-3） | 这是有意设计：`SeniorStaff`（filtered over merged）作为**查询视图**完全合法（现有测试断言其可查询），仅 create 因无法确定具体 `__type` 被拒（r9 已有明确错误）。声明期全面拒绝会误伤合法查询视图 |
+| 「`defaultValue` + `computation` 并存静默接受」（builtins 探查 I-4） | 实测 setup 期已有 fail-fast（`Scheduler.ts` L339 assert），消息明确指向宿主与属性名；仅拼写错误，已顺带修正 |
+
+## 六、既有遗留项复确（r2–r9 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4 I-1）；`!=` 三值逻辑；dispatch 先持久化事件再 resolve 的时序（r9 I-2）；Condition/Attributive 非 boolean truthy 放行（r9 I-4）；payload 弱校验族 / `userRef` / `itemRef` 死 API（r7）；StateMachine 单事件单跳 / 宿主 delete-trigger 静默 skip（r7）；Transform 身份 =（sourceRecordId, transformIndex）二元组的重排语义（契约限制）。
+- **性能/资源**：global dict 变更宿主全表扫描；async task 表只增不减；级联无深度上限；迁移锁无租约；property 聚合 relatedAttribute>3 一律 fullRecompute。
+- **并发**：activity `refs` 无版本 read-modify-write（r5 I-12/r10 复确，stateVersion CAS 不覆盖 refs）。
+- **migration**：rename = remove+add（r9 I-3）；dictionary defaultValue 不进 modelHash（r4 R-7）。
+- **filtered/merged 功能空洞**：base 宿主 property 聚合无法引用 filtered 变体端点 relation（r9 I-1）。
+
+## 七、修复优先级建议（遗留项）
+
+1. **I-1 迁移阶段顺序**——唯一可能产出「静默错误聚合值」的未修项，虽然触发组合窄，但一旦命中无自愈路径；
+2. **I-2 merged input 移除的孤儿数据**——与 I-1 同属「声明演化 × merged/filtered」象限，r8–r10 三轮证明这个象限是致命问题的持续产地；
+3. I-8 多 head 裸 dispatch 分裂 + I-9 union 名写入面——Activity/merged 的「误用防护」收尾（改动小）；
+4. I-5/I-6 事件与初值契约文档化（与 r9 K-1 的「Mutation event snapshots」小节合并扩展）。
+
+## 附录：复现要点（验证用）
+
+- F-1：`ActivityGroup.create({type:'every', activities: []})` 入图 → `new ActivityManager` 应抛 deadlock 错误。
+- F-2：merged input 名下写兄弟 input 特有属性 / 任意名下写拼写错误键 → 应抛归属/未知键错误；`{...snapshot}` ref 载荷与 `_rowId` round-trip 应通过。
+- F-3：collection 属性 `['=', ['x','y']]` 匹配 → PGLite/SQLite 均应正确命中；`!=` 不含 NULL 行。
+- R-1：`computeTarget` 返回 `{source:{}, target:{id}}` → 应抛 `endpoint form whose source has no id`。
+- R-2：`Interaction.create({conditions: Conditions.create({})})` → 应抛声明期错误。
+- R-4：`Entity.create({baseEntity})` 无 matchExpression → 应抛声明期错误。
+- R-5：`key:'owner.name.extra'` → 应抛 value-attribute 路径错误。
+- R-6：同 source 两条 Transfer → 应抛 multiple transfers 错误。

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -147,6 +147,16 @@ export class Interaction implements InteractionInstance {
   };
   
   static create(args: InteractionCreateArgs, options?: { uuid?: string }): InteractionInstance {
+    // fail-fast：挂在守卫链上的容器必须可执行。content 为空的 Conditions/Attributives
+    //  会在每次 dispatch 时深入到 BoolExp 构造器才抛出与用户写法无关的内部错误
+    //  （"BoolExp raw data cannot be undefined"），必须在声明期给出业务级错误。
+    if (Conditions.is(args.conditions) && !args.conditions.content) {
+      throw new Error(`Interaction "${args.name}" declares conditions with a Conditions instance that has no content. Provide content (a Condition BoolExp), or omit the conditions field.`);
+    }
+    if (Attributives.is(args.userAttributives) && !args.userAttributives.content) {
+      throw new Error(`Interaction "${args.name}" declares userAttributives with an Attributives instance that has no content. Provide content (an Attributive BoolExp), or omit the userAttributives field.`);
+    }
+
     const instance = new Interaction(args, options);
     
     const existing = this.instances.find(i => i.uuid === instance.uuid);
@@ -482,6 +492,11 @@ export async function checkPayload(controller: GuardController, interaction: Int
 // attached to a concept against a payload item.
 async function checkConceptAttributive(controller: GuardController, attributive: unknown, eventArgs: InteractionEventArgs, target: unknown): Promise<boolean | string> {
   if (Attributives.is(attributive)) {
+    // fail-closed：content 为空的 Attributives 无法求值。给出业务级错误，
+    //  而不是让 BoolExp 构造器抛出与声明处无关的内部错误。
+    if (!(attributive as AttributivesInstance).content) {
+      return `Attributives instance has no content to evaluate — declare content (an Attributive BoolExp) or remove the attributives declaration`;
+    }
     const combined = BoolExp.fromValue<AttributiveInstance>((attributive as AttributivesInstance).content! as ExpressionData<AttributiveInstance>);
     const result = await combined.evaluateAsync((atom: AttributiveInstance) => checkAttributive(controller, atom, eventArgs, target));
     return result === true ? true : 'attributives check failed';

--- a/src/builtins/interaction/activity/ActivityCall.ts
+++ b/src/builtins/interaction/activity/ActivityCall.ts
@@ -228,6 +228,13 @@ export class ActivityCall {
                 const supported = Array.from(InteractionState.GroupStateNodeType.keys()).map(t => `'${t}'`).join(', ')
                 throw new Error(`ActivityGroup type "${group.type}" in activity "${activity.name}" is not supported. Supported types: ${supported}.`)
             }
+            // fail-fast: a group with no child activities can never complete (group state
+            // only advances via child-branch onChange callbacks, and an empty group has no
+            // branches to trigger them), so any transfer out of the group is permanently
+            // unreachable — the activity deadlocks silently at runtime.
+            if (!group.activities?.length) {
+                throw new Error(`ActivityGroup (type '${group.type}') in activity "${activity.name}" has no child activities. An empty group can never complete, so the activity would deadlock — declare at least one child activity or remove the group.`)
+            }
             const node: ActivityGroupNode = {
                 uuid: group.uuid,
                 content: group,
@@ -249,6 +256,12 @@ export class ActivityCall {
 
             assert(!!sourceNode, `cannot find source ${(transfer.source as InteractionInstance).name!}`)
             assert(!!targetNode, `cannot find target ${(transfer.target as InteractionInstance).name!}`)
+            // fail-fast: each node holds a single `next` pointer, so a second transfer from
+            // the same source would silently overwrite the first one — the built graph would
+            // no longer match the declaration. Branching must be modeled with ActivityGroup.
+            if (sourceNode.next) {
+                throw new Error(`Activity "${activity.name}" declares multiple transfers from the same source "${(transfer.source as InteractionInstance).name}". Each node can have only one outgoing transfer; model branching with ActivityGroup (type 'any'/'every'/'race') instead.`)
+            }
             sourceNode.next = targetNode
             targetNode.prev = sourceNode
 

--- a/src/core/Entity.ts
+++ b/src/core/Entity.ts
@@ -135,6 +135,11 @@ export class Entity implements EntityInstance {
     if (typeof args.name !== 'string' || !validNameFormatExp.test(args.name)) {
       throw new Error(`Entity name "${args.name}" is invalid. Entity names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
     }
+    // filtered entity 是 base 上的谓词视图：没有 matchExpression 的"视图"没有任何语义
+    // （查询重写拿不到谓词，setup/查询在深处抛裸 TypeError），必须在声明期 fail-fast。
+    if (args.baseEntity && !args.matchExpression) {
+      throw new Error(`Filtered entity "${args.name}" declares baseEntity but no matchExpression. A filtered entity is a predicate view over its base — declare matchExpression, or use the base entity directly.`);
+    }
 
     const instance = new Entity(args, options);
     

--- a/src/core/Relation.ts
+++ b/src/core/Relation.ts
@@ -6,6 +6,7 @@ import type { ComputationInstance } from './types.js';
 import type { ConstraintInstance } from './Constraint.js';
 
 const validNameFormatExp = /^[a-zA-Z0-9_]+$/;
+const VALID_RELATION_TYPES = ['1:1', '1:n', 'n:1', 'n:n'];
 
 export interface RelationInstance extends IInstance {
   name?: string;
@@ -127,6 +128,11 @@ export class Relation implements RelationInstance {
       // Filtered relation must have sourceProperty and targetProperty
       if (!args.sourceProperty || !args.targetProperty) {
         throw new Error('Filtered relation must have sourceProperty and targetProperty');
+      }
+      // filtered relation 是 base 上的谓词视图：没有 matchExpression 的"视图"没有任何语义
+      // （查询重写拿不到谓词，运行期在深处抛裸 TypeError），必须在声明期 fail-fast。
+      if (!args.matchExpression) {
+        throw new Error(`Filtered relation${args.name ? ` "${args.name}"` : ''} declares baseRelation but no matchExpression. A filtered relation is a predicate view over its base — declare matchExpression, or use the base relation directly.`);
       }
       
       this.baseRelation = args.baseRelation;
@@ -290,7 +296,12 @@ export class Relation implements RelationInstance {
     if (args.targetProperty !== undefined && !validNameFormatExp.test(args.targetProperty)) {
       throw new Error(`Relation targetProperty "${args.targetProperty}" is invalid. Property names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
     }
-
+    // type 直接决定存储布局（relType.split(':')）与基数语义，畸形值不会在任何后续阶段被检查，
+    // 会静默产出不可预测的表结构/查询行为，必须在声明期 fail-fast。
+    // filtered/merged relation 的 type 继承自 baseRelation/inputRelations，不允许显式传入矛盾值之外的校验负担。
+    if (args.type !== undefined && !VALID_RELATION_TYPES.includes(args.type)) {
+      throw new Error(`Relation type "${args.type}" is invalid. Valid types: ${VALID_RELATION_TYPES.map(t => `'${t}'`).join(', ')}.`);
+    }
     const instance = new Relation(args, options);
     
     // 检查 uuid 是否重复

--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -201,6 +201,15 @@ export class MysqlDB implements Database{
                     fieldParams: [JSON.stringify(value[1])]
                 }
             }
+            // JSON 列与字符串参数直接比较会按类型序比较（恒不等）。CAST 成 JSON 做语义相等比较。
+            // NULL 行不参与匹配，与标量列的 =/!= 语义一致。
+            if (value[0] === '=' || value[0] === '!=') {
+                const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                return {
+                    fieldValue: `IS NOT NULL AND ${fieldNameWithQuotes} ${value[0]} CAST(${p()} AS JSON)`,
+                    fieldParams: [JSON.stringify(value[1])]
+                }
+            }
         }
     }
 

--- a/src/drivers/PGLite.ts
+++ b/src/drivers/PGLite.ts
@@ -209,6 +209,15 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
                     fieldParams: [value[1]]
                 }
             }
+            // json 类型没有 = / != 操作符（"operator does not exist: json = unknown"），
+            // 转成 jsonb 做语义相等比较（对键序不敏感）。NULL 行不参与匹配，与标量列的 =/!= 语义一致。
+            if (value[0] === '=' || value[0] === '!=') {
+                const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                return {
+                    fieldValue: `IS NOT NULL AND ${fieldNameWithQuotes}::jsonb ${value[0]} ${p()}::jsonb`,
+                    fieldParams: [JSON.stringify(value[1])]
+                }
+            }
         }
     }
 

--- a/src/drivers/PostgreSQL.ts
+++ b/src/drivers/PostgreSQL.ts
@@ -352,6 +352,15 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
                     fieldParams: [value[1]]
                 }
             }
+            // json 类型没有 = / != 操作符（"operator does not exist: json = unknown"），
+            // 转成 jsonb 做语义相等比较（对键序不敏感）。NULL 行不参与匹配，与标量列的 =/!= 语义一致。
+            if (value[0] === '=' || value[0] === '!=') {
+                const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                return {
+                    fieldValue: `IS NOT NULL AND ${fieldNameWithQuotes}::jsonb ${value[0]} ${p()}::jsonb`,
+                    fieldParams: [JSON.stringify(value[1])]
+                }
+            }
         }
     }
 

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -336,7 +336,7 @@ export class Scheduler {
                     const propertyDataContext = computation.dataContext as PropertyDataContext
 
                     // assertion: 有 computation 的 property 就不能有原本的 defaultValue 了，因为会被 computation 的 getInitialValue 覆盖。
-                    assert(!propertyDataContext.id.defaultValue, `${propertyDataContext.host.name}.${propertyDataContext.id.name} property shuold not has a defaultValue, because it will be overridden by computation`)
+                    assert(!propertyDataContext.id.defaultValue, `${propertyDataContext.host.name}.${propertyDataContext.id.name} property should not have a defaultValue, because it will be overridden by computation`)
 
                     // TODO 未来合成一个 listener ?
                     listeners.push(async (mutationEvents) => {

--- a/src/runtime/computations/StateMachine.ts
+++ b/src/runtime/computations/StateMachine.ts
@@ -106,7 +106,15 @@ async function normalizeComputeTargetResult(
             const targets = Array.isArray(item) ? [item[1]].flat() : [item.target].flat()
             for (const source of sources) {
                 for (const target of targets) {
-                    if (!source?.id || !target?.id) continue
+                    // fail-fast：端点形态已被显式声明（{source, target}），其中缺 id 只能是
+                    //  computeTarget 的实现错误。静默 continue 会让转移无声失效（与「整体返回
+                    //  undefined 表示 skip」不同，那是显式的跳过契约）。
+                    if (!source?.id || !target?.id) {
+                        throw new ComputationProtocolError(
+                            `StateMachine computation of property "${dataContext.host.name}.${dataContext.id.name}" ${describeTransfer()}: computeTarget returned an endpoint form whose ${!source?.id ? 'source' : 'target'} has no id (got ${JSON.stringify({ source, target })}). Every endpoint must be {id} (or an array of {id}); return undefined to skip the transfer explicitly.`,
+                            { handleName: 'StateMachine', computationPhase: 'compute-dirty-records' }
+                        )
+                    }
                     const match = BoolExp.atom({ key: 'source.id', value: ['=', source.id] })
                         .and({ key: 'target.id', value: ['=', target.id] })
                     const relationRecords = await controller.system.storage.find(dataContext.host.name!, match, undefined, ['id'])

--- a/src/storage/erstorage/EntityQueryHandle.ts
+++ b/src/storage/erstorage/EntityQueryHandle.ts
@@ -6,7 +6,7 @@ import { assert } from "../utils.js";
 import { RecordQuery, LINK_SYMBOL } from "./RecordQuery.js";
 import { NewRecordData, RawEntityData } from "./NewRecordData.js";
 import { RecordQueryAgent } from "./RecordQueryAgent.js";
-import { EntityIdRef, Database, RecordMutationEvent, ID_ATTR } from "@runtime";
+import { EntityIdRef, Database, RecordMutationEvent, ID_ATTR, ROW_ID_ATTR } from "@runtime";
 import { Record } from "./RecordQueryAgent.js";
 import { RecordInfo } from "./RecordInfo.js";
 import { MERGED_TYPE_ATTR } from "./MergedItemProcessor.js";
@@ -57,14 +57,21 @@ export class EntityQueryHandle {
     }
 
     /**
-     * merged entity/relation 的 `__type` 判别列由框架管理（创建时按使用的名字写入），
-     * 显式覆写会把记录静默错标到其他 input 视图（跨视图可见性错乱 + 特有列交叉污染）。
-     * 公共写入口在此 fail-fast；递归检查嵌套的关联记录载荷（含 `&` link 数据）。
+     * 公共写入口的载荷校验（递归覆盖嵌套关联记录载荷与 `&` link 数据）：
+     * 1. merged entity/relation 的 `__type` 判别列由框架管理（创建时按使用的名字写入），
+     *    显式覆写会把记录静默错标到其他 input 视图（跨视图可见性错乱 + 特有列交叉污染）。
+     * 2. 未声明的属性名（拼写错误等）此前被 groupAttributes 静默丢弃——零告警数据丢失。
+     * 3. merged input 视图共享物理 base 的属性命名空间：以 input A 的名义写 input B 的
+     *    特有属性此前会静默落库（跨视图列污染）。
+     *
+     * 嵌套的 ref 载荷（携带 id 的既有记录引用）豁免 2/3：ref 的语义是「按 id 建立关系」，
+     * 其携带的其他字段是快照残留、被写路径显式忽略（把完整记录对象直接用作关系端点是合法形态，
+     * 例如把 event.user 作为 source）。判别列检查（1）对 ref 同样生效。
      */
-    private assertNoDiscriminatorWrite(recordName: string, rawData?: RawEntityData | RawEntityData[] | null) {
+    private validateWritePayload(recordName: string, rawData?: RawEntityData | RawEntityData[] | null, isNested = false) {
         if (!rawData || typeof rawData !== 'object') return
         if (Array.isArray(rawData)) {
-            rawData.forEach(item => this.assertNoDiscriminatorWrite(recordName, item))
+            rawData.forEach(item => this.validateWritePayload(recordName, item, isNested))
             return
         }
         const record = this.map.getRecord(recordName)
@@ -79,14 +86,34 @@ export class EntityQueryHandle {
                 )
             }
         }
-        for (const [key, value] of Object.entries(rawData)) {
-            if (!value || typeof value !== 'object') continue
+        const isRefPayload = isNested && rawData[ID_ATTR] !== undefined
+        for (const [rawKey, value] of Object.entries(rawData)) {
+            // ROW_ID_ATTR 出现在框架返回的记录上，round-trip 回写是合法形态（写路径会忽略它）。
+            if (rawKey === ID_ATTR || rawKey === ROW_ID_ATTR || rawKey === LINK_SYMBOL) continue
+            const [key] = this.map.getAttributeAndSymmetricDirection(rawKey)
             const attribute = record.attributes[key] as RecordAttribute | undefined
-            if (!attribute?.isRecord) continue
-            this.assertNoDiscriminatorWrite(attribute.recordName, value as RawEntityData | RawEntityData[])
-            const linkData = (value as RawEntityData)[LINK_SYMBOL]
-            if (linkData && attribute.linkName) {
-                this.assertNoDiscriminatorWrite(attribute.linkName, linkData as RawEntityData)
+            if (!attribute) {
+                if (isRefPayload) continue
+                throw new Error(
+                    `unknown attribute "${rawKey}" in write payload for "${recordName}". ` +
+                    `Unknown keys were previously dropped silently (zero-warning data loss). ` +
+                    `Declared attributes: ${Object.keys(record.attributes).join(', ')}.`
+                )
+            }
+            if (attribute.isRecord) {
+                if (!value || typeof value !== 'object') continue
+                this.validateWritePayload(attribute.recordName, value as RawEntityData | RawEntityData[], true)
+                const linkData = (value as RawEntityData)[LINK_SYMBOL]
+                if (linkData && attribute.linkName) {
+                    this.validateWritePayload(attribute.linkName, linkData as RawEntityData, true)
+                }
+            } else if (!isRefPayload && record.writablePropertyNames && !record.writablePropertyNames.includes(key)) {
+                // merged input 视图：attributes 表是整个家族的共享命名空间，必须按声明面裁剪。
+                throw new Error(
+                    `property "${key}" is not declared on "${recordName}" — it belongs to another input of merged record "${record.resolvedBaseRecordName || recordName}". ` +
+                    `Writing it through "${recordName}" would silently pollute a column owned by a sibling input view. ` +
+                    `Properties writable through "${recordName}": ${record.writablePropertyNames.join(', ')}.`
+                )
             }
         }
     }
@@ -94,14 +121,14 @@ export class EntityQueryHandle {
     async create(entityName: string, rawData: RawEntityData, events?: RecordMutationEvent[]): Promise<EntityIdRef> {
         // 支持使用外部 id。
         // assert(rawData[ID_ATTR] === null || rawData[ID_ATTR] === undefined, `${ID_ATTR} should be null or undefined when creating new record`)
-        this.assertNoDiscriminatorWrite(entityName, rawData)
+        this.validateWritePayload(entityName, rawData)
         const newEntityData = new NewRecordData(this.map, entityName, rawData)
         return this.agent.createRecord(newEntityData, `create record ${entityName} from handle`, events)
     }
 
     // CAUTION 不能递归更新 relate entity 的 value，如果传入了 related entity 的值，说明是建立新的联系。
     async update(entity: string, matchExpressionData: MatchExpressionData, rawData: RawEntityData, events?: RecordMutationEvent[]) {
-        this.assertNoDiscriminatorWrite(entity, rawData)
+        this.validateWritePayload(entity, rawData)
         const newEntityData = new NewRecordData(this.map, entity, rawData)
         return this.agent.updateRecord(entity, matchExpressionData, newEntityData, events)
     }
@@ -112,18 +139,18 @@ export class EntityQueryHandle {
 
     async addRelationByNameById(relationName: string, sourceEntityId: string, targetEntityId: string, rawData: RawEntityData = {}, events?: RecordMutationEvent[]) {
         assert(!!relationName && !!sourceEntityId && targetEntityId!!, `relationName: ${relationName} sourceEntityId:${sourceEntityId} targetEntityId:${targetEntityId} all cannot be empty`)
-        this.assertNoDiscriminatorWrite(relationName, rawData)
+        this.validateWritePayload(relationName, rawData)
         return this.agent.addLink(relationName, sourceEntityId, targetEntityId, rawData, false, events)
     }
 
     async addRelationById(entity: string, attribute: string, entityId: string, attributeEntityId: string, relationData?: RawEntityData, events?: RecordMutationEvent[]) {
-        this.assertNoDiscriminatorWrite(this.map.getInfo(entity, attribute).linkName, relationData)
+        this.validateWritePayload(this.map.getInfo(entity, attribute).linkName, relationData)
         return this.agent.addLinkFromRecord(entity, attribute, entityId, attributeEntityId, relationData, events)
     }
 
     async updateRelationByName(relationName: string, matchExpressionData: MatchExpressionData, rawData: RawEntityData, events?: RecordMutationEvent[]) {
         assert(!rawData.source && !rawData.target, 'Relation can only update attributes. Use addRelation/removeRelation to update source/target.')
-        this.assertNoDiscriminatorWrite(relationName, rawData)
+        this.validateWritePayload(relationName, rawData)
         return this.agent.updateRecord(relationName, matchExpressionData, new NewRecordData(this.map, relationName, rawData), events)
     }
 

--- a/src/storage/erstorage/EntityToTableMap.ts
+++ b/src/storage/erstorage/EntityToTableMap.ts
@@ -71,6 +71,10 @@ export type RecordMapItem = {
     // 该 record 是 merged item 编译出的物理 base，持有框架管理的 __type 判别列。
     // 判别列的值只能由"创建时使用的名字"决定，公共写入口必须拒绝显式写入。
     hasMergedDiscriminator?: boolean
+    // merged input 视图名下可写的 value 属性名集合（该 input 声明面 + base 链）。
+    // merged 编译把全部 input 的属性合并进同一物理表，attributes 表因此是共享命名空间——
+    // 没有这个集合，以 input A 的名义写 input B 的特有属性会静默落库（跨视图列污染）。
+    writablePropertyNames?: string[]
 }
 
 type RecordMap = {
@@ -204,6 +208,13 @@ export class EntityToTableMap {
                 attributeData = undefined
             } else {
                 const data = this.data.records[currentEntity]
+                // fail-fast：上一段是值属性时 currentEntity 为 ''（值属性没有可继续深入的记录），
+                //  继续解析会在这里对 undefined 取 attributes 抛与用户写法无关的裸 TypeError。
+                if (!data) {
+                    throw new Error(
+                        `invalid attribute path "${namePath.join('.')}": "${lastAttribute}" is a value attribute and cannot be traversed further (unexpected segment "${currentAttribute}")`
+                    )
+                }
                 // Filtered entity/relation 的 attributes 已经在 Setup 阶段复制过了，直接使用即可
                 attributeData = data!.attributes[currentAttribute!] as RecordAttribute
                 assert(!!attributeData, `attribute ${currentAttribute} not found in ${currentEntity}. namePath: ${namePath.join('.')}`)

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -243,6 +243,20 @@ export class MatchExp {
                     throw new Error(`match operator '${value[0]}' does not support null for key "${key}". Use ['=', null] (IS NULL) or ['!=', null] (IS NOT NULL)`)
                 }
                 fieldParams = []
+            } else if (fieldType?.toLowerCase() === 'json' && (value[0] === '=' || value[0] === '!=')) {
+                // CAUTION json 列的写入路径统一走 JSON.stringify（SQLBuilder.prepareFieldValue），
+                //  匹配参数若不做同样的序列化：文本型存储（SQLite/MySQL 文本比较）恒零命中，
+                //  PG/PGLite 直接抛 "operator does not exist: json = unknown" 的裸数据库错误。
+                //  优先给驱动方言机会（PG 系需要 ::jsonb 做语义相等比较），否则退化为与写入
+                //  路径一致的序列化文本相等比较。
+                const dialectResult = db?.parseMatchExpression?.(key, value, fieldName, fieldType!, isReferenceValue, this.getReferenceFieldValue.bind(this), p)
+                if (dialectResult) {
+                    fieldValue = dialectResult.fieldValue
+                    fieldParams = dialectResult.fieldParams || []
+                } else {
+                    fieldValue = `${value[0]} ${p()}`
+                    fieldParams = [JSON.stringify(value[1])]
+                }
             } else {
                 fieldValue = `${value[0]} ${p()}`
                 fieldParams = [value[1]]

--- a/src/storage/erstorage/MergedItemProcessor.ts
+++ b/src/storage/erstorage/MergedItemProcessor.ts
@@ -30,6 +30,13 @@ export interface ProcessMergedItemsResult {
      * 判别列由框架管理（记录创建时按使用的名字写入），公共写入口据此拒绝显式覆写。
      */
     discriminatorHostNames: Set<string>;
+    /**
+     * 各 input 视图名（含 filtered input 的 root base 名）→ 该名字下可写的 value 属性名集合。
+     * merged 编译把所有 input 的属性合并进同一张物理表，属性命名空间因此被共享——
+     * 以 input A 的名义写入 input B 的特有属性会静默落库（跨视图列污染）。
+     * 公共写入口据此拒绝写入不属于该 input 声明面的属性（explicit control）。
+     */
+    inputWritablePropertyNames: Map<string, string[]>;
 }
 
 function isEntity(item: MergedItem): item is EntityInstance {
@@ -126,6 +133,7 @@ export function processMergedItems(
     const refContainer = new RefContainer(entities, relations);
     const abstractNames = new Set<string>();
     const discriminatorHostNames = new Set<string>();
+    const inputWritablePropertyNames = new Map<string, string[]>();
 
     // 1. 基于原始（克隆前的）图计算每个名字的具体类型值：
     //    typeValue(name) = 沿 base 链走到根的名字；根是 merged item 时该名字是抽象的（不可创建）。
@@ -151,14 +159,14 @@ export function processMergedItems(
     const relationTree = buildItemTree(relations);
 
     for (const mergedEntity of mergedEntities) {
-        processSingleMergedItem(mergedEntity, refContainer, 'entity', entityTree, typeValueByName, compiledByName, abstractNames, discriminatorHostNames);
+        processSingleMergedItem(mergedEntity, refContainer, 'entity', entityTree, typeValueByName, compiledByName, abstractNames, discriminatorHostNames, inputWritablePropertyNames);
     }
     for (const mergedRelation of mergedRelations) {
-        processSingleMergedItem(mergedRelation, refContainer, 'relation', relationTree, typeValueByName, compiledByName, abstractNames, discriminatorHostNames);
+        processSingleMergedItem(mergedRelation, refContainer, 'relation', relationTree, typeValueByName, compiledByName, abstractNames, discriminatorHostNames, inputWritablePropertyNames);
     }
 
     const result = refContainer.getAll();
-    return { ...result, abstractNames, discriminatorHostNames };
+    return { ...result, abstractNames, discriminatorHostNames, inputWritablePropertyNames };
 }
 
 /**
@@ -245,6 +253,7 @@ function processSingleMergedItem<T extends MergedItem>(
     compiledByName: Map<string, CompiledMergedInfo>,
     abstractNames: Set<string>,
     discriminatorHostNames: Set<string>,
+    inputWritablePropertyNames: Map<string, string[]>,
 ): void {
     const isEntityType = itemType === 'entity';
     const itemName = getItemName(mergedItem);
@@ -324,8 +333,14 @@ function processSingleMergedItem<T extends MergedItem>(
     // 4. 把每个 input 替换成物理 base 上的 filtered item
     //    rootBaseName -> 该 root base 承载的类型集合，用于保持 root base 的可查询性（IS-A 语义）。
     const rootsToRebase = new Map<string, MergedItem>();
-    for (const { inputItem, memberCondition: inputCondition, rootToRebase } of inputMemberships) {
-        rebaseAsFilteredItem(getItemName(inputItem), registeredBaseItem, inputCondition, refContainer, isEntityType);
+    for (const { inputItem, memberCondition: inputCondition } of inputMemberships) {
+        const inputName = getItemName(inputItem);
+        // rebase 之前记录该 input 名下可写的属性集合：pre-rebase 的 base 链上全部声明属性
+        //（plain input = 自身；filtered input = 自身 + root base；嵌套 merged input = 其合并后的全集）。
+        inputWritablePropertyNames.set(inputName, collectWritablePropertyNames(inputName, refContainer, isEntityType));
+        rebaseAsFilteredItem(inputName, registeredBaseItem, inputCondition, refContainer, isEntityType);
+    }
+    for (const { rootToRebase } of inputMemberships) {
         if (rootToRebase && getItemName(rootToRebase) !== getItemName(registeredBaseItem)) {
             rootsToRebase.set(getItemName(rootToRebase), rootToRebase);
         }
@@ -335,8 +350,27 @@ function processSingleMergedItem<T extends MergedItem>(
     //    rebase 为物理 base 上的 filtered item，成员条件就是自己的类型判别（IS-A：包含所有子 input 的记录）。
     for (const [rootName] of rootsToRebase) {
         const rootCondition = MatchExp.atom({ key: MERGED_TYPE_ATTR, value: ['=', rootName] });
+        inputWritablePropertyNames.set(rootName, collectWritablePropertyNames(rootName, refContainer, isEntityType));
         rebaseAsFilteredItem(rootName, registeredBaseItem, rootCondition, refContainer, isEntityType);
     }
+}
+
+/**
+ * 收集 name（pre-rebase）的可写属性名：沿 base 链向上取全部声明属性的并集。
+ * - plain input：自身属性（含 commonProperties 的同名再声明、bound-state 注入列）。
+ * - filtered input：自身（通常为空）∪ root base 的属性。
+ * - 嵌套 merged input：其 transform 后的属性全集（自身或虚拟 base 上的 mergedProperties）。
+ */
+function collectWritablePropertyNames(name: string, refContainer: RefContainer, isEntityType: boolean): string[] {
+    let current: MergedItem | undefined = isEntityType ? refContainer.getEntityByName(name) : refContainer.getRelationByName(name);
+    const names = new Set<string>();
+    while (current) {
+        for (const property of current.properties || []) {
+            names.add(property.name);
+        }
+        current = getBaseItem(current);
+    }
+    return [...names];
 }
 
 /**

--- a/src/storage/erstorage/Setup.ts
+++ b/src/storage/erstorage/Setup.ts
@@ -869,6 +869,7 @@ export class DBSetup {
      */
     private mergedAbstractNames: Set<string> = new Set()
     private mergedDiscriminatorHostNames: Set<string> = new Set()
+    private mergedInputWritablePropertyNames: Map<string, string[]> = new Map()
     private processMergedItems() {
         const result = processMergedItems(
             this.entities,
@@ -879,6 +880,7 @@ export class DBSetup {
         this.relations = result.relations;
         this.mergedAbstractNames = result.abstractNames;
         this.mergedDiscriminatorHostNames = result.discriminatorHostNames;
+        this.mergedInputWritablePropertyNames = result.inputWritablePropertyNames;
     }
 
     /**
@@ -895,6 +897,13 @@ export class DBSetup {
         for (const name of this.mergedDiscriminatorHostNames) {
             if (this.map.records[name]) {
                 this.map.records[name].hasMergedDiscriminator = true
+            }
+        }
+        // input 视图共享物理 base 的属性命名空间，写入口需要知道每个 input 名下声明了哪些属性，
+        // 才能拒绝「以 input A 的名义写 input B 的特有属性」的静默跨视图污染。
+        for (const [name, propertyNames] of this.mergedInputWritablePropertyNames) {
+            if (this.map.records[name]) {
+                this.map.records[name].writablePropertyNames = propertyNames
             }
         }
     }

--- a/tests/core/review-fixes-core.spec.ts
+++ b/tests/core/review-fixes-core.spec.ts
@@ -43,6 +43,7 @@ describe('S9: Relation.isTargetReliance inheritance', () => {
             baseRelation: base,
             sourceProperty: 'p',
             targetProperty: 'o',
+            matchExpression: { key: 'active', value: ['=', true] },
             isTargetReliance: false,
         });
         expect(filtered.isTargetReliance).toBe(false);

--- a/tests/runtime/activity.spec.ts
+++ b/tests/runtime/activity.spec.ts
@@ -51,8 +51,10 @@ describe("activity state", () => {
         rejectES = controller.findEventSourceByName(`${activityName}:reject`)!
         cancelES = controller.findEventSourceByName(`${activityName}:cancel`)!
 
-        userA = await controller.system.storage.create('User', { roles: ['user']})
-        userB = await controller.system.storage.create('User', { roles: ['user']})
+        // roles 不是 User entity 声明的属性（storage 写入口现在 fail-fast），
+        // 但 guard 的 role attributive 检查的是 dispatch 传入的内存 user 对象——在内存上补齐。
+        userA = { ...await controller.system.storage.create('User', { name: 'A' }), roles: ['user'] }
+        userB = { ...await controller.system.storage.create('User', { name: 'B' }), roles: ['user'] }
     })
 
     test("call friend request activity with approve response via dispatch", async () => {

--- a/tests/runtime/every.spec.ts
+++ b/tests/runtime/every.spec.ts
@@ -583,7 +583,9 @@ describe('Every computed handle', () => {
     await controller.setup(true)
 
     // 创建 1 个 user 和 2 个 request
-    const user = await system.storage.create('User', {everyRequestHandled: false})  
+    // 该段的 User 声明的是 everyRequestHasTwoItems（计算属性），此前误写的 everyRequestHandled
+    // 被静默丢弃；写入口 fail-fast 后必须移除。
+    const user = await system.storage.create('User', {name: 'u1'})
     const request1 = await system.storage.create('Request', {handled: false, owner: user})      
 
     const user2 = await system.storage.findOne('User', MatchExp.atom({key: 'id', value: ['=', user.id]}), undefined, ['*'])

--- a/tests/runtime/review-fixes-2026-07-09-r10.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r10.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "vitest";
+import {
+    Entity, Property, Relation, KlassByName,
+    Controller, MonoSystem,
+    Interaction, Action, Activity, Transfer, ActivityManager, ActivityGroup,
+    Conditions, Condition, Attributives, Attributive,
+    StateMachine, StateNode, StateTransfer,
+} from 'interaqt';
+import { MatchExp } from '@storage';
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r10 review 回归（runtime/builtins 侧）。
+ *
+ * F-1: activities 为空的 ActivityGroup 永远无法完成（group 状态只靠子分支的
+ *      onChange 推进，空 group 没有分支），后续 transfer 目标永不可达——activity
+ *      静默死锁。现在 buildGraph 声明期 fail-fast。
+ *
+ * R-1: relation 宿主 property StateMachine 的 computeTarget 返回端点形态
+ *      （{source, target}）但端点缺 id 时，此前静默 continue——转移无声失效。
+ *      现在按「无法识别形态一律 fail-fast」的既有契约抛 ComputationProtocolError。
+ *
+ * R-2: content 为空的 Conditions/Attributives 挂上守卫链后，每次 dispatch 都在
+ *      BoolExp 构造器深处抛 "BoolExp raw data cannot be undefined" 的内部错误。
+ *      现在 Interaction.create 声明期给出业务级错误。
+ *
+ * R-5: 同一 source 的多条 Transfer 此前后写覆盖先写（每个节点只有一个 next 指针），
+ *      构建出的图与声明不一致。现在 buildGraph 声明期 fail-fast。
+ */
+
+function makeInteraction(name: string) {
+    return Interaction.create({ name, action: Action.create({ name }) })
+}
+
+describe('r10 F-1: empty ActivityGroup is rejected at declaration time', () => {
+    test('group with no child activities throws instead of deadlocking', () => {
+        const start = makeInteraction('r10S')
+        const end = makeInteraction('r10E')
+        const empty = ActivityGroup.create({ type: 'every', activities: [] })
+        const act = Activity.create({
+            name: 'R10Deadlock', interactions: [start, end], groups: [empty],
+            transfers: [
+                Transfer.create({ name: 't1', source: start, target: empty }),
+                Transfer.create({ name: 't2', source: empty, target: end }),
+            ],
+        })
+        expect(() => new ActivityManager([act])).toThrow(/has no child activities.*deadlock/)
+    })
+})
+
+describe('r10 R-5: duplicate transfers from the same source are rejected', () => {
+    test('second outgoing transfer from one node throws', () => {
+        const a = makeInteraction('r10a')
+        const b = makeInteraction('r10b')
+        const c = makeInteraction('r10c')
+        const d = makeInteraction('r10d')
+        const act = Activity.create({
+            name: 'R10Fork', interactions: [a, b, c, d],
+            transfers: [
+                Transfer.create({ name: 't1', source: a, target: b }),
+                Transfer.create({ name: 't2', source: a, target: c }),
+                Transfer.create({ name: 't3', source: b, target: d }),
+                Transfer.create({ name: 't4', source: c, target: d }),
+            ],
+        })
+        expect(() => new ActivityManager([act])).toThrow(/multiple transfers from the same source "r10a"/)
+    })
+})
+
+describe('r10 R-2: content-less guard containers are rejected at declaration time', () => {
+    test('Conditions without content', () => {
+        expect(() => Interaction.create({
+            name: 'R10BadCond',
+            action: Action.create({ name: 'r10badCond' }),
+            conditions: Conditions.create({}),
+        })).toThrow(/Conditions instance that has no content/)
+    })
+
+    test('Attributives without content', () => {
+        expect(() => Interaction.create({
+            name: 'R10BadAttr',
+            action: Action.create({ name: 'r10badAttr' }),
+            userAttributives: Attributives.create({}),
+        })).toThrow(/Attributives instance that has no content/)
+    })
+
+    test('well-formed Conditions still dispatch normally', async () => {
+        const User = Entity.create({ name: 'UserR10I', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const ok = Interaction.create({
+            name: 'R10GoodCond',
+            action: Action.create({ name: 'r10goodCond' }),
+            conditions: Condition.create({ name: 'always', content: async () => true }),
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [User], relations: [], eventSources: [ok] })
+        await controller.setup(true)
+        const user = await system.storage.create('UserR10I', { name: 'u' })
+        const res = await controller.dispatch(ok, { user })
+        expect(res.error).toBeUndefined()
+        await system.destroy()
+    })
+})
+
+describe('r10 R-1: StateMachine computeTarget endpoint without id fails fast', () => {
+    test('endpoint form missing source.id surfaces a protocol error instead of silent skip', async () => {
+        const U = Entity.create({ name: 'UR10J', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const P = Entity.create({ name: 'PR10J', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const idle = StateNode.create({ name: 'idle' })
+        const hot = StateNode.create({ name: 'hot' })
+        const Rel = Relation.create({
+            source: U, sourceProperty: 'posts', target: P, targetProperty: 'owner', type: '1:n',
+            properties: [Property.create({
+                name: 'flag', type: 'string',
+                computation: StateMachine.create({
+                    states: [idle, hot],
+                    initialState: idle,
+                    transfers: [StateTransfer.create({
+                        current: idle, next: hot,
+                        trigger: { recordName: 'PR10J', type: 'update' },
+                        computeTarget: (event: any) => ({ source: {}, target: { id: event.record.id } })
+                    })]
+                })
+            })]
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [U, P], relations: [Rel], eventSources: [] })
+        await controller.setup(true)
+        const u = await system.storage.create('UR10J', { name: 'u' })
+        const p = await system.storage.create('PR10J', { title: 't', owner: { id: u.id } })
+        await expect(
+            system.storage.update('PR10J', MatchExp.atom({ key: 'id', value: ['=', p.id] }), { title: 't2' })
+        ).rejects.toThrow(/endpoint form whose source has no id/)
+        await system.destroy()
+    })
+
+    test('well-formed endpoint form still transitions', async () => {
+        const U = Entity.create({ name: 'UR10K', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const P = Entity.create({ name: 'PR10K', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const idle = StateNode.create({ name: 'idle' })
+        const hot = StateNode.create({ name: 'hot' })
+        const Rel = Relation.create({
+            source: U, sourceProperty: 'posts', target: P, targetProperty: 'owner', type: '1:n',
+            properties: [Property.create({
+                name: 'flag', type: 'string',
+                computation: StateMachine.create({
+                    states: [idle, hot],
+                    initialState: idle,
+                    transfers: [StateTransfer.create({
+                        current: idle, next: hot,
+                        trigger: { recordName: 'PR10K', type: 'update' },
+                        computeTarget: async function (this: Controller, event: any) {
+                            const post = await this.system.storage.findOne('PR10K',
+                                MatchExp.atom({ key: 'id', value: ['=', event.record.id] }), undefined,
+                                ['id', ['owner', { attributeQuery: ['id'] }]])
+                            return { source: { id: post.owner.id }, target: { id: post.id } }
+                        }
+                    })]
+                })
+            })]
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [U, P], relations: [Rel], eventSources: [] })
+        await controller.setup(true)
+        const u = await system.storage.create('UR10K', { name: 'u' })
+        const p = await system.storage.create('PR10K', { title: 't', owner: { id: u.id } })
+        await system.storage.update('PR10K', MatchExp.atom({ key: 'id', value: ['=', p.id] }), { title: 't2' })
+        const rel = await system.storage.findOne(Rel.name!, undefined, undefined, ['flag'])
+        expect(rel.flag).toBe('hot')
+        await system.destroy()
+    })
+})

--- a/tests/runtime/symmetricRelation.spec.ts
+++ b/tests/runtime/symmetricRelation.spec.ts
@@ -247,7 +247,8 @@ describe('Symmetric relation computation', () => {
     const user2 = await system.storage.create('User', {username: 'Bob'});
     
     // Create friendship from user1 to user2
-    await system.storage.addRelationByNameById('User_friends_friends_User', user1.id, user2.id, {level: 'bestfriend'});
+    // 该 relation 未声明 level 属性（未声明键此前被静默丢弃，写入口现在 fail-fast）。
+    await system.storage.addRelationByNameById('User_friends_friends_User', user1.id, user2.id);
     
     // Query friends of user1
     const user1WithFriends = await system.storage.findOne(

--- a/tests/runtime/transformInteraction.spec.ts
+++ b/tests/runtime/transformInteraction.spec.ts
@@ -40,13 +40,14 @@ describe('map interaction', () => {
         sendRequestInteraction = interactions.find(i => i.name === 'sendRequest')!
         approveRequestInteraction = interactions.find(i => i.name === 'approve')!
 
-        const userARef = await system.storage.create('User', {name: 'A', age: 10})
+        // leaveRequest 的 User 只声明了 name（age 此前被静默丢弃，写入口现在 fail-fast）。
+        const userARef = await system.storage.create('User', {name: 'A'})
         userAId = userARef.id
 
-        const userBRef = await system.storage.create('User', {name: 'B', age: 12})
+        const userBRef = await system.storage.create('User', {name: 'B'})
         userBId = userBRef.id
 
-        const userCRef = await system.storage.create('User', {name: 'C', age: 14})
+        const userCRef = await system.storage.create('User', {name: 'C'})
         userCId = userCRef.id
     })
 

--- a/tests/runtime/versionControlHardDeleteExample2.spec.ts
+++ b/tests/runtime/versionControlHardDeleteExample2.spec.ts
@@ -252,10 +252,14 @@ describe('Version Control Example with Hard Delete', () => {
           ['*']
         );
 
+        // VersionedStyle 只声明了 content/status/version/createdAt——显式拷贝声明面。
+        // （...style 展开会带上 Style 的 _isDeleted_ / bound-state 列，未声明键写入口现在 fail-fast。）
         return currentStyles.map(style => {
           return {
-            ...style,
-            id: undefined,
+            content: style.content,
+            status: style.status,
+            version: style.version,
+            createdAt: style.createdAt,
             }
           });
       }
@@ -306,9 +310,12 @@ describe('Version Control Example with Hard Delete', () => {
               ['*']
             );
 
+            // Style 的声明面是 content/status/version/createdAt——显式拷贝。
+            // （...style 展开会带上 VersionedStyle 的 bound-state 列，未声明键写入口现在 fail-fast。）
             return targetStyles.map(style => ({
-              ...style,
-              id: undefined,
+              content: style.content,
+              status: style.status,
+              createdAt: style.createdAt,
               version: versionInfo.version,
             }));
           }

--- a/tests/storage/longColumnNames.spec.ts
+++ b/tests/storage/longColumnNames.spec.ts
@@ -403,16 +403,21 @@ describe('Long column name tests', () => {
             'UserWithExtremelyLongEntityNameForRelationCRUDTesting',
             MatchExp.atom({ key: 'id', value: ['=', userWithTeams.id] }),
             {
+                // 关系属性必须通过 '&' 声明（内联在 ref 对象上的关系属性此前被静默丢弃，写入口现在 fail-fast）。
                 belongsToTeamsWithVeryLongPropertyNameToTestColumnShortening: [
                     {
                         id: teamAData.id,
-                        roleWithAnExtremelyLongPropertyNameInTheRelationToTestFieldShortening: 'Leader',
-                        joinDateWithAnotherVeryLongPropertyNameToEnsureProperHandling: '2024-01-01'
+                        '&': {
+                            roleWithAnExtremelyLongPropertyNameInTheRelationToTestFieldShortening: 'Leader',
+                            joinDateWithAnotherVeryLongPropertyNameToEnsureProperHandling: '2024-01-01'
+                        }
                     },
                     {
                         id: teamBData.id,
-                        roleWithAnExtremelyLongPropertyNameInTheRelationToTestFieldShortening: 'Member',
-                        joinDateWithAnotherVeryLongPropertyNameToEnsureProperHandling: '2024-01-02'
+                        '&': {
+                            roleWithAnExtremelyLongPropertyNameInTheRelationToTestFieldShortening: 'Member',
+                            joinDateWithAnotherVeryLongPropertyNameToEnsureProperHandling: '2024-01-02'
+                        }
                     }
                 ]
             }

--- a/tests/storage/review-fixes-2026-07-09-r10.spec.ts
+++ b/tests/storage/review-fixes-2026-07-09-r10.spec.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "vitest";
+import { Entity, Property, Relation } from 'interaqt';
+import { DBSetup, EntityQueryHandle, EntityToTableMap, MatchExp } from '@storage';
+import { PGLiteDB, SQLiteDB } from '@drivers';
+
+/**
+ * r10 review 回归（storage/core 侧）。
+ *
+ * F-2: merged 编译把全部 input 的属性合并进同一物理表，属性命名空间被共享——
+ *      此前以 input A 的名义写 input B 的特有属性会静默落库（跨视图列污染）；
+ *      未声明的属性名（拼写错误）也被 groupAttributes 静默丢弃（零告警数据丢失）。
+ *      现在公共写入口 fail-fast；携带 id 的嵌套 ref 载荷（记录快照 round-trip）保持豁免。
+ *
+ * F-3: json/collection 字段的 =/!= 匹配此前参数不做序列化——PG/PGLite 直接抛
+ *      "operator does not exist: json = unknown" 的裸数据库错误，文本型存储恒零命中。
+ *      现在与写入路径一致地序列化（PG 系走 ::jsonb 语义比较）。
+ *
+ * F-4: baseEntity/baseRelation 不带 matchExpression 的"filtered 视图"没有语义，
+ *      此前 setup/查询在深处抛裸 TypeError，现在声明期 fail-fast。
+ *
+ * R-3: Relation.create 此前不校验 type，畸形值静默流入 relType.split(':')，
+ *      产出不可预测的存储布局。现在白名单校验。
+ *
+ * R-4: match/attributeQuery 路径越过值属性继续深入时，此前抛
+ *      "Cannot read properties of undefined" 的裸 TypeError，现在给出指明路径的错误。
+ */
+
+async function setupHandle(entities: any[], relations: any[]) {
+    const db = new PGLiteDB()
+    await db.open()
+    const setup = new DBSetup(entities, relations, db)
+    await setup.createTables()
+    const handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+    return { db, handle }
+}
+
+describe('r10 F-2: merged input property namespace is guarded at the write entry', () => {
+    function makeMergedFamily(suffix: string) {
+        const Customer = Entity.create({
+            name: `Customer${suffix}`,
+            properties: [Property.create({ name: 'name', type: 'string' }), Property.create({ name: 'level', type: 'string' })]
+        })
+        const Vendor = Entity.create({
+            name: `Vendor${suffix}`,
+            properties: [Property.create({ name: 'name', type: 'string' }), Property.create({ name: 'vendorCode', type: 'string' })]
+        })
+        const Contact = Entity.create({ name: `Contact${suffix}`, inputEntities: [Customer, Vendor] })
+        return { Customer, Vendor, Contact }
+    }
+
+    test('writing a sibling input property through another input fails fast (create and update)', async () => {
+        const { Customer, Vendor, Contact } = makeMergedFamily('R10A')
+        const { db, handle } = await setupHandle([Customer, Vendor, Contact], [])
+
+        await expect(handle.create('CustomerR10A', { name: 'c', vendorCode: 'X' }))
+            .rejects.toThrow(/property "vendorCode" is not declared on "CustomerR10A"/)
+
+        const c = await handle.create('CustomerR10A', { name: 'c', level: 'gold' })
+        await expect(handle.update('CustomerR10A', MatchExp.atom({ key: 'id', value: ['=', c.id] }), { vendorCode: 'X' }))
+            .rejects.toThrow(/belongs to another input of merged record "ContactR10A"/)
+
+        // 自己声明面内的写入照常可用
+        await handle.update('CustomerR10A', MatchExp.atom({ key: 'id', value: ['=', c.id] }), { level: 'silver' })
+        const read = await handle.findOne('CustomerR10A', MatchExp.atom({ key: 'id', value: ['=', c.id] }), {}, ['name', 'level'])
+        expect(read.level).toBe('silver')
+        await db.close()
+    })
+})
+
+describe('r10 F-2: unknown payload keys fail fast instead of silent drop', () => {
+    test('typo keys are rejected; ref payloads and _rowId round-trips stay legal', async () => {
+        const User = Entity.create({ name: 'UserR10B', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const Post = Entity.create({ name: 'PostR10B', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const Rel = Relation.create({ source: User, sourceProperty: 'posts', target: Post, targetProperty: 'owner', type: '1:n' })
+        const { db, handle } = await setupHandle([User, Post], [Rel])
+
+        await expect(handle.create('UserR10B', { nmae: 'Alice' }))
+            .rejects.toThrow(/unknown attribute "nmae" in write payload for "UserR10B"/)
+
+        const u = await handle.create('UserR10B', { name: 'Alice' })
+        await expect(handle.update('UserR10B', MatchExp.atom({ key: 'id', value: ['=', u.id] }), { nmae: 'Bob' }))
+            .rejects.toThrow(/unknown attribute "nmae"/)
+
+        // 框架返回的记录（含 _rowId）round-trip 回写、以及携带快照字段的 ref 载荷是合法形态
+        const userSnapshot = await handle.findOne('UserR10B', MatchExp.atom({ key: 'id', value: ['=', u.id] }), {}, ['*'])
+        const p = await handle.create('PostR10B', { title: 't', owner: { ...userSnapshot, extraneousSnapshotField: 1 } })
+        const readBack = await handle.findOne('PostR10B', MatchExp.atom({ key: 'id', value: ['=', p.id] }), {}, ['title', ['owner', { attributeQuery: ['name'] }]])
+        expect(readBack.owner.name).toBe('Alice')
+        await db.close()
+    })
+})
+
+describe('r10 F-3: json field equality match', () => {
+    test('collection property = / != works on PGLite (jsonb semantic comparison)', async () => {
+        const Doc = Entity.create({
+            name: 'DocR10C',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'tags', type: 'string', collection: true })
+            ]
+        })
+        const { db, handle } = await setupHandle([Doc], [])
+        await handle.create('DocR10C', { title: 'a', tags: ['x', 'y'] })
+        await handle.create('DocR10C', { title: 'b', tags: ['z'] })
+        await handle.create('DocR10C', { title: 'c' }) // tags 为 NULL 的行不参与 =/!= 匹配
+
+        const eq = await handle.find('DocR10C', MatchExp.atom({ key: 'tags', value: ['=', ['x', 'y']] }), {}, ['title'])
+        expect(eq.map(r => r.title)).toEqual(['a'])
+
+        const ne = await handle.find('DocR10C', MatchExp.atom({ key: 'tags', value: ['!=', ['x', 'y']] }), {}, ['title'])
+        expect(ne.map(r => r.title)).toEqual(['b'])
+        await db.close()
+    })
+
+    test('collection property = works on SQLite (serialized text comparison)', async () => {
+        const Doc = Entity.create({
+            name: 'DocR10D',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'tags', type: 'string', collection: true })
+            ]
+        })
+        const db = new SQLiteDB(':memory:')
+        await db.open()
+        const setup = new DBSetup([Doc], [], db)
+        await setup.createTables()
+        const handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db)
+        await handle.create('DocR10D', { title: 'a', tags: ['x', 'y'] })
+        await handle.create('DocR10D', { title: 'b', tags: ['z'] })
+        const eq = await handle.find('DocR10D', MatchExp.atom({ key: 'tags', value: ['=', ['x', 'y']] }), {}, ['title'])
+        expect(eq.map(r => r.title)).toEqual(['a'])
+        await db.close()
+    })
+})
+
+describe('r10 F-4: filtered view without matchExpression is rejected at declaration time', () => {
+    test('filtered entity', () => {
+        const U = Entity.create({ name: 'UserR10E', properties: [Property.create({ name: 'name', type: 'string' })] })
+        expect(() => Entity.create({ name: 'AllUserR10E', baseEntity: U }))
+            .toThrow(/declares baseEntity but no matchExpression/)
+    })
+
+    test('filtered relation', () => {
+        const U = Entity.create({ name: 'UserR10F', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const P = Entity.create({ name: 'PostR10F', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const base = Relation.create({ source: U, sourceProperty: 'posts', target: P, targetProperty: 'owner', type: '1:n' })
+        expect(() => Relation.create({ baseRelation: base, sourceProperty: 'activePosts', targetProperty: 'activeOwner' }))
+            .toThrow(/declares baseRelation but no matchExpression/)
+    })
+})
+
+describe('r10 R-3: Relation.create validates type', () => {
+    test('malformed type values are rejected', () => {
+        const A = Entity.create({ name: 'AR10G', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const B = Entity.create({ name: 'BR10G', properties: [Property.create({ name: 'name', type: 'string' })] })
+        expect(() => Relation.create({ source: A, sourceProperty: 'bs', target: B, targetProperty: 'as', type: 'bogus' }))
+            .toThrow(/Relation type "bogus" is invalid/)
+        expect(() => Relation.create({ source: A, sourceProperty: 'bs2', target: B, targetProperty: 'as2', type: 'n:n:extra' }))
+            .toThrow(/Relation type "n:n:extra" is invalid/)
+        // 合法值照常可用
+        const rel = Relation.create({ source: A, sourceProperty: 'bs3', target: B, targetProperty: 'as3', type: 'n:n' })
+        expect(rel.type).toBe('n:n')
+    })
+})
+
+describe('r10 R-4: attribute path past a value attribute gives a clear error', () => {
+    test('match path continuing after a value attribute', async () => {
+        const U = Entity.create({ name: 'UserR10H', properties: [Property.create({ name: 'name', type: 'string' })] })
+        const P = Entity.create({ name: 'PostR10H', properties: [Property.create({ name: 'title', type: 'string' })] })
+        const Rel = Relation.create({ source: U, sourceProperty: 'posts', target: P, targetProperty: 'owner', type: '1:n' })
+        const { db, handle } = await setupHandle([U, P], [Rel])
+        await expect(handle.find('PostR10H', MatchExp.atom({ key: 'owner.name.extra', value: ['=', 'x'] }), {}, ['title']))
+            .rejects.toThrow(/"name" is a value attribute and cannot be traversed further/)
+        await db.close()
+    })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

第十轮全代码库深度 review（接 r1–r9）。四路并行探查历史盲区（storage 写路径冷区 / runtime 调度 / builtins 执行链与 core 声明校验 / drivers 与 migration），与既往九轮报告逐条去重后，对每个候选编写最小复现测试实际运行验证。报告：`agentspace/output/deep-review-2026-07-09-r10.md`。

## 致命问题（已复现，已修）

| # | 问题 | 修复 |
|---|------|------|
| F-1 | `activities: []` 的空 ActivityGroup：进入即永久死锁，声明期零告警 | `buildGraph` 声明期 fail-fast |
| F-2 | merged input 视图跨 input 属性写入静默污染（`create('Customer', {vendorCode})` 落库）+ 全写入口未知键静默丢弃（`{nmae:'Alice'}` 零告警数据丢失） | `EntityQueryHandle.validateWritePayload` 统一写入口校验：未知键 fail-fast、merged input 按声明面裁剪（`MergedItemProcessor` 收集各 input 可写属性集合 → `RecordMapItem.writablePropertyNames`）；携带 id 的 ref 载荷与 `_rowId` round-trip 保持合法 |
| F-3 | json/collection 字段 `=`/`!=` 匹配：PG/PGLite 抛 `operator does not exist: json = unknown` 裸错误，SQLite/MySQL 静默零命中 | `MatchExp` 与写路径一致地序列化参数；PG/PGLite 走 `::jsonb` 语义比较，MySQL 走 `CAST(? AS JSON)` |

## 重要问题（已复现，已修）

- StateMachine `computeTarget` 端点形态缺 id：静默 skip → 抛 `ComputationProtocolError`
- `Conditions.create({})` / `Attributives.create({})` 挂守卫链：dispatch 期 BoolExp 内部错误 → `Interaction.create` 声明期校验
- `Relation.create` 不校验 `type`（`'bogus'` 静默接受）→ 白名单校验
- filtered entity/relation 无 `matchExpression`：裸 TypeError → 声明期 fail-fast
- match 路径越过值属性（`owner.name.extra`）：裸 TypeError → 指明路径的错误
- 同一 source 多条 Transfer 静默覆盖 `next` 指针 → 声明期 fail-fast
- 知识库驱动导入路径教错（`PGLiteDB` 列在主包 import，实际在 `interaqt/drivers` 子入口）——代码生成管线级文档污染，修正 `18-api-exports-reference.md` 与 `13-testing.md`

## 证伪的候选（见报告第五节）

merged 合表部分删除 `__type` 置 NULL（实测行为正确）、drivers types 路径不一致（实测双路径均产出）、filtered-over-merged 应声明期拒绝（有意设计的查询视图）、defaultValue+computation 静默接受（已有 fail-fast）。

## 未修的高置信度遗留（报告第四节，9 项）

最优先：迁移阶段顺序（filtered 成员资格重算先于 computation 重算）、merged input 移除后的孤儿 `__type` 行。

## 测试

- 新增回归：`tests/storage/review-fixes-2026-07-09-r10.spec.ts`（8 用例）+ `tests/runtime/review-fixes-2026-07-09-r10.spec.ts`（7 用例）
- 顺带修正 7 处被新 fail-fast 暴露的既有测试反模式（含 `every.spec` 的真实属性名拼写错误 `everyRequestHandled`，此前靠静默丢弃侥幸通过）
- `npm run check` 通过；`npm test` 全量 **1795 passed / 26 skipped**（基线 1780，净 +15 回归用例）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5271bfd7-b1c3-4dd4-b4a8-fc019c73f03a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5271bfd7-b1c3-4dd4-b4a8-fc019c73f03a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

