### PR TITLE
Deep code review r11: propagation cycle guard, GetAction identity binding, json IN/NOT IN, and fail-fast hardening

### DIFF
--- a/agent/agentspace/knowledge/generator/api-reference.md
+++ b/agent/agentspace/knowledge/generator/api-reference.md
@@ -4089,6 +4089,14 @@ storage.listen(async (events) => {
 })
 ```
 
+⚠️ **Transaction semantics**: `listen` callbacks run **inside** the dispatch transaction,
+**before** it commits. If a later step of the same dispatch fails (guard, resolve,
+computation), the transaction rolls back — database writes made by the callback roll
+back with it, but any **external** side effects (HTTP calls, message queues, logs)
+have already happened and cannot be undone. For external side effects that must only
+fire for committed data, use `RecordMutationSideEffect` instead: it runs **after
+commit** and its results are reported in `DispatchResponse.sideEffects`.
+
 #### AttributeQueryData Format
 
 AttributeQuery specifies which fields to retrieve and supports nested queries for relations:

--- a/agent/agentspace/knowledge/generator/api-reference.md
+++ b/agent/agentspace/knowledge/generator/api-reference.md
@@ -2596,7 +2596,12 @@ const CreatePostInteraction = Interaction.create({
 
 2. **Get Data Interactions**
 
-To retrieve data, use `GetAction` and specify the `data` field:
+To retrieve data, use `GetAction` and specify the `data` field.
+
+⚠️ `GetAction` is an exported **constant** with a fixed built-in identity — you must
+`import { GetAction } from 'interaqt'`. An Action you create yourself with the name
+`'get'` (`Action.create({ name: 'get' })`) is just an ordinary action and carries no
+query semantics; declaring `data`/`dataPolicy` with it is a declaration-time error.
 
 ```typescript
 // Get all users

--- a/agent/agentspace/knowledge/generator/test-implementation.md
+++ b/agent/agentspace/knowledge/generator/test-implementation.md
@@ -215,7 +215,7 @@ test('should create and update style', async () => {
 // ❌ WRONG: Creating query interactions just for testing
 const GetStyleBySlug = Interaction.create({  // Don't create this just for tests!
   name: 'GetStyleBySlug',
-  action: Action.create({ name: 'get' }),
+  action: GetAction,  // query semantics come from the exported GetAction constant
   // ...
 })
 ```

--- a/agent/agentspace/knowledge/usage/18-api-exports-reference.md
+++ b/agent/agentspace/knowledge/usage/18-api-exports-reference.md
@@ -17,6 +17,7 @@ import {
   // Interaction-related
   Interaction,
   Action,
+  GetAction,        // the built-in query action constant — required for data/dataPolicy interactions
   Payload,
   PayloadItem,
   

--- a/agentspace/output/deep-review-2026-07-09-r11.md
+++ b/agentspace/output/deep-review-2026-07-09-r11.md
@@ -1,0 +1,160 @@
+# 全代码库深度 Review 报告（2026-07-09 第十一轮）
+
+- 日期：2026-07-09
+- 基线：`main` @ `e447997a`（v2.0.2，r1–r10 的致命/重要修复全部落地）
+- 范围：四路并行深度探查历史冷区——ScopedSequence/RealTime 全栈 / 并发·事务·异步生命周期（transaction、asyncContext、ComputationSourceMap）/ storage 读路径与表达式层（QueryExecutor、MatchExp 非 simpleOp 分支、objectstorage）/ builtins 执行链与 core 声明层（GetAction、序列化、Klass 注册表）
+- 方法：与 r1–r10 报告**逐条去重** → 对每个致命/重要候选**编写最小复现测试实际运行**（PGLiteDB/SQLiteDB）。只有「已运行复现确认」的问题列为致命/重要；证伪或重新归类的候选明确记录（见第五节）。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1795 passed / 26 skipped。
+
+> **维护说明（2026-07-09）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r11-5327`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-09-r11.spec.ts`（10 用例）+ `tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts`（1 用例）+ `tests/storage/review-fixes-2026-07-09-r11.spec.ts`（6 用例）。顺带修正 2 处被新 fail-fast 暴露的既有测试（`queryDataInteraction.spec.ts` 的 data-on-non-get 用例改为断言声明期错误；`review-fixes-2026-07.spec.ts` 的 RealTime 守卫用例补占位 dataDep）。
+
+---
+
+## 一、结论摘要
+
+经十轮修复，读写主路径、聚合增量、filtered/merged 编译、Activity 状态机、migration 已高度收敛。本轮在历史冷区找到的新致命项集中在两类：
+
+1. **无终止的反应式反馈环**——计算写回重入 mutation listener 是反应式语义的主干，但十轮以来这条主干上**没有任何环路/深度守卫**：互相派生的 Transform、互相依赖的 dict 计算，声明期零告警、运行期无任何报错地挂起（实测 setup 挂满 120s 超时）或无限创建记录。
+2. **引用同一性绑定的查询语义**——`resolve` 只在 `args.action === GetAction`（单例引用相等）时挂载。GetAction 的 uuid 每进程随机，序列化 round-trip 重建的 Action 对象必然 `!==` 单例；用户自建 `Action.create({name:'get'})` 同理——声明看起来是查询交互，dispatch 却静默返回 `data: undefined`。
+3. 另有 r10 F-3 的直接延伸：json 列的 `in`/`not in` 与 `=`/`!=` 同病（写路径序列化、匹配参数裸绑定），PGLite 裸报数据库错误、SQLite 直接崩（数组参数被展开成多余绑定参数）。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修） | 3 | 计算传播环无守卫、GetAction 引用同一性绑定、json IN/NOT IN 断裂 |
+| 重要（已复现，已修） | 4 | 见第三节 |
+| 证伪/重新归类 | 4 | 见第五节 |
+| 重要（精读/探查，高置信度，未修） | 8 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认，本轮已修复）
+
+### F-1 计算传播无环路/深度守卫：循环依赖声明 → 无报错的死循环/无限增长
+
+- 位置：`src/runtime/Scheduler.ts` `buildComputationMutationListener`（计算写回 `applyResult/applyResultPatch` → `callWithEvents` → `dispatch` → 同一 listener 同步重入，无 visited/depth/批次延迟任何机制）；`src/runtime/ComputationSourceMap.ts` `initialize`（自引用 dataDep 无声明期校验）。
+- 复现（实测输出）：
+
+```
+// 互相派生的 Transform：Entity A 由 B 派生，B 由 A 派生
+create('A', {label:'seed'}) → 回调无限执行（测试用 30 次上限抛错才终止）  ❌ 无守卫
+// 互相依赖的 dict：X 依赖 Y、Y 依赖 X（或 X 依赖自身）
+controller.setup(true) → 挂满 120s 测试超时，无任何报错                  ❌ setup 死锁
+```
+
+- 影响：AGENTS.md 只有一句 "Avoid circular computation dependencies" 的提醒；migration 有静态环检测（`migration.ts` L2216）但只在迁移期生效。运行期一旦命中：Transform 环 = 每跳创建新记录（事务内无限增长直至 OOM/参数上限），dict 环 = 无限重算挂起。与 r10 F-1（空 ActivityGroup 死锁）同族——「类型系统接受但运行时死锁」，且这条比 Activity 更隐蔽：跨实体的派生链在大模型里靠人工审查几乎不可能发现。
+- 修复（双层）：
+  1. **声明期**：dict 计算把自己的输出声明为 global dataDep（直接自引用）在 source-map 初始化时抛 `ComputationProtocolError`（指引改用 `useLastValue`/`GlobalBoundState`）；
+  2. **运行期**：mutation listener 用 `AsyncLocalStorage` 记录传播深度（并发事务互不串扰），超过 `Scheduler.MAX_COMPUTATION_PROPAGATION_DEPTH`（100，对合法深链留充足余量）时抛出带最近传播轨迹（最近若干个计算名）的 `SchedulerError`。间接环（X→Y→X、Transform 互相派生）由此层兜住。
+  3. 正向回归：合法的两跳链（Transform 派生 + 计数）无误报。
+
+### F-2 json/collection 列的 `IN` / `NOT IN`：与 r10 F-3 的 `=`/`!=` 同病，且 SQLite 上直接崩
+
+- 位置：`src/storage/erstorage/MatchExp.ts` `getFinalFieldValue` 的 `in`/`not in` 分支（元素参数原样绑定）；对照写路径 `SQLBuilder.prepareFieldValue`（一律 `JSON.stringify`）。
+- 复现（实测输出）：
+
+```
+Property.create({ name:'tags', type:'string', collection:true })
+find('Doc', MatchExp.atom({ key:'tags', value:['in', [['alpha','beta']]] }))
+→ PGLite: error: operator does not exist: json = unknown        ❌ 裸数据库错误
+→ SQLite: RangeError: Too many parameter values were provided   ❌ 数组参数被 better-sqlite3 展开，直接崩
+```
+
+- 影响：r10 F-3 修了 `=`/`!=` 后，「按快照集合查 json 列」的下一个自然写法（`in`）仍然全链路断裂，且 SQLite 上是崩溃而非零命中。
+- 修复：与 r10 F-3 同一治理模板——`MatchExp` 对 json 字段的 `in`/`not in` 先给驱动方言机会、否则退化为与写路径一致的逐元素序列化文本比较；PG/PGLite `parseMatchExpression` 新增逐元素 `::jsonb` 语义比较（键序不敏感），MySQL 新增 `CAST(? AS JSON)`。NULL 行不参与匹配（与 `=`/`!=` 一致）。空数组的恒 false/true 表达式对 json 列避开 `IN (NULL)`（PG 系会触发 json 比较操作符）。PGLite/SQLite 双驱动 + 空数组回归用例。
+
+### F-3 GetAction 按引用同一性绑定 resolve：round-trip / 自建 'get' Action 的查询交互静默返回 undefined
+
+- 位置：`src/builtins/interaction/Interaction.ts` L172（`if (args.action === GetAction)`）；`src/builtins/interaction/Action.ts` L87（`GetAction = Action.create({name:'get'})`，uuid 每进程随机）。
+- 复现（实测输出）：
+
+```
+// 形态一：用户自建同名 Action
+Interaction.create({ action: Action.create({name:'get'}), data: Post, dataPolicy: ... })
+dispatch → { error: undefined, data: undefined }                ❌ 声明形似查询、静默无数据
+
+// 形态二：graph round-trip（uuid 保留但对象重建）
+stringifyAllInstances → clearAllInstances → createInstances
+→ restored.action.uuid === GetAction.uuid 为 true，restored.resolve === undefined  ❌ resolve 静默丢失
+```
+
+- 影响：形态二意味着**任何**经过序列化管线（migration manifest、代码生成、跨进程传输）的查询交互都会静默失去查询能力——r8 已把 Payload/DataPolicy/EventSource 纳入 round-trip 治理，但 GetAction 的单例身份从未被审视。形态一是 r7 I-10（data/dataPolicy 挂非 get action 静默失效）的对偶：get 形状的 action 也可以静默失效。
+- 修复：查询语义按 `action.name === 'get'` 识别（名字是序列化中稳定的身份，引用不是）；并把 r7 I-10 一并收口——`data`/`dataPolicy` 挂在非 get action 上声明期 fail-fast。既有测试 `queryDataInteraction.spec.ts` 的「非 GetAction 不返回数据」用例改为断言声明期错误（该用例此前固化的正是静默失效行为）。round-trip 回归：反序列化后的 get 交互 `resolve` 正常重建。
+
+---
+
+## 三、重要问题（已复现，本轮已修复）
+
+### R-1 Controller 同名 eventSource：静默后写覆盖先写
+
+- 位置：`src/runtime/Controller.ts` L190–195（`eventSourcesByName.set` 无重复检测）。
+- 复现：两个同名 Interaction（不同守卫链）注册进同一 Controller → `findEventSourceByName` 只命中最后注册者，先注册者的 guard/权限链从此不可达，零告警。Activity 名重复（`ActivityManager` L79）与 entity/relation 名重复（`Setup.ts`）早有 fail-fast，eventSource 是最后一个无守卫的注册表。
+- 修复：构造期对「不同实例、相同名字」抛错；同一实例重复注册保持合法。Activity 内的 interaction 以 `activity:interaction` 作用域名注册，不受影响。
+
+### R-2 零触发的 RealTime 计算：声明合法、callback 永不执行、property 形态静默持久化 0
+
+- 位置：`src/runtime/computations/RealTime.ts`——property 形态无 `attributeQuery` 且无 `dataDeps` 时 `dataDeps={}`，注册不出任何监听；`getInitialValue()` 返回 0 被宿主 create 监听持久化。global 形态同理（值永远停在 null）。
+- 复现：纯时间驱动的 property RealTime（只有 `nextRecomputeTime` + `callback`）→ 实测 `callbackRuns === 0`、`liveSeconds === 0` 永不变化。
+- 背景：时间驱动的重算调度器尚未实现（r3 R-5 遗留，`nextRecomputeTime` 只被记录、无消费方）——纯时间驱动形态是「声明合法、永不可用」的死配置，且 property 形态还主动写入误导性的 0。
+- 修复：两个 handle 构造期 fail-fast，错误信息明确说明「时间调度未实现，需声明 attributeQuery/dataDeps」。调度器落地后此校验应放宽。
+
+### R-3 操作符大小写：`['LIKE', ...]` 落入内部 assert
+
+- 位置：`src/storage/erstorage/MatchExp.ts` L226–229——simpleOp 表精确匹配小写 `'like'`，而 `in`/`not in`/`between` 早已 `toLowerCase()`，口径不一致。大写 `LIKE` 穿透到末尾 `assert(result, 'unknown value expression ...')`。
+- 复现：`value: ['LIKE', '%hello%']` → `Error: unknown value expression ["LIKE","%hello%"]`。
+- 修复：simpleOp 统一按小写归一识别；大小写 LIKE 双回归。
+
+### R-4 `between` 操作数不校验：畸形值裸 TypeError
+
+- 复现：`value: ['between', 25]` → 深入 `value[1][0]` 抛裸错。`in` 早有 `Array.isArray` 守卫（r5 I-1），`between` 漏了。
+- 修复：非两元数组给出带指引的受控错误；合法 between 正向回归。
+
+---
+
+## 四、重要问题（探查/精读判定，高置信度，本轮未修）
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | **`storage.listen` 的用户回调在事务提交前执行**：dispatch 后续失败回滚时，框架内监听的写入随事务回滚，但用户回调已产生的外部副作用（webhook、日志、消息队列）不会 | `MonoSystem.ts` `callWithEvents` L1146–1171（listener 在 `runInTransaction` 内同步 await）对照 `Controller.ts` L734+（`RecordMutationSideEffect` 明确 post-commit） | 需要外部副作用的场景应使用 `RecordMutationSideEffect`（post-commit 语义有测试固化）。建议在知识库明确「listen = 事务内、可能随回滚作废；SideEffect = 提交后」的契约分工 |
+| I-2 | 同一 source 的多条 records dataDeps：一次 mutation 每个 dep 各触发一次 incrementalCompute（本轮实测同一 create 事件双跑、计数翻倍） | `ComputationSourceMap.ts` L151–154 每 dep 独立注册；`Custom.ts` L218–222 注释确认「任何已声明 dataDep 的事件都会走到 incrementalCompute」是既定契约 | 契约成立但极易踩坑：用户可按 `event.dataDep` 区分来源，但这一点只存在于源码注释。建议知识库 Custom 增量一节明确「每 (dataDep, event) 一次调用」并给出去重范式；对**完全相同**的 dep 声明（同 source 同 attributeQuery 同 match）可考虑注册期去重 |
+| I-3 | `RecordMutationCallback` 返回的 `{events}` 被累积进 effects 但**从不回喂 listener**：监听器合成的事件不会触发任何计算 | `MonoSystem.ts` `dispatch` L1205–1213（`newEvents` 只 push 不再 dispatch）；`System.ts` L10 类型契约允许返回 events | 仓库内无消费方（死 API）。要么实现回喂（需接入 F-1 的深度守卫），要么从类型契约中移除返回值，避免下游按契约实现后静默失效 |
+| I-4 | `RecordMutationSideEffect` 对 effects 里**所有**事件触发（含计算驱动的 update、bound-state 列写入），不区分业务写入 | `Controller.ts` `runRecordChangeSideEffects` L779+ | 对 `User` 声明的副作用会被 `likeCount` 这类计算列更新触发，外部 IO 次数放大。与 r5 R-8（同名结果覆盖）正交。建议文档化或提供事件过滤声明 |
+| I-5 | `isRef` payload 守卫只做存在性校验（按 id `findOne`），无行级授权：能通过 user 门槛的调用方可以引用该实体的**任意**存量 id | `Interaction.ts` L458–474 | 行级授权的正确出口是 attributive/DerivedConcept base，但「裸 Entity base + isRef = 存在即通过」这一点未在知识库风险提示。属 r7 I-14 弱校验族的安全切面，建议文档显式警告 IDOR 形态 |
+| I-6 | ScopedSequence `allowManualValue`：手工值不推进计数器（`scopedSequence.spec.ts` 已固化该语义）——手工值落在自动分配区间内时，后续自动分配产生重复序号；无 UniqueConstraint 时是静默重复 | `computations/ScopedSequence.ts` L54–58；`MonoSystem.ts` `nextSequenceValue` | 语义是深思后的选择（导入历史高位号不应跳空自动区间），但安全网只有「建议声明 UniqueConstraint」的惯例。建议声明期要求（或强烈建议）宿主对 scope+serial 声明 UniqueConstraint，或文档明确风险 |
+| I-7 | ScopedSequence scope path 若读取「create 载荷之外、由 reliance/link 后置合并的字段」，分配时读到的是 create 事件的早期快照 → `scope is missing` 或错误 scope | `CreationExecutor.ts` L180–188（事件快照先于 reliance 合并）；`Scheduler.ts` L344 传 `mutationEvent.record` | 中高置信度（事件时序已核实、现有测试全部把 scope 字段放在 payload）。建议文档明确「scope 字段必须在 create 载荷内」或对缺失字段给出指向该约束的错误 |
+| I-8 | Klass `static public.*.constraints` 是死元数据：如 `Entity.public.properties.constraints.eachNameUnique` 从不在 `create()` 执行，重复属性名的实体声明成功、错误延迟到 storage 深处 | `Entity.ts` L76–80 对照 `create()` L133+ | r7 I-13（未知参数静默丢弃）的姊妹项：已知约束也不执行。建议 `createClass` 层统一执行 public.constraints，一次性根治 |
+
+另有低优先级项（本轮探查发现、影响面小）：`objectstorage/objectStorage.js` 将 `rawFileName` 直传应用的 `makePath`（信任边界未文档化）；批量 1:n 分组用原始 `Map` 键（父子 id 类型分歧时静默丢子行，现实触发面窄，可用 `String()` 归一化根治）；`dataPolicy.modifier` 只在声明 `limit` 时锁定调用方分页键（r7 F-3 的残余语义，policy 只声明 orderBy 时不构成可见范围约束）。
+
+## 五、本轮证伪/重新归类的候选
+
+| 候选 | 结论 |
+|------|------|
+| 「`initializeFrom.scope[].path` 与声明 scope 的 path 不一致 → 迁移种子错桶」（ScopedSequence 探查） | 证伪：initializer 的 path 映射进的是 `initializeFrom.record`（历史遗留实体）的字段，与运行期宿主 scope path 本就应当不同，跨记录的路径等价性无法也不应静态校验 |
+| 「GetAction 单例不在序列化 blob 中 → 反序列化抛 Cannot resolve reference」 | 重新归类：fail-closed 的正确行为（引用完整性校验），非 bug；真正的问题是 blob 完整时 resolve 仍丢失，已作为 F-3 修复 |
+| 「property RealTime 首次 create 持久化错误的 0」（RealTime 探查 #4） | 归并进 R-2：根因是零触发死配置，fail-fast 后该形态不再可声明；有 attributeQuery/dataDeps 的形态首次 create 会执行 compute，无此问题 |
+| 「Activity 首步 guard 不接 `checkUserRef`」（builtins 探查 #6） | 与 r8 §四已记录项重复，去重剔除 |
+
+## 六、既有遗留项复确（r2–r10 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4 I-1）；`!=` 三值逻辑；dispatch 先持久化事件再 resolve（r9 I-2）；守卫非 boolean truthy 放行（r9 I-4）；payload 弱校验族 / `userRef`/`itemRef` 死 API（r7）；StateMachine 单事件单跳（r7 I-8）；同批 property 计算无拓扑序（r7 I-9）。
+- **性能/资源**：global dict 变更宿主全表扫描；async task 表只增不减；级联无深度上限（注：F-1 的传播深度守卫覆盖了其中「计算传播」一翼，storage 级联删除仍无上限）；迁移锁无租约。
+- **并发**：activity `refs` 无版本 read-modify-write（r5 I-12）。
+- **migration**：rename = remove+add（r9 I-3）；I-1/I-2（r10 未修项：迁移阶段顺序、merged input 移除孤儿数据）仍在。
+- **时间调度**：`nextRecomputeTime` 无消费方（r3 R-5）——R-2 的 fail-fast 使这一缺口从「静默」变为「显式」，实现调度器后应放宽。
+
+## 七、修复优先级建议（遗留项）
+
+1. **I-1 `storage.listen` 事务语义文档化**——外部副作用误挂 listen 是数据一致性事故的直接来源，一段知识库文档即可消除；
+2. **r10 I-1 迁移阶段顺序**（连续两轮位居榜首的未修项）——唯一可能产出「静默错误聚合值」的已知路径；
+3. **I-8 public.constraints 统一执行**——与 r7 I-13 合并做一次 `createClass` 层的声明校验收口，能同时消灭一族「声明期静默接受」问题；
+4. I-2/I-3/I-4 事件契约收口（Custom 多依赖触发口径、listener 返回值死 API、SideEffect 触发面）——同属「mutation 事件消费契约」，适合一轮集中治理；
+5. I-6/I-7 ScopedSequence 使用面防护（改动小，文档为主）。
+
+## 附录：复现要点（验证用）
+
+- F-1：互相派生的 Transform → `create` 应抛 `propagation exceeded the maximum depth`；dict 自引用 dataDep → setup 应抛 `references the computation's own output`；X→Y→X 间接环 → setup 应抛深度错误；合法两跳链不误报。
+- F-2：collection 属性 `['in', [['alpha','beta']]]` → PGLite/SQLite 均应正确命中快照；`not in` 排除且 NULL 行不参与；空数组恒 false/true。
+- F-3：`Action.create({name:'get'})` + data → dispatch 应返回数据；data 挂非 get action → 声明期错误；round-trip 后 `resolve` 应存在。
+- R-1：两个同名 eventSource → Controller 构造期抛 `Duplicate eventSource name`。
+- R-2：无 attributeQuery/dataDeps 的 RealTime（property/global）→ 构造期错误。
+- R-3/R-4：`['LIKE','%x%']` 应正常命中；`['between', 25]` 应抛 two-element array 错误。

--- a/agentspace/output/deep-review-2026-07-09-r11.md
+++ b/agentspace/output/deep-review-2026-07-09-r11.md
@@ -6,7 +6,7 @@
 - 方法：与 r1–r10 报告**逐条去重** → 对每个致命/重要候选**编写最小复现测试实际运行**（PGLiteDB/SQLiteDB）。只有「已运行复现确认」的问题列为致命/重要；证伪或重新归类的候选明确记录（见第五节）。
 - 基线健康度：`npm run check` 通过；`npm test` 全量 1795 passed / 26 skipped。
 
-> **维护说明（2026-07-09）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r11-5327`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-09-r11.spec.ts`（10 用例）+ `tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts`（1 用例）+ `tests/storage/review-fixes-2026-07-09-r11.spec.ts`（6 用例）。修复后 `npm run check` 通过；`npm test` 全量 **1812 passed / 26 skipped**。顺带修正 4 处被新 fail-fast 暴露的既有测试反模式（`queryDataInteraction.spec.ts` / `core-domain-refactored.spec.ts` / `ignorePermission.spec.ts` / `computationEdgeCases.spec.ts` 均在非 get action 上声明 data——此前静默失效，现改为 get action 或删除死配置并断言声明期错误）。另按 I-1 在知识库 `generator/api-reference.md` 补充 `storage.listen` 事务语义（事务内、pre-commit）与 `RecordMutationSideEffect`（post-commit）的契约分工。
+> **维护说明（2026-07-09，2026-07-10 按评审意见修订 F-3 设计）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r11-5327`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-09-r11.spec.ts`（12 用例）+ `tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts`（2 用例）+ `tests/storage/review-fixes-2026-07-09-r11.spec.ts`（6 用例）。修复后 `npm run check` 通过；`npm test` 全量 **1815 passed / 26 skipped**。顺带修正 4 处被新 fail-fast 暴露的既有测试反模式（`queryDataInteraction.spec.ts` / `core-domain-refactored.spec.ts` / `ignorePermission.spec.ts` / `computationEdgeCases.spec.ts` 均在非 get action 上声明 data——此前静默失效，现改为 get action 或删除死配置并断言声明期错误）。另按 I-1 在知识库 `generator/api-reference.md` 补充 `storage.listen` 事务语义（事务内、pre-commit）与 `RecordMutationSideEffect`（post-commit）的契约分工。
 
 ---
 
@@ -78,7 +78,11 @@ stringifyAllInstances → clearAllInstances → createInstances
 ```
 
 - 影响：形态二意味着**任何**经过序列化管线（migration manifest、代码生成、跨进程传输）的查询交互都会静默失去查询能力——r8 已把 Payload/DataPolicy/EventSource 纳入 round-trip 治理，但 GetAction 的单例身份从未被审视。形态一是 r7 I-10（data/dataPolicy 挂非 get action 静默失效）的对偶：get 形状的 action 也可以静默失效。
-- 修复：查询语义按 `action.name === 'get'` 识别（名字是序列化中稳定的身份，引用不是）；并把 r7 I-10 一并收口——`data`/`dataPolicy` 挂在非 get action 上声明期 fail-fast。既有测试 `queryDataInteraction.spec.ts` 的「非 GetAction 不返回数据」用例改为断言声明期错误（该用例此前固化的正是静默失效行为）。round-trip 回归：反序列化后的 get 交互 `resolve` 正常重建。
+- 修复（评审后定稿：绑定在**显式导出常量的固定身份**上，而不是名字上——`'get'` 是常用词，用户自建同名 Action 不应在不知情的情况下获得查询语义）：
+  1. `GetAction` 单例改用固定 uuid（导出常量 `GET_ACTION_UUID = 'interaqt:builtin:action:get'`），查询语义按该 uuid 识别。固定 uuid 随序列化保留，round-trip / 跨进程后身份仍可识别；普通 Action 的 uuid 是进程内递增值，不会与之冲突；
+  2. `Action.create` 对该固定 uuid 幂等：注册表里已有单例时直接返回它（反序列化路径不再撞 duplicate uuid，且 restored.action 回到同一个单例）；固定 uuid 配非 'get' 名字属于损毁数据，fail-fast；
+  3. r7 I-10 一并收口——`data`/`dataPolicy` 挂在非 GetAction 上声明期 fail-fast，错误信息指引 `import { GetAction } from 'interaqt'`；action 恰好名为 'get' 时额外提示「同名不等于查询 action」。
+- 测试矩阵连带修正：`queryDataInteraction.spec.ts` 的「非 GetAction 不返回数据」用例改为断言声明期错误（此前固化的正是静默失效行为）；`core-domain-refactored.spec.ts` / `ignorePermission.spec.ts` / `computationEdgeCases.spec.ts` 三处在非 get action 上声明 data 的死配置分别改用 GetAction 常量或删除。round-trip 回归覆盖「注册表未清空（幂等复用单例）」与「冷注册表（模拟跨进程）」两种形态。知识库 `generator/api-reference.md` 与 `usage/18-api-exports-reference.md` 明确「查询语义来自导出常量，同名自建 Action 无效」。
 
 ---
 
@@ -154,7 +158,7 @@ stringifyAllInstances → clearAllInstances → createInstances
 
 - F-1：互相派生的 Transform → `create` 应抛 `propagation exceeded the maximum depth`；dict 自引用 dataDep → setup 应抛 `references the computation's own output`；X→Y→X 间接环 → setup 应抛深度错误；合法两跳链不误报。
 - F-2：collection 属性 `['in', [['alpha','beta']]]` → PGLite/SQLite 均应正确命中快照；`not in` 排除且 NULL 行不参与；空数组恒 false/true。
-- F-3：`Action.create({name:'get'})` + data → dispatch 应返回数据；data 挂非 get action → 声明期错误；round-trip 后 `resolve` 应存在。
+- F-3：`GetAction` 常量 + data → dispatch 应返回数据；`Action.create({name:'get'})` 不获得查询语义（+ data 时声明期错误并提示导入 GetAction）；round-trip 后 `resolve` 应存在且 action 幂等复用单例；`Action.create({name:'x'}, {uuid: GET_ACTION_UUID})` 应被拒绝。
 - R-1：两个同名 eventSource → Controller 构造期抛 `Duplicate eventSource name`。
 - R-2：无 attributeQuery/dataDeps 的 property RealTime → 构造期错误；同形态 global RealTime 保持合法。
 - R-3/R-4：`['LIKE','%x%']` 应正常命中；`['between', 25]` 应抛 two-element array 错误。

--- a/agentspace/output/deep-review-2026-07-09-r11.md
+++ b/agentspace/output/deep-review-2026-07-09-r11.md
@@ -6,7 +6,7 @@
 - 方法：与 r1–r10 报告**逐条去重** → 对每个致命/重要候选**编写最小复现测试实际运行**（PGLiteDB/SQLiteDB）。只有「已运行复现确认」的问题列为致命/重要；证伪或重新归类的候选明确记录（见第五节）。
 - 基线健康度：`npm run check` 通过；`npm test` 全量 1795 passed / 26 skipped。
 
-> **维护说明（2026-07-09）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r11-5327`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-09-r11.spec.ts`（10 用例）+ `tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts`（1 用例）+ `tests/storage/review-fixes-2026-07-09-r11.spec.ts`（6 用例）。顺带修正 2 处被新 fail-fast 暴露的既有测试（`queryDataInteraction.spec.ts` 的 data-on-non-get 用例改为断言声明期错误；`review-fixes-2026-07.spec.ts` 的 RealTime 守卫用例补占位 dataDep）。
+> **维护说明（2026-07-09）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r11-5327`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-09-r11.spec.ts`（10 用例）+ `tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts`（1 用例）+ `tests/storage/review-fixes-2026-07-09-r11.spec.ts`（6 用例）。修复后 `npm run check` 通过；`npm test` 全量 **1812 passed / 26 skipped**。顺带修正 4 处被新 fail-fast 暴露的既有测试反模式（`queryDataInteraction.spec.ts` / `core-domain-refactored.spec.ts` / `ignorePermission.spec.ts` / `computationEdgeCases.spec.ts` 均在非 get action 上声明 data——此前静默失效，现改为 get action 或删除死配置并断言声明期错误）。另按 I-1 在知识库 `generator/api-reference.md` 补充 `storage.listen` 事务语义（事务内、pre-commit）与 `RecordMutationSideEffect`（post-commit）的契约分工。
 
 ---
 
@@ -90,12 +90,12 @@ stringifyAllInstances → clearAllInstances → createInstances
 - 复现：两个同名 Interaction（不同守卫链）注册进同一 Controller → `findEventSourceByName` 只命中最后注册者，先注册者的 guard/权限链从此不可达，零告警。Activity 名重复（`ActivityManager` L79）与 entity/relation 名重复（`Setup.ts`）早有 fail-fast，eventSource 是最后一个无守卫的注册表。
 - 修复：构造期对「不同实例、相同名字」抛错；同一实例重复注册保持合法。Activity 内的 interaction 以 `activity:interaction` 作用域名注册，不受影响。
 
-### R-2 零触发的 RealTime 计算：声明合法、callback 永不执行、property 形态静默持久化 0
+### R-2 零触发的 property RealTime：声明合法、callback 永不执行、每次 create 静默持久化 0
 
-- 位置：`src/runtime/computations/RealTime.ts`——property 形态无 `attributeQuery` 且无 `dataDeps` 时 `dataDeps={}`，注册不出任何监听；`getInitialValue()` 返回 0 被宿主 create 监听持久化。global 形态同理（值永远停在 null）。
+- 位置：`src/runtime/computations/RealTime.ts`——property 形态无 `attributeQuery` 且无 `dataDeps` 时 `dataDeps={}`，注册不出任何监听；`getInitialValue()` 返回 0 被宿主 create 监听持久化。
 - 复现：纯时间驱动的 property RealTime（只有 `nextRecomputeTime` + `callback`）→ 实测 `callbackRuns === 0`、`liveSeconds === 0` 永不变化。
-- 背景：时间驱动的重算调度器尚未实现（r3 R-5 遗留，`nextRecomputeTime` 只被记录、无消费方）——纯时间驱动形态是「声明合法、永不可用」的死配置，且 property 形态还主动写入误导性的 0。
-- 修复：两个 handle 构造期 fail-fast，错误信息明确说明「时间调度未实现，需声明 attributeQuery/dataDeps」。调度器落地后此校验应放宽。
+- 背景：时间驱动的重算调度器尚未实现（r3 R-5 遗留，`nextRecomputeTime` 只被记录、无消费方）——纯时间驱动的 property 形态是「声明合法、永不可用」的死配置，且每个新记录都被主动写入误导性的 0。
+- 修复：property handle 构造期 fail-fast，错误信息明确说明「时间调度未实现，需声明 attributeQuery/dataDeps」。**global 形态保持合法**：migration rebuild 是 global computation 的合法触发路径（`migration.spec.ts` 的 RealTime 迁移用例依赖零 dataDeps 的 global RealTime 在迁移期全量重算），且 global 形态不会写入误导性初值（保持 null）。调度器落地后 property 校验应放宽。
 
 ### R-3 操作符大小写：`['LIKE', ...]` 落入内部 assert
 
@@ -156,5 +156,5 @@ stringifyAllInstances → clearAllInstances → createInstances
 - F-2：collection 属性 `['in', [['alpha','beta']]]` → PGLite/SQLite 均应正确命中快照；`not in` 排除且 NULL 行不参与；空数组恒 false/true。
 - F-3：`Action.create({name:'get'})` + data → dispatch 应返回数据；data 挂非 get action → 声明期错误；round-trip 后 `resolve` 应存在。
 - R-1：两个同名 eventSource → Controller 构造期抛 `Duplicate eventSource name`。
-- R-2：无 attributeQuery/dataDeps 的 RealTime（property/global）→ 构造期错误。
+- R-2：无 attributeQuery/dataDeps 的 property RealTime → 构造期错误；同形态 global RealTime 保持合法。
 - R-3/R-4：`['LIKE','%x%']` 应正常命中；`['between', 25]` 应抛 two-element array 错误。

--- a/src/builtins/interaction/Action.ts
+++ b/src/builtins/interaction/Action.ts
@@ -36,6 +36,18 @@ export class Action implements ActionInstance {
   };
 
   static create(args: ActionCreateArgs, options?: { uuid?: string }): ActionInstance {
+    // GetAction 单例的幂等重建：反序列化（createInstances）会带着固定 uuid 重新 create。
+    //  注册表里已有该单例时直接返回它（而不是抛 duplicate uuid），保证 round-trip 后
+    //  引用仍然指向同一个查询 action 身份。名字必须是 'get'——固定 uuid 是查询语义的
+    //  唯一标识，挂其他名字属于损毁的序列化数据，fail-fast。
+    if (options?.uuid === GET_ACTION_UUID) {
+      if (args.name !== 'get') {
+        throw new Error(`Action with the reserved GetAction uuid must be named "get", got "${args.name}". The GET_ACTION_UUID identity is reserved for the built-in query action.`);
+      }
+      const existingGetAction = this.instances.find(i => i.uuid === GET_ACTION_UUID);
+      if (existingGetAction) return existingGetAction;
+    }
+
     const instance = new Action(args, options);
     
     // 检查 uuid 是否重复
@@ -83,7 +95,16 @@ export class Action implements ActionInstance {
 // 导出类型，保持兼容性
 export type { Action as ActionKlass };
 
-// 导出 GetAction 实例
-export const GetAction = Action.create({ name: 'get' });
+// GetAction 的固定 uuid：查询语义的唯一身份标识。
+// CAUTION 查询语义必须绑定在跨序列化稳定的身份上：
+//  - 不能按引用同一性（round-trip 重建的 Action 对象 `===` 判定必然失败，resolve 静默丢失）；
+//  - 也不能按 name === 'get'（'get' 是常用词，用户自建同名 Action 会在不知情的情况下
+//    获得/被期望获得查询语义）。
+//  固定 uuid 随序列化保留，跨进程/round-trip 后仍可识别；普通 Action 的 uuid 是
+//  进程内递增值，不会与之冲突。
+export const GET_ACTION_UUID = 'interaqt:builtin:action:get';
+
+// 导出 GetAction 实例——声明查询交互（data/dataPolicy）时必须使用这个常量。
+export const GetAction = Action.create({ name: 'get' }, { uuid: GET_ACTION_UUID });
 
  

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -156,6 +156,16 @@ export class Interaction implements InteractionInstance {
     if (Attributives.is(args.userAttributives) && !args.userAttributives.content) {
       throw new Error(`Interaction "${args.name}" declares userAttributives with an Attributives instance that has no content. Provide content (an Attributive BoolExp), or omit the userAttributives field.`);
     }
+    // CAUTION 查询语义按 action 的 name（'get'）识别，不能按 GetAction 单例的引用同一性识别：
+    //  序列化 round-trip（createInstances 会重建 uuid 相同但对象不同的 Action 实例）和用户自建的
+    //  Action.create({ name: 'get' }) 都会让 `===` 判定失败——声明看起来是查询交互，
+    //  dispatch 却静默返回 data: undefined。
+    const isGetAction = args.action?.name === GetAction.name;
+    // fail-fast：data/dataPolicy 只在 get 语义下被消费。挂在非 get action 上是合法声明、
+    //  永不生效的死配置（dispatch 成功但永远不返回数据），必须在声明期拒绝。
+    if (!isGetAction && (args.data !== undefined || args.dataPolicy !== undefined)) {
+      throw new Error(`Interaction "${args.name}" declares data/dataPolicy but its action "${args.action?.name}" is not the query action. Only interactions with GetAction (action name "get") retrieve data; remove data/dataPolicy or use GetAction.`);
+    }
 
     const instance = new Interaction(args, options);
     
@@ -169,7 +179,7 @@ export class Interaction implements InteractionInstance {
     instance.guard = buildInteractionGuard(instance);
     instance.mapEventData = buildInteractionMapEventData(instance);
 
-    if (args.action === GetAction) {
+    if (isGetAction) {
       instance.resolve = buildInteractionResolve(instance);
     }
     

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -5,7 +5,7 @@ import {
     stringifyInstance, decodeFunctionValues
 } from '@core';
 import type { Controller } from '@runtime';
-import { ActionInstance, GetAction } from './Action.js';
+import { ActionInstance, GET_ACTION_UUID } from './Action.js';
 import { ConditionInstance } from './Condition.js';
 import { ConditionsInstance, Conditions } from './Conditions.js';
 import { AttributiveInstance, AttributivesInstance, Attributive, Attributives } from './Attributive.js';
@@ -156,15 +156,19 @@ export class Interaction implements InteractionInstance {
     if (Attributives.is(args.userAttributives) && !args.userAttributives.content) {
       throw new Error(`Interaction "${args.name}" declares userAttributives with an Attributives instance that has no content. Provide content (an Attributive BoolExp), or omit the userAttributives field.`);
     }
-    // CAUTION 查询语义按 action 的 name（'get'）识别，不能按 GetAction 单例的引用同一性识别：
-    //  序列化 round-trip（createInstances 会重建 uuid 相同但对象不同的 Action 实例）和用户自建的
-    //  Action.create({ name: 'get' }) 都会让 `===` 判定失败——声明看起来是查询交互，
-    //  dispatch 却静默返回 data: undefined。
-    const isGetAction = args.action?.name === GetAction.name;
-    // fail-fast：data/dataPolicy 只在 get 语义下被消费。挂在非 get action 上是合法声明、
+    // CAUTION 查询语义按 GetAction 的固定 uuid（GET_ACTION_UUID）识别：
+    //  - 不能按引用同一性（args.action === GetAction）：序列化 round-trip 重建的 Action
+    //    对象 `===` 判定必然失败，resolve 静默丢失、dispatch 返回 data: undefined；
+    //  - 也不能按 name === 'get'：'get' 是常用词，用户自建同名 Action 不应在不知情的
+    //    情况下获得查询语义。固定 uuid 随序列化保留，是跨进程稳定的显式身份。
+    const isGetAction = args.action?.uuid === GET_ACTION_UUID;
+    // fail-fast：data/dataPolicy 只在查询语义下被消费。挂在非 GetAction 上是合法声明、
     //  永不生效的死配置（dispatch 成功但永远不返回数据），必须在声明期拒绝。
     if (!isGetAction && (args.data !== undefined || args.dataPolicy !== undefined)) {
-      throw new Error(`Interaction "${args.name}" declares data/dataPolicy but its action "${args.action?.name}" is not the query action. Only interactions with GetAction (action name "get") retrieve data; remove data/dataPolicy or use GetAction.`);
+      const namedGetHint = args.action?.name === 'get'
+        ? ` An Action merely named "get" is not the query action.`
+        : '';
+      throw new Error(`Interaction "${args.name}" declares data/dataPolicy but its action "${args.action?.name}" is not the built-in query action.${namedGetHint} Import { GetAction } from 'interaqt' and declare action: GetAction, or remove data/dataPolicy.`);
     }
 
     const instance = new Interaction(args, options);

--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -210,6 +210,16 @@ export class MysqlDB implements Database{
                     fieldParams: [JSON.stringify(value[1])]
                 }
             }
+            // IN / NOT IN 与 =/!= 同理：逐元素 CAST 成 JSON 做语义比较。NULL 行不参与匹配。
+            const lowerOp = value[0].toLowerCase()
+            if ((lowerOp === 'in' || lowerOp === 'not in') && Array.isArray(value[1]) && value[1].length > 0) {
+                const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                const placeholders = (value[1] as unknown[]).map(() => `CAST(${p()} AS JSON)`).join(',')
+                return {
+                    fieldValue: `IS NOT NULL AND ${fieldNameWithQuotes} ${lowerOp === 'in' ? 'IN' : 'NOT IN'} (${placeholders})`,
+                    fieldParams: (value[1] as unknown[]).map(item => JSON.stringify(item))
+                }
+            }
         }
     }
 

--- a/src/drivers/PGLite.ts
+++ b/src/drivers/PGLite.ts
@@ -218,6 +218,16 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
                     fieldParams: [JSON.stringify(value[1])]
                 }
             }
+            // IN / NOT IN 与 =/!= 同理：逐元素做 jsonb 语义比较。NULL 行不参与匹配。
+            const lowerOp = value[0].toLowerCase()
+            if ((lowerOp === 'in' || lowerOp === 'not in') && Array.isArray(value[1]) && value[1].length > 0) {
+                const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                const placeholders = (value[1] as unknown[]).map(() => `${p()}::jsonb`).join(',')
+                return {
+                    fieldValue: `IS NOT NULL AND ${fieldNameWithQuotes}::jsonb ${lowerOp === 'in' ? 'IN' : 'NOT IN'} (${placeholders})`,
+                    fieldParams: (value[1] as unknown[]).map(item => JSON.stringify(item))
+                }
+            }
         }
     }
 

--- a/src/drivers/PostgreSQL.ts
+++ b/src/drivers/PostgreSQL.ts
@@ -361,6 +361,16 @@ CREATE TABLE IF NOT EXISTS "_ScopedSequence_" (
                     fieldParams: [JSON.stringify(value[1])]
                 }
             }
+            // IN / NOT IN 与 =/!= 同理：逐元素做 jsonb 语义比较。NULL 行不参与匹配。
+            const lowerOp = value[0].toLowerCase()
+            if ((lowerOp === 'in' || lowerOp === 'not in') && Array.isArray(value[1]) && value[1].length > 0) {
+                const fieldNameWithQuotes = fieldName.split('.').map(x => `"${x}"`).join('.')
+                const placeholders = (value[1] as unknown[]).map(() => `${p()}::jsonb`).join(',')
+                return {
+                    fieldValue: `IS NOT NULL AND ${fieldNameWithQuotes}::jsonb ${lowerOp === 'in' ? 'IN' : 'NOT IN'} (${placeholders})`,
+                    fieldParams: (value[1] as unknown[]).map(item => JSON.stringify(item))
+                }
+            }
         }
     }
 

--- a/src/runtime/ComputationSourceMap.ts
+++ b/src/runtime/ComputationSourceMap.ts
@@ -149,6 +149,22 @@ export class ComputationSourceMapManager {
 
                 const computationSources: EntityEventSourceMap[][] = [[], [], []]
                 Object.entries(computation.dataDeps).forEach(([dataDepName, dataDep]) => {
+                    // CAUTION fail fast：global 计算把自己的输出 dict 声明为 global dataDep 是无终止的
+                    //  反馈环——每次写回都触发自身重算，setup/dispatch 无任何报错地挂起。
+                    //  「依赖上一次的计算结果」应使用 useLastValue / state（GlobalBoundState），不是 dataDep。
+                    if (dataDep.type === 'global' && computation.dataContext.type === 'global' && dataDep.source === computation.dataContext.id) {
+                        throw new ComputationProtocolError(
+                            `Global dataDep "${dataDepName}" of the computation on dictionary "${(computation.dataContext.id as { name?: string }).name}" references the computation's own output. ` +
+                            `This creates an unterminated feedback loop (every write re-triggers the computation). ` +
+                            `To use the previous result, rely on lastValue (useLastValue) or a GlobalBoundState instead of a dataDep.`,
+                            {
+                                handleName: computation.constructor.name,
+                                computationName: computation.args.constructor.displayName,
+                                dataContext: computation.dataContext,
+                                computationPhase: 'source-map-initialization'
+                            }
+                        )
+                    }
                     const sources = this.convertDataDepToERMutationEventsSourceMap(dataDepName, dataDep, computation)
                     computationSources[dataDep.phase || PHASE_NORMAL].push(...sources)
                 })

--- a/src/runtime/Controller.ts
+++ b/src/runtime/Controller.ts
@@ -189,6 +189,14 @@ export class Controller {
 
         for (const es of this.eventSources) {
             if (es.name) {
+                // CAUTION fail fast：同名 eventSource 静默后写覆盖先写——findEventSourceByName
+                //  只会命中最后注册者，先注册者的 guard/权限链从此不可达（按名 dispatch 的调用方
+                //  可能走到完全不同的授权路径）。Activity 内的 interaction 以 "activity:interaction"
+                //  作用域名注册，不受影响。
+                const existing = this.eventSourcesByName.get(es.name)
+                if (existing && existing !== es) {
+                    throw new Error(`Duplicate eventSource name "${es.name}". Event source names must be unique within a Controller; findEventSourceByName would silently resolve to only one of them.`)
+                }
                 this.eventSourcesByName.set(es.name, es)
             }
             this.eventSourcesByUUID.set(es.uuid, es)

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -21,6 +21,7 @@ import {
     EntityCreateEventsSourceMap
 } from "./ComputationSourceMap.js";
 import { createScopedSequenceSignatures, scopedSequenceComputationId } from "./scopedSequenceManifest.js";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 export { EtityMutationEvent };
 
@@ -384,32 +385,57 @@ export class Scheduler {
     }
     erMutationEventSources: EntityEventSourceMap[] = []
     dataSourceMapTree: DataSourceMapTree = {}
+    // CAUTION 计算传播的重入守卫。计算的写回（applyResult/applyResultPatch）会在同一事务内
+    //  立即重入 mutation listener，触发下游计算——这是反应式语义的主干。但循环依赖的声明
+    //  （互相派生的 Transform、dataDeps 引用自身输出的 dict 等）会让这条链永不收敛：
+    //  Transform 环每一跳都创建新记录（无限增长），dict 环每一跳都改写值（无限重算），
+    //  表现为 dispatch/setup 无任何报错地挂起或栈溢出。这里用 AsyncLocalStorage 记录
+    //  传播深度（并发事务互不串扰），超限时抛出带传播轨迹的受控错误。
+    //  上限对合法的深计算链（实践中通常 < 10 跳）留了充足余量。
+    static MAX_COMPUTATION_PROPAGATION_DEPTH = 100
+    private propagationContext = new AsyncLocalStorage<{ depth: number, trail: string[] }>()
     private buildComputationMutationListener(): RecordMutationCallback {
         this.sourceMapManager.initialize(new Set(this.computationsHandles.values()))
         this.dataSourceMapTree = this.sourceMapManager.getSourceMapTree()
 
         return (async (mutationEvents) => {
-            for(let mutationEvent of mutationEvents){
-                const sources = this.sourceMapManager.findSourceMapsForMutation(mutationEvent)
-                if (sources.length > 0) {
-                    for(const source of sources) {
-                        if(!this.sourceMapManager.shouldTriggerUpdateComputation(source, mutationEvent)) {
-                            continue
+            const parent = this.propagationContext.getStore()
+            const depth = (parent?.depth ?? 0) + 1
+            if (depth > Scheduler.MAX_COMPUTATION_PROPAGATION_DEPTH) {
+                const trailTail = (parent?.trail ?? []).slice(-10).join(' -> ')
+                throw new SchedulerError(
+                    `Computation propagation exceeded the maximum depth of ${Scheduler.MAX_COMPUTATION_PROPAGATION_DEPTH}. ` +
+                    `This almost always means circular computation dependencies (e.g. two Transforms deriving records from each other, ` +
+                    `or a computation whose dataDeps include its own output). Recent propagation trail: ${trailTail}`,
+                    { schedulingPhase: 'computation-propagation-depth-guard' }
+                )
+            }
+            const trail = parent?.trail ?? []
+            await this.propagationContext.run({ depth, trail }, async () => {
+                for(let mutationEvent of mutationEvents){
+                    const sources = this.sourceMapManager.findSourceMapsForMutation(mutationEvent)
+                    if (sources.length > 0) {
+                        for(const source of sources) {
+                            if(!this.sourceMapManager.shouldTriggerUpdateComputation(source, mutationEvent)) {
+                                continue
+                            }
+                            // 对于 EventBasedComputation，进行深度匹配检查
+                            if (!('dataDep' in source) && !this.sourceMapManager.shouldTriggerEventBasedComputation(source as EventBasedEntityEventsSourceMap, mutationEvent)) {
+                                continue
+                            }
+                            // filtered 源的 update 监听挂在物理 base 名上（见 ComputationSourceMap），
+                            // 路由前做成员资格守卫并把事件名改写回 filtered 名。
+                            const routedEvent = await this.resolveFilteredUpdateEvent(source, mutationEvent, mutationEvents)
+                            if (!routedEvent) {
+                                continue
+                            }
+                            trail.push(this.getComputationName(source.computation))
+                            if (trail.length > 32) trail.splice(0, trail.length - 32)
+                            await this.runDirtyRecordsComputation(source, routedEvent)
                         }
-                        // 对于 EventBasedComputation，进行深度匹配检查
-                        if (!('dataDep' in source) && !this.sourceMapManager.shouldTriggerEventBasedComputation(source as EventBasedEntityEventsSourceMap, mutationEvent)) {
-                            continue
-                        }
-                        // filtered 源的 update 监听挂在物理 base 名上（见 ComputationSourceMap），
-                        // 路由前做成员资格守卫并把事件名改写回 filtered 名。
-                        const routedEvent = await this.resolveFilteredUpdateEvent(source, mutationEvent, mutationEvents)
-                        if (!routedEvent) {
-                            continue
-                        }
-                        await this.runDirtyRecordsComputation(source, routedEvent)
                     }
                 }
-            }
+            })
         })
     }
     /**

--- a/src/runtime/computations/RealTime.ts
+++ b/src/runtime/computations/RealTime.ts
@@ -60,17 +60,10 @@ export class GlobalRealTimeComputation implements DataBasedComputation {
 
     constructor(public controller: Controller, public args: RealTimeInstance, public dataContext: DataContext) {
         this.dataDeps = (this.args.dataDeps ?? {}) as {[key: string]: DataDep};
-        // CAUTION fail fast：时间驱动的重算调度器尚未实现（nextRecomputeTime 只被记录、无消费方）。
-        //  没有任何 dataDeps 的 global RealTime 注册不出任何监听——callback 一次都不会执行，
-        //  值永远停在 null。这是声明合法、永不可用的死配置，必须在 setup 阶段拒绝。
-        if (Object.keys(this.dataDeps).length === 0) {
-            throw new ComputationError(
-                `RealTime computation on dictionary "${(this.dataContext.id as { name?: string })?.name ?? String(this.dataContext.id)}" declares no dataDeps. ` +
-                `Time-based rescheduling is not implemented yet, so a RealTime computation without data dependencies would never run and its value would stay null forever. ` +
-                `Declare dataDeps whose mutations should trigger recomputation.`,
-                { computationName: 'RealTime' }
-            )
-        }
+        // 注意：global RealTime 允许零 dataDeps——迁移 rebuild 是合法的计算触发路径
+        //  （migration 会全量重算新增的 global computation），值保持 null 直到被触发。
+        //  property 形态则不允许（见 PropertyRealTimeComputation：getInitialValue 会
+        //  在每次 create 时持久化误导性的 0）。
         this.callback = (now: Expression, dataDeps: Record<string, unknown>) => {
             return this.args.callback.call(this.controller, now, dataDeps);
         };

--- a/src/runtime/computations/RealTime.ts
+++ b/src/runtime/computations/RealTime.ts
@@ -60,6 +60,17 @@ export class GlobalRealTimeComputation implements DataBasedComputation {
 
     constructor(public controller: Controller, public args: RealTimeInstance, public dataContext: DataContext) {
         this.dataDeps = (this.args.dataDeps ?? {}) as {[key: string]: DataDep};
+        // CAUTION fail fast：时间驱动的重算调度器尚未实现（nextRecomputeTime 只被记录、无消费方）。
+        //  没有任何 dataDeps 的 global RealTime 注册不出任何监听——callback 一次都不会执行，
+        //  值永远停在 null。这是声明合法、永不可用的死配置，必须在 setup 阶段拒绝。
+        if (Object.keys(this.dataDeps).length === 0) {
+            throw new ComputationError(
+                `RealTime computation on dictionary "${(this.dataContext.id as { name?: string })?.name ?? String(this.dataContext.id)}" declares no dataDeps. ` +
+                `Time-based rescheduling is not implemented yet, so a RealTime computation without data dependencies would never run and its value would stay null forever. ` +
+                `Declare dataDeps whose mutations should trigger recomputation.`,
+                { computationName: 'RealTime' }
+            )
+        }
         this.callback = (now: Expression, dataDeps: Record<string, unknown>) => {
             return this.args.callback.call(this.controller, now, dataDeps);
         };
@@ -119,6 +130,18 @@ export class PropertyRealTimeComputation implements DataBasedComputation {
                 }
             } : {}),
             ...(this.args.dataDeps || {})
+        }
+        // CAUTION fail fast：时间驱动的重算调度器尚未实现。既没有 attributeQuery 也没有 dataDeps 的
+        //  property RealTime 注册不出任何监听——callback 一次都不会执行，值被 getInitialValue
+        //  持久化为 0 后永远不变（静默错误值）。必须在 setup 阶段拒绝。
+        if (Object.keys(this.dataDeps).length === 0) {
+            const host = (this.dataContext as { host?: { name?: string } }).host?.name ?? ''
+            throw new ComputationError(
+                `RealTime computation on property "${host}.${(this.dataContext.id as { name?: string })?.name ?? String(this.dataContext.id)}" declares neither attributeQuery nor dataDeps. ` +
+                `Time-based rescheduling is not implemented yet, so this computation would never run and the property would silently stay at its initial value (0). ` +
+                `Declare attributeQuery (host fields) or dataDeps whose mutations should trigger recomputation.`,
+                { computationName: 'RealTime' }
+            )
         }
         this.isResultNumber = (this.dataContext.id as PropertyInstance).type === 'number'
         this.callback = (now: Expression, dataDeps: Record<string, unknown>) => {

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -226,7 +226,9 @@ export class MatchExp {
         const simpleOp = ['=', '>', '<', '<=', '>=', 'like', '!=']
         const lowerOp = typeof value[0] === 'string' ? value[0].toLowerCase() : value[0]
 
-        if (simpleOp.includes(value[0])) {
+        // CAUTION 操作符按小写归一识别（'LIKE' 与 'like' 等价，与 in/not in/between 的处理一致）。
+        //  否则大写写法落入末尾的 unknown-expression assert，抛出与用户写法脱节的内部错误。
+        if (simpleOp.includes(lowerOp)) {
             if (isReferenceValue) {
                 // 当 isReferenceValue 为 true 时，直接将列引用嵌入 SQL，不使用占位符
                 const referenceField = this.getReferenceFieldValue(value[1])
@@ -283,8 +285,23 @@ export class MatchExp {
                 // 空数组的 IN 语义上恒为 false（任何值都不在空集合中）。
                 // `IN ()` 是非法 SQL，这里生成跨数据库合法且恒为 false 的表达式：
                 // `x IN (NULL)` 求值为 NULL，`NULL AND (1=0)` 为 false，且在外层 NOT 下取反后正确为 true。
-                fieldValue = `IN (NULL) AND 1=0`
+                // json 列不能参与 `= NULL` 比较（PG 系报 "operator does not exist"），
+                // 改用等价且不比较列值的恒 false 表达式。
+                fieldValue = fieldType?.toLowerCase() === 'json' ? `IS NOT NULL AND 1=0` : `IN (NULL) AND 1=0`
                 fieldParams = []
+            } else if (fieldType?.toLowerCase() === 'json') {
+                // CAUTION 与 =/!= 同理（见上）：json 列的写入路径统一 JSON.stringify，
+                //  IN/NOT IN 的元素参数不做同样的序列化会导致 PG 系裸报 "operator does not exist"、
+                //  SQLite 把数组元素展开成多余绑定参数直接崩溃。优先给驱动方言机会（PG 系 ::jsonb），
+                //  否则退化为与写入路径一致的序列化文本比较。
+                const dialectResult = db?.parseMatchExpression?.(key, value, fieldName, fieldType!, isReferenceValue, this.getReferenceFieldValue.bind(this), p)
+                if (dialectResult) {
+                    fieldValue = dialectResult.fieldValue
+                    fieldParams = dialectResult.fieldParams || []
+                } else {
+                    fieldValue = `IN (${value[1].map((_x: unknown) => p()).join(',')})`
+                    fieldParams = value[1].map((item: unknown) => JSON.stringify(item))
+                }
             } else {
                 fieldValue = `IN (${value[1].map((_x: unknown) => p()).join(',')})`
                 fieldParams = value[1]
@@ -298,13 +315,26 @@ export class MatchExp {
             if (value[1].length === 0) {
                 // 空集合的 NOT IN 语义上恒为 true（任何值都不在空集合中）。
                 // 依赖 buildWhereClause 对原子加括号，保证 OR 不会泄漏到外层表达式。
-                fieldValue = `NOT IN (NULL) OR 1=1`
+                // json 列同上，避免 `NOT IN (NULL)` 触发 json 比较操作符。
+                fieldValue = fieldType?.toLowerCase() === 'json' ? `IS NULL OR 1=1` : `NOT IN (NULL) OR 1=1`
                 fieldParams = []
+            } else if (fieldType?.toLowerCase() === 'json') {
+                const dialectResult = db?.parseMatchExpression?.(key, value, fieldName, fieldType!, isReferenceValue, this.getReferenceFieldValue.bind(this), p)
+                if (dialectResult) {
+                    fieldValue = dialectResult.fieldValue
+                    fieldParams = dialectResult.fieldParams || []
+                } else {
+                    fieldValue = `NOT IN (${value[1].map((_x: unknown) => p()).join(',')})`
+                    fieldParams = value[1].map((item: unknown) => JSON.stringify(item))
+                }
             } else {
                 fieldValue = `NOT IN (${value[1].map((_x: unknown) => p()).join(',')})`
                 fieldParams = value[1]
             }
         } else if (value[0].toLowerCase() === 'between') {
+            if (!Array.isArray(value[1]) || value[1].length !== 2) {
+                throw new Error(`match operator 'between' requires a two-element array value [min, max], got: ${JSON.stringify(value[1])} for key "${key}"`)
+            }
             if (isReferenceValue) {
                 // 当 isReferenceValue 为 true 时，直接将列引用嵌入 SQL
                 const ref1 = this.getReferenceFieldValue(value[1][0])

--- a/tests/core/core-domain-refactored.spec.ts
+++ b/tests/core/core-domain-refactored.spec.ts
@@ -208,11 +208,13 @@ describe("Core Domain Classes Refactored", () => {
 
     test("should create interaction with entity data", () => {
       const userEntity = Entity.create({ name: "User" });
-      const createAction = Action.create({ name: "create" });
-      
+      // r11: data is only meaningful on the query action ('get'); declaring it on
+      // other actions is now a declaration-time error.
+      const getAction = Action.create({ name: "get" });
+
       const interaction = Interaction.create({
-        name: "CreateUser",
-        action: createAction,
+        name: "GetUser",
+        action: getAction,
         data: userEntity
       });
 

--- a/tests/core/core-domain-refactored.spec.ts
+++ b/tests/core/core-domain-refactored.spec.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach } from "vitest";
 import {
   Entity, Property, Relation, clearAllInstances
 } from "@core";
-import { Interaction, Action } from "interaqt";
+import { Interaction, Action, GetAction } from "interaqt";
 
 describe("Core Domain Classes Refactored", () => {
   beforeEach(() => {
@@ -208,13 +208,11 @@ describe("Core Domain Classes Refactored", () => {
 
     test("should create interaction with entity data", () => {
       const userEntity = Entity.create({ name: "User" });
-      // r11: data is only meaningful on the query action ('get'); declaring it on
-      // other actions is now a declaration-time error.
-      const getAction = Action.create({ name: "get" });
-
+      // r11: data is only meaningful on the exported GetAction constant; declaring it
+      // on any other action is now a declaration-time error.
       const interaction = Interaction.create({
         name: "GetUser",
-        action: getAction,
+        action: GetAction,
         data: userEntity
       });
 

--- a/tests/runtime/computationEdgeCases.spec.ts
+++ b/tests/runtime/computationEdgeCases.spec.ts
@@ -34,10 +34,11 @@ describe('Transform computation edge cases', () => {
         });
 
         const createAction = Action.create({ name: 'create' });
+        // r11: data on a non-get action is a declaration-time error (it was silently
+        // ignored before); this Transform test only needs the interaction event.
         const interaction = Interaction.create({
             name: 'createTfSource',
             action: createAction,
-            data: SourceEntity,
         });
 
         const system = new MonoSystem(new PGLiteDB());

--- a/tests/runtime/ignorePermission.spec.ts
+++ b/tests/runtime/ignorePermission.spec.ts
@@ -83,7 +83,8 @@ describe('Controller ignorePermission parameter', () => {
                 ]
             }),
             conditions: restrictedCondition,
-            data: Post
+            // r11: data on a non-get action is a declaration-time error (it was silently
+            // ignored before); this test only exercises conditions/ignorePermission.
         })
     })
 

--- a/tests/runtime/queryDataInteraction.spec.ts
+++ b/tests/runtime/queryDataInteraction.spec.ts
@@ -608,13 +608,13 @@ describe('Get Data Interaction', () => {
                 ]
             })
 
-            // r11: data/dataPolicy on a non-get action used to be silently ignored
+            // r11: data/dataPolicy on a non-GetAction used to be silently ignored
             // (dispatch succeeded but never returned data). It is now a declaration error.
             expect(() => Interaction.create({
                 name: 'createUser',
                 action: Action.create({ name: 'create' }),  // Not GetAction
                 data: User
-            })).toThrow(/declares data\/dataPolicy but its action "create" is not the query action/)
+            })).toThrow(/declares data\/dataPolicy but its action "create" is not the built-in query action/)
         })
     })
 

--- a/tests/runtime/queryDataInteraction.spec.ts
+++ b/tests/runtime/queryDataInteraction.spec.ts
@@ -600,7 +600,7 @@ describe('Get Data Interaction', () => {
             ).rejects.toThrow()
         })
 
-        test('should return error when action is not GetAction', async () => {
+        test('should fail fast when data is declared on a non-get action', async () => {
             const User = Entity.create({
                 name: 'User',
                 properties: [
@@ -608,31 +608,13 @@ describe('Get Data Interaction', () => {
                 ]
             })
 
-            // Create interaction with wrong action type
-            const CreateUser = Interaction.create({
+            // r11: data/dataPolicy on a non-get action used to be silently ignored
+            // (dispatch succeeded but never returned data). It is now a declaration error.
+            expect(() => Interaction.create({
                 name: 'createUser',
                 action: Action.create({ name: 'create' }),  // Not GetAction
                 data: User
-            })
-
-            controller = new Controller({
-                system,
-                entities: [User],
-                eventSources: [CreateUser]
-            })
-            await controller.setup(true)
-
-            await system.storage.create('User', { name: 'Alice' })
-
-            const result = await controller.dispatch(CreateUser, {
-                user: { id: 'test-user' },
-                query: {
-                    attributeQuery: ['id', 'name']
-                }
-            })
-
-            // Should not return data since it's not a GetAction
-            expect(result.data).toBeUndefined()
+            })).toThrow(/declares data\/dataPolicy but its action "create" is not the query action/)
         })
     })
 

--- a/tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+    Entity, Property,
+    Interaction, Action, GetAction,
+    clearAllInstances, createInstances,
+} from 'interaqt';
+
+/**
+ * r11 F-3（序列化侧）：GetAction 是模块级单例（uuid 每个进程随机生成）。
+ * graph 反序列化（createInstances）会重建 uuid 相同但对象不同的 Action 实例，
+ * 引用同一性判定（args.action === GetAction）必然失败——round-trip 后的查询交互
+ * 静默丢失 resolve，dispatch 永远返回 data: undefined。
+ * 现在按 action name（'get'）识别，round-trip 后 resolve 正常重建。
+ *
+ * CAUTION 本测试会 clearAllInstances(Interaction/Action/Entity/Property)，
+ *  必须独占一个 spec 文件，避免影响同文件其他测试的实例注册表。
+ */
+describe('r11 F-3: GetAction interaction survives graph round-trip', () => {
+    test('deserialized get-interaction keeps its resolve binding', () => {
+        const Post = Entity.create({
+            name: 'R11SerPost',
+            properties: [Property.create({ name: 'title', type: 'string' })],
+        })
+        const ListPosts = Interaction.create({
+            name: 'R11SerListPosts',
+            action: GetAction,
+            data: Post,
+        })
+        expect((ListPosts as any).resolve).toBeDefined()
+
+        const blob = `[${[
+            Interaction.stringify(ListPosts),
+            Action.stringify(GetAction),
+            Entity.stringify(Post),
+            ...Post.properties.map((p: any) => (p.constructor as any).stringify(p)),
+        ].join(',')}]`
+
+        clearAllInstances(Interaction as any, Action as any, Entity as any, Property as any)
+
+        const instances = createInstances(JSON.parse(blob))
+        const restored = Array.from(instances.values()).find((i: any) => i._type === 'Interaction') as any
+        // 反序列化重建的 Action 与单例对象不同但 uuid 相同
+        expect(restored.action).not.toBe(GetAction)
+        expect(restored.action.uuid).toBe(GetAction.uuid)
+        // 修复点：resolve 按 action name 重建
+        expect(restored.resolve).toBeDefined()
+    })
+})

--- a/tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts
@@ -1,22 +1,24 @@
 import { describe, expect, test } from "vitest";
 import {
     Entity, Property,
-    Interaction, Action, GetAction,
+    Interaction, Action, GetAction, GET_ACTION_UUID,
     clearAllInstances, createInstances,
 } from 'interaqt';
 
 /**
- * r11 F-3（序列化侧）：GetAction 是模块级单例（uuid 每个进程随机生成）。
- * graph 反序列化（createInstances）会重建 uuid 相同但对象不同的 Action 实例，
+ * r11 F-3（序列化侧）：GetAction 此前是 uuid 每进程随机的模块级单例。
+ * graph 反序列化（createInstances）重建的 Action 对象与单例 `!==`，
  * 引用同一性判定（args.action === GetAction）必然失败——round-trip 后的查询交互
  * 静默丢失 resolve，dispatch 永远返回 data: undefined。
- * 现在按 action name（'get'）识别，round-trip 后 resolve 正常重建。
+ * 现在 GetAction 拥有固定 uuid（GET_ACTION_UUID），查询语义按这个跨序列化稳定的
+ * 显式身份识别；Action.create 对该 uuid 幂等（注册表里已有单例时直接返回），
+ * round-trip 后 resolve 正常重建、action 引用回到同一个单例。
  *
  * CAUTION 本测试会 clearAllInstances(Interaction/Action/Entity/Property)，
  *  必须独占一个 spec 文件，避免影响同文件其他测试的实例注册表。
  */
 describe('r11 F-3: GetAction interaction survives graph round-trip', () => {
-    test('deserialized get-interaction keeps its resolve binding', () => {
+    test('deserialized get-interaction keeps its resolve binding (registry intact: singleton reused)', () => {
         const Post = Entity.create({
             name: 'R11SerPost',
             properties: [Property.create({ name: 'title', type: 'string' })],
@@ -35,14 +37,38 @@ describe('r11 F-3: GetAction interaction survives graph round-trip', () => {
             ...Post.properties.map((p: any) => (p.constructor as any).stringify(p)),
         ].join(',')}]`
 
-        clearAllInstances(Interaction as any, Action as any, Entity as any, Property as any)
-
+        // Action 注册表保持原样（GetAction 单例仍注册）：反序列化按固定 uuid
+        // 重建 GetAction 时幂等返回单例。其余类型清空以避免 uuid 重复拒绝。
+        clearAllInstances(Interaction as any, Entity as any, Property as any)
         const instances = createInstances(JSON.parse(blob))
         const restored = Array.from(instances.values()).find((i: any) => i._type === 'Interaction') as any
-        // 反序列化重建的 Action 与单例对象不同但 uuid 相同
-        expect(restored.action).not.toBe(GetAction)
-        expect(restored.action.uuid).toBe(GetAction.uuid)
-        // 修复点：resolve 按 action name 重建
+        expect(restored.action).toBe(GetAction)
+        expect(restored.resolve).toBeDefined()
+    })
+
+    test('deserialized get-interaction keeps its resolve binding (cold registry, e.g. another process)', () => {
+        const Post = Entity.create({
+            name: 'R11SerPost2',
+            properties: [Property.create({ name: 'title', type: 'string' })],
+        })
+        const ListPosts = Interaction.create({
+            name: 'R11SerListPosts2',
+            action: GetAction,
+            data: Post,
+        })
+        const blob = `[${[
+            Interaction.stringify(ListPosts),
+            Action.stringify(GetAction),
+            Entity.stringify(Post),
+            ...Post.properties.map((p: any) => (p.constructor as any).stringify(p)),
+        ].join(',')}]`
+
+        // 模拟冷进程：全部注册表清空后重建
+        clearAllInstances(Interaction as any, Action as any, Entity as any, Property as any)
+        const instances = createInstances(JSON.parse(blob))
+        const restored = Array.from(instances.values()).find((i: any) => i._type === 'Interaction') as any
+        // 冷注册表下重建的 Action 是新对象，但携带固定 uuid，查询语义识别不受影响
+        expect(restored.action.uuid).toBe(GET_ACTION_UUID)
         expect(restored.resolve).toBeDefined()
     })
 })

--- a/tests/runtime/review-fixes-2026-07-09-r11.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r11.spec.ts
@@ -207,7 +207,7 @@ describe('r11 R-2: RealTime without any trigger fails fast', () => {
             .toThrow(/neither attributeQuery nor dataDeps/)
     })
 
-    test('global RealTime without dataDeps is rejected', () => {
+    test('global RealTime without dataDeps stays legal (migration rebuild is a valid trigger path)', () => {
         const clock = Dictionary.create({
             name: 'r11r2Clock',
             type: 'number',
@@ -219,7 +219,6 @@ describe('r11 R-2: RealTime without any trigger fails fast', () => {
         })
         const system = new MonoSystem(new PGLiteDB())
         system.conceptClass = KlassByName
-        expect(() => new Controller({ system, entities: [], relations: [], dict: [clock] }))
-            .toThrow(/declares no dataDeps/)
+        expect(() => new Controller({ system, entities: [], relations: [], dict: [clock] })).not.toThrow()
     })
 })

--- a/tests/runtime/review-fixes-2026-07-09-r11.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r11.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
     Entity, Property, KlassByName,
     Controller, MonoSystem,
-    Interaction, Action, DataPolicy,
+    Interaction, Action, GetAction, GET_ACTION_UUID, DataPolicy,
     Transform, Custom, Dictionary, RealTime,
 } from 'interaqt';
 import { PGLiteDB } from '@drivers';
@@ -18,11 +18,14 @@ import { PGLiteDB } from '@drivers';
  *        - 其余环路由传播深度守卫（AsyncLocalStorage 计数，上限 100）在运行期抛出
  *          带传播轨迹的受控错误。
  *
- * F-3: GetAction 查询语义此前按引用同一性（args.action === GetAction）绑定 resolve。
- *      用户自建 Action.create({ name: 'get' })、或序列化 round-trip 重建的 Action
- *      （uuid 相同但对象不同）都会让判定失败——声明看起来是查询交互，dispatch 却
- *      静默返回 data: undefined。现在按 action name（'get'）识别；并且 data/dataPolicy
- *      挂在非 get action 上（合法声明、永不生效的死配置）在声明期 fail-fast。
+ * F-3: GetAction 查询语义此前按引用同一性（args.action === GetAction）绑定 resolve，
+ *      而 GetAction 的 uuid 每进程随机——序列化 round-trip 重建的 Action 对象必然
+ *      `!==` 单例，resolve 静默丢失、dispatch 返回 data: undefined。
+ *      现在 GetAction 拥有固定 uuid（导出常量 GET_ACTION_UUID），查询语义按这个
+ *      跨序列化稳定的显式身份识别：普通 Action.create({name:'get'}) 不再特殊
+ *      （'get' 是常用词，同名不应隐式获得查询语义），带 data/dataPolicy 的非
+ *      GetAction 声明（合法声明、永不生效的死配置）在声明期 fail-fast 并指引
+ *      使用导出常量。反序列化按固定 uuid 重建 GetAction 时幂等返回单例。
  *
  * R-1: Controller 中同名 eventSource 静默后写覆盖先写（findEventSourceByName 只命中
  *      最后注册者，先注册者的 guard/权限链不可达）。现在构造期 fail-fast。
@@ -130,15 +133,15 @@ describe('r11 F-1: computation propagation cycle guard', () => {
     })
 })
 
-describe('r11 F-3: GetAction is recognized by name, data on non-get actions is rejected', () => {
-    test('a user-created Action named "get" resolves data', async () => {
+describe('r11 F-3: query semantics bound to the exported GetAction identity (fixed uuid)', () => {
+    test('the exported GetAction constant resolves data', async () => {
         const Post = Entity.create({
             name: 'R11F3Post',
             properties: [Property.create({ name: 'title', type: 'string' })],
         })
         const ListPosts = Interaction.create({
             name: 'R11F3ListPosts',
-            action: Action.create({ name: 'get' }),  // not the GetAction singleton
+            action: GetAction,
             data: Post,
             dataPolicy: DataPolicy.create({ attributeQuery: ['id', 'title'] }),
         })
@@ -153,16 +156,44 @@ describe('r11 F-3: GetAction is recognized by name, data on non-get actions is r
         await system.destroy()
     })
 
-    test('data/dataPolicy on a non-get action fails fast at declaration time', () => {
+    test('an Action merely named "get" gains no query semantics; with data it fails fast with a GetAction hint', () => {
         const Post = Entity.create({
             name: 'R11F3Post2',
+            properties: [Property.create({ name: 'title', type: 'string' })],
+        })
+        // 普通同名 action 完全合法，只是没有查询语义（不挂 resolve）
+        const plain = Interaction.create({
+            name: 'R11F3PlainGet',
+            action: Action.create({ name: 'get' }),
+        })
+        expect((plain as any).resolve).toBeUndefined()
+        // 带 data 时声明期报错，并明确指引使用导出的 GetAction 常量
+        expect(() => Interaction.create({
+            name: 'R11F3NamedGet',
+            action: Action.create({ name: 'get' }),
+            data: Post,
+        })).toThrow(/An Action merely named "get" is not the query action.*GetAction/)
+    })
+
+    test('data/dataPolicy on a non-get action fails fast at declaration time', () => {
+        const Post = Entity.create({
+            name: 'R11F3Post3',
             properties: [Property.create({ name: 'title', type: 'string' })],
         })
         expect(() => Interaction.create({
             name: 'R11F3CreatePost',
             action: Action.create({ name: 'create' }),
             data: Post,
-        })).toThrow(/is not the query action/)
+        })).toThrow(/is not the built-in query action.*GetAction/)
+    })
+
+    test('re-creating the GetAction identity is idempotent; hijacking its uuid with another name is rejected', () => {
+        // 反序列化路径会带固定 uuid 重新 create：应返回同一个单例而不是抛 duplicate uuid
+        const recreated = Action.create({ name: 'get' }, { uuid: GET_ACTION_UUID })
+        expect(recreated).toBe(GetAction)
+        // 固定 uuid 配其他名字属于损毁数据
+        expect(() => Action.create({ name: 'hijack' }, { uuid: GET_ACTION_UUID }))
+            .toThrow(/must be named "get"/)
     })
 })
 

--- a/tests/runtime/review-fixes-2026-07-09-r11.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-09-r11.spec.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "vitest";
+import {
+    Entity, Property, KlassByName,
+    Controller, MonoSystem,
+    Interaction, Action, DataPolicy,
+    Transform, Custom, Dictionary, RealTime,
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+/**
+ * r11 review 回归（runtime/builtins 侧）。
+ *
+ * F-1: 计算传播（computation 写回重入 mutation listener）此前没有任何环路/深度守卫。
+ *      互相派生的 Transform、互相依赖的 global dict 计算是「声明合法、运行期死循环」的
+ *      形态：dispatch/setup 无任何报错地挂起（实测挂满测试超时）或无限创建记录。
+ *      现在：
+ *        - 直接自引用（dict 计算把自己的输出声明为 global dataDep）在 setup 期 fail-fast；
+ *        - 其余环路由传播深度守卫（AsyncLocalStorage 计数，上限 100）在运行期抛出
+ *          带传播轨迹的受控错误。
+ *
+ * F-3: GetAction 查询语义此前按引用同一性（args.action === GetAction）绑定 resolve。
+ *      用户自建 Action.create({ name: 'get' })、或序列化 round-trip 重建的 Action
+ *      （uuid 相同但对象不同）都会让判定失败——声明看起来是查询交互，dispatch 却
+ *      静默返回 data: undefined。现在按 action name（'get'）识别；并且 data/dataPolicy
+ *      挂在非 get action 上（合法声明、永不生效的死配置）在声明期 fail-fast。
+ *
+ * R-1: Controller 中同名 eventSource 静默后写覆盖先写（findEventSourceByName 只命中
+ *      最后注册者，先注册者的 guard/权限链不可达）。现在构造期 fail-fast。
+ *
+ * R-2: 时间驱动的重算调度器尚未实现（nextRecomputeTime 无消费方）。零 dataDeps 的
+ *      RealTime 计算注册不出任何监听——callback 一次都不会执行，property 形态还会被
+ *      getInitialValue 持久化成 0（静默错误值）。现在在 setup 期 fail-fast。
+ */
+
+describe('r11 F-1: computation propagation cycle guard', () => {
+    test('mutual entity Transforms fail with a propagation depth error instead of looping forever', async () => {
+        const A = Entity.create({
+            name: 'R11F1A',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+        })
+        const B = Entity.create({
+            name: 'R11F1B',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+            computation: Transform.create({
+                record: A,
+                attributeQuery: ['label'],
+                callback: () => ({ label: 'from-a' })
+            })
+        })
+        ;(A as any).computation = Transform.create({
+            record: B,
+            attributeQuery: ['label'],
+            callback: () => ({ label: 'from-b' })
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [A, B], relations: [] })
+        await controller.setup(true)
+        await expect(system.storage.create('R11F1A', { label: 'seed' }))
+            .rejects.toThrow(/propagation exceeded the maximum depth/)
+        await system.destroy()
+    }, 60000)
+
+    test('a dict computation depending on its own output fails fast at setup', async () => {
+        const total: any = Dictionary.create({
+            name: 'r11f1SelfTotal',
+            type: 'number',
+            collection: false,
+        })
+        total.computation = Custom.create({
+            name: 'R11F1Self',
+            dataDeps: { prev: { type: 'global', source: total } },
+            getInitialValue: () => 0,
+            compute: async (deps: any) => (deps.prev ?? 0) + 1,
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [], relations: [], dict: [total] })
+        await expect(controller.setup(true)).rejects.toThrow(/references the computation's own output/)
+        await system.destroy()
+    })
+
+    test('an indirect dict cycle (X -> Y -> X) hits the runtime propagation guard', async () => {
+        const x: any = Dictionary.create({ name: 'r11f1X', type: 'number', collection: false })
+        const y: any = Dictionary.create({ name: 'r11f1Y', type: 'number', collection: false })
+        x.computation = Custom.create({
+            name: 'R11F1X',
+            dataDeps: { other: { type: 'global', source: y } },
+            getInitialValue: () => 0,
+            compute: async (deps: any) => (deps.other ?? 0) + 1,
+        })
+        y.computation = Custom.create({
+            name: 'R11F1Y',
+            dataDeps: { other: { type: 'global', source: x } },
+            getInitialValue: () => 0,
+            compute: async (deps: any) => (deps.other ?? 0) + 1,
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [], relations: [], dict: [x, y] })
+        await expect(controller.setup(true)).rejects.toThrow(/propagation exceeded the maximum depth/)
+        await system.destroy()
+    }, 60000)
+
+    test('legitimate computation chains still work (no false positive)', async () => {
+        // A -> Transform -> B, and a dict counting B: a two-hop legitimate chain.
+        const A = Entity.create({
+            name: 'R11F1ChainA',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+        })
+        const B = Entity.create({
+            name: 'R11F1ChainB',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+            computation: Transform.create({
+                record: A,
+                attributeQuery: ['label'],
+                callback: (a: any) => ({ label: `derived-${a.label}` })
+            })
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [A, B], relations: [] })
+        await controller.setup(true)
+        await system.storage.create('R11F1ChainA', { label: 'x' })
+        const derived = await system.storage.find('R11F1ChainB', undefined, undefined, ['label'])
+        expect(derived.map((d: any) => d.label)).toEqual(['derived-x'])
+        await system.destroy()
+    })
+})
+
+describe('r11 F-3: GetAction is recognized by name, data on non-get actions is rejected', () => {
+    test('a user-created Action named "get" resolves data', async () => {
+        const Post = Entity.create({
+            name: 'R11F3Post',
+            properties: [Property.create({ name: 'title', type: 'string' })],
+        })
+        const ListPosts = Interaction.create({
+            name: 'R11F3ListPosts',
+            action: Action.create({ name: 'get' }),  // not the GetAction singleton
+            data: Post,
+            dataPolicy: DataPolicy.create({ attributeQuery: ['id', 'title'] }),
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [Post], relations: [], eventSources: [ListPosts] })
+        await controller.setup(true)
+        await system.storage.create('R11F3Post', { title: 'hello' })
+        const result = await controller.dispatch(ListPosts, { user: { id: 'u1' } })
+        expect(result.error).toBeUndefined()
+        expect((result.data as any[]).map(p => p.title)).toEqual(['hello'])
+        await system.destroy()
+    })
+
+    test('data/dataPolicy on a non-get action fails fast at declaration time', () => {
+        const Post = Entity.create({
+            name: 'R11F3Post2',
+            properties: [Property.create({ name: 'title', type: 'string' })],
+        })
+        expect(() => Interaction.create({
+            name: 'R11F3CreatePost',
+            action: Action.create({ name: 'create' }),
+            data: Post,
+        })).toThrow(/is not the query action/)
+    })
+})
+
+describe('r11 R-1: duplicate eventSource names are rejected', () => {
+    test('two event sources with the same name throw at Controller construction', () => {
+        const A = Interaction.create({ name: 'R11R1Submit', action: Action.create({ name: 'r11r1a' }) })
+        const B = Interaction.create({ name: 'R11R1Submit', action: Action.create({ name: 'r11r1b' }) })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        expect(() => new Controller({ system, entities: [], relations: [], eventSources: [A, B] }))
+            .toThrow(/Duplicate eventSource name "R11R1Submit"/)
+    })
+
+    test('registering the same instance under one name stays legal', () => {
+        const A = Interaction.create({ name: 'R11R1Single', action: Action.create({ name: 'r11r1c' }) })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [], relations: [], eventSources: [A, A] })
+        expect(controller.findEventSourceByName('R11R1Single')).toBe(A)
+    })
+})
+
+describe('r11 R-2: RealTime without any trigger fails fast', () => {
+    test('property RealTime with neither attributeQuery nor dataDeps is rejected', () => {
+        const U = Entity.create({
+            name: 'R11R2User',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({
+                    name: 'liveSeconds',
+                    type: 'number',
+                    computation: RealTime.create({
+                        nextRecomputeTime: () => 1000,
+                        callback: (async (now: any) => now.divide(1000)) as any,
+                    }),
+                }),
+            ],
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        expect(() => new Controller({ system, entities: [U], relations: [] }))
+            .toThrow(/neither attributeQuery nor dataDeps/)
+    })
+
+    test('global RealTime without dataDeps is rejected', () => {
+        const clock = Dictionary.create({
+            name: 'r11r2Clock',
+            type: 'number',
+            collection: false,
+            computation: RealTime.create({
+                nextRecomputeTime: () => 1000,
+                callback: (async (now: any) => now.divide(1000)) as any,
+            }),
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        expect(() => new Controller({ system, entities: [], relations: [], dict: [clock] }))
+            .toThrow(/declares no dataDeps/)
+    })
+})

--- a/tests/runtime/review-fixes-2026-07.spec.ts
+++ b/tests/runtime/review-fixes-2026-07.spec.ts
@@ -125,6 +125,8 @@ describe('R-1: RealTime guards', () => {
         const realTimeArgs = RealTime.create({
             callback: (async (now: Expression) => now.add(1)) as any,
             // 故意不声明 nextRecomputeTime
+            // r11: 零 dataDeps 的 RealTime 现在在构造期 fail-fast，这里给一个占位依赖
+            dataDeps: { trigger: { type: 'global', source: { name: 'r1RealTimeTrigger' } } } as any,
         })
         const handle = new GlobalRealTimeComputation(
             {} as any,

--- a/tests/runtime/review-fixes-2026-07.spec.ts
+++ b/tests/runtime/review-fixes-2026-07.spec.ts
@@ -125,8 +125,6 @@ describe('R-1: RealTime guards', () => {
         const realTimeArgs = RealTime.create({
             callback: (async (now: Expression) => now.add(1)) as any,
             // 故意不声明 nextRecomputeTime
-            // r11: 零 dataDeps 的 RealTime 现在在构造期 fail-fast，这里给一个占位依赖
-            dataDeps: { trigger: { type: 'global', source: { name: 'r1RealTimeTrigger' } } } as any,
         })
         const handle = new GlobalRealTimeComputation(
             {} as any,

--- a/tests/storage/review-fixes-2026-07-09-r11.spec.ts
+++ b/tests/storage/review-fixes-2026-07-09-r11.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+import { Entity, Property, KlassByName, Controller, MonoSystem } from 'interaqt';
+import { MatchExp } from '@storage';
+import { PGLiteDB, SQLiteDB } from '@drivers';
+
+/**
+ * r11 review 回归（storage 侧）。
+ *
+ * F-2: json/collection 列的 IN / NOT IN 匹配。写入路径统一 JSON.stringify，
+ *      匹配参数此前原样绑定：PG 系裸报 "operator does not exist: json = unknown"，
+ *      SQLite 把数组元素展开成多余绑定参数直接崩（"Too many parameter values"）。
+ *      r10 F-3 只修了 =/!=，本轮把同一治理延伸到 IN / NOT IN：
+ *      PG/PGLite 走 ::jsonb 语义比较（键序不敏感），MySQL 走 CAST(? AS JSON)，
+ *      其余驱动退化为与写入路径一致的序列化文本比较。NULL 行不参与匹配。
+ *
+ * R-3: 操作符大小写归一。'LIKE'（大写）此前落入末尾的 unknown-expression assert，
+ *      抛出与用户写法脱节的内部错误；in/not in/between 早已 toLowerCase。
+ *      现在 simpleOp（=、!=、>、<、>=、<=、like）统一按小写识别。
+ *
+ * R-4: between 的操作数校验。['between', 25]（非两元数组）此前深入到 value[1][0]
+ *      抛裸 TypeError，现在给出带指引的受控错误。
+ */
+
+async function setupDocModel(name: string, db: any) {
+    const Doc = Entity.create({
+        name,
+        properties: [
+            Property.create({ name: 'name', type: 'string' }),
+            Property.create({ name: 'tags', type: 'string', collection: true }),
+        ],
+    })
+    const system = new MonoSystem(db)
+    system.conceptClass = KlassByName
+    const controller = new Controller({ system, entities: [Doc], relations: [] })
+    await controller.setup(true)
+    return { system, controller }
+}
+
+describe('r11 F-2: json IN / NOT IN matching', () => {
+    test('PGLite: IN matches whole-value snapshots, NOT IN excludes and skips NULL rows', async () => {
+        const { system } = await setupDocModel('R11JsonDocPg', new PGLiteDB())
+        await system.storage.create('R11JsonDocPg', { name: 'a', tags: ['alpha', 'beta'] })
+        await system.storage.create('R11JsonDocPg', { name: 'b', tags: ['gamma'] })
+        await system.storage.create('R11JsonDocPg', { name: 'nullRow' })
+
+        const hits = await system.storage.find('R11JsonDocPg',
+            MatchExp.atom({ key: 'tags', value: ['in', [['alpha', 'beta'], ['x']]] }), undefined, ['name'])
+        expect(hits.map((h: any) => h.name)).toEqual(['a'])
+
+        const misses = await system.storage.find('R11JsonDocPg',
+            MatchExp.atom({ key: 'tags', value: ['not in', [['alpha', 'beta']]] }), undefined, ['name'])
+        expect(misses.map((h: any) => h.name)).toEqual(['b'])
+        await system.destroy()
+    })
+
+    test('SQLite: IN matches whole-value snapshots, NOT IN excludes', async () => {
+        const { system } = await setupDocModel('R11JsonDocSq', new SQLiteDB())
+        await system.storage.create('R11JsonDocSq', { name: 'a', tags: ['alpha', 'beta'] })
+        await system.storage.create('R11JsonDocSq', { name: 'b', tags: ['gamma'] })
+
+        const hits = await system.storage.find('R11JsonDocSq',
+            MatchExp.atom({ key: 'tags', value: ['in', [['alpha', 'beta']]] }), undefined, ['name'])
+        expect(hits.map((h: any) => h.name)).toEqual(['a'])
+
+        const misses = await system.storage.find('R11JsonDocSq',
+            MatchExp.atom({ key: 'tags', value: ['not in', [['alpha', 'beta']]] }), undefined, ['name'])
+        expect(misses.map((h: any) => h.name)).toEqual(['b'])
+        await system.destroy()
+    })
+
+    test('empty IN / NOT IN lists on json columns keep constant-false/true semantics', async () => {
+        const { system } = await setupDocModel('R11JsonDocEmpty', new PGLiteDB())
+        await system.storage.create('R11JsonDocEmpty', { name: 'a', tags: ['alpha'] })
+
+        const none = await system.storage.find('R11JsonDocEmpty',
+            MatchExp.atom({ key: 'tags', value: ['in', []] }), undefined, ['name'])
+        expect(none).toEqual([])
+
+        const all = await system.storage.find('R11JsonDocEmpty',
+            MatchExp.atom({ key: 'tags', value: ['not in', []] }), undefined, ['name'])
+        expect(all.map((h: any) => h.name)).toEqual(['a'])
+        await system.destroy()
+    })
+})
+
+describe('r11 R-3: operator case normalization', () => {
+    test('uppercase LIKE works the same as lowercase', async () => {
+        const { system } = await setupDocModel('R11LikeDoc', new PGLiteDB())
+        await system.storage.create('R11LikeDoc', { name: 'hello world' })
+
+        const upper = await system.storage.find('R11LikeDoc',
+            MatchExp.atom({ key: 'name', value: ['LIKE', '%hello%'] }), undefined, ['name'])
+        const lower = await system.storage.find('R11LikeDoc',
+            MatchExp.atom({ key: 'name', value: ['like', '%hello%'] }), undefined, ['name'])
+        expect(upper.length).toBe(1)
+        expect(lower.length).toBe(1)
+        await system.destroy()
+    })
+})
+
+describe('r11 R-4: between operand validation', () => {
+    test('non-array between value gives a controlled error', async () => {
+        const Doc = Entity.create({
+            name: 'R11BetweenDoc',
+            properties: [Property.create({ name: 'num', type: 'number' })],
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [Doc], relations: [] })
+        await controller.setup(true)
+        await expect(system.storage.find('R11BetweenDoc',
+            MatchExp.atom({ key: 'num', value: ['between', 25] }), undefined, ['num'])
+        ).rejects.toThrow(/requires a two-element array/)
+        await system.destroy()
+    })
+
+    test('valid between still works', async () => {
+        const Doc = Entity.create({
+            name: 'R11BetweenDoc2',
+            properties: [Property.create({ name: 'num', type: 'number' })],
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({ system, entities: [Doc], relations: [] })
+        await controller.setup(true)
+        await system.storage.create('R11BetweenDoc2', { num: 30 })
+        await system.storage.create('R11BetweenDoc2', { num: 99 })
+        const hits = await system.storage.find('R11BetweenDoc2',
+            MatchExp.atom({ key: 'num', value: ['between', [25, 50]] }), undefined, ['num'])
+        expect(hits.map((h: any) => h.num)).toEqual([30])
+        await system.destroy()
+    })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Eleventh-round deep code review targeting historical cold zones (ScopedSequence/RealTime stack, concurrency/transaction lifecycle, storage expression layer, builtins execution chain + serialization). Every fatal/important finding below was **reproduced with a running test before fixing**. Full report: `agentspace/output/deep-review-2026-07-09-r11.md`.

### Fatal (reproduced, fixed)

- **F-1 — No cycle/depth guard on computation propagation.** Mutually-derived Transforms or mutually-dependent global dict computations were declaration-legal but looped forever at runtime (reproduced: `controller.setup(true)` hung past a 120s timeout with zero errors). Fixed two ways: a direct self-referential global dataDep now fails fast at setup, and a propagation depth guard in the scheduler's mutation listener (`AsyncLocalStorage`-scoped, limit 100) turns any remaining divergent cycle into a controlled `SchedulerError` carrying the recent propagation trail. Legitimate chains are unaffected (regression-tested).
- **F-2 — json/collection columns broke on `IN` / `NOT IN`.** Same disease r10 F-3 fixed for `=`/`!=`: write path serializes, match path bound raw params. PGLite raised `operator does not exist: json = unknown`; SQLite crashed outright (`Too many parameter values`). Fixed via dialect hooks (`::jsonb` on PG family, `CAST(? AS JSON)` on MySQL) with a serialized-text fallback; NULL rows excluded consistently; empty-list constant-false/true forms avoid json comparison operators.
- **F-3 — GetAction query semantics bound by reference identity.** `resolve` was only attached when `args.action === GetAction` (the singleton, whose uuid was random per process). Any serialization round-trip (which rebuilds an Action as a different object) silently produced `data: undefined`. **Design (revised per review feedback):** query semantics now bind to an explicit exported constant identity — `GetAction` carries a fixed well-known uuid (exported `GET_ACTION_UUID`) that survives serialization; `Action.create` is idempotent for that uuid (deserialization reuses the live singleton) and rejects it under any other name. An Action merely *named* `'get'` is an ordinary action and gains no query semantics; declaring `data`/`dataPolicy` without the `GetAction` constant fails fast with a hint to import it.

### Important (reproduced, fixed)

- Duplicate eventSource names in one `Controller` silently overwrote earlier registrations (`findEventSourceByName` resolved only the last one; earlier guard chains became unreachable) — now fails fast.
- Property RealTime with neither `attributeQuery` nor `dataDeps` registered zero listeners: the callback never ran and every created record silently persisted `0` — now fails fast (the time-based scheduler is not implemented; global RealTime stays legal because migration rebuild is a valid trigger path).
- `['LIKE', ...]` (uppercase) fell through to the internal `unknown value expression` assert — simple operators are now case-normalized.
- `['between', 25]` (malformed operand) threw a bare TypeError — now a controlled error.

### Also

- Knowledge base: documented that `storage.listen` callbacks run **inside** the dispatch transaction (pre-commit, external side effects are not rolled back) vs `RecordMutationSideEffect` (post-commit); documented that query semantics come from the exported `GetAction` constant only.
- Test-matrix corrections: 4 existing specs declared `data` on non-get actions (silently dead before, now rejected).
- Report also records 8 high-confidence unfixed items (with priorities) and 4 falsified/reclassified candidates.

## Testing

- ✅ New regression suites: `tests/runtime/review-fixes-2026-07-09-r11.spec.ts` (12), `tests/runtime/review-fixes-2026-07-09-r11-serialization.spec.ts` (2), `tests/storage/review-fixes-2026-07-09-r11.spec.ts` (6)
- ✅ `npm run check`
- ✅ `npm test` — 1815 passed / 26 skipped (baseline before fixes: 1795 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-443d250c-050c-462e-8c6e-cbf2743b5327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-443d250c-050c-462e-8c6e-cbf2743b5327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

