### PR TITLE
Deep code review r12: global patch envelope, reference-value joins, json value-domain matrix, declaration-mode fail-fasts

### DIFF
--- a/agent/agentspace/knowledge/usage/12-data-querying.md
+++ b/agent/agentspace/knowledge/usage/12-data-querying.md
@@ -242,6 +242,19 @@ const usersWithHighScore = await system.storage.find(
   {},
   ['id', 'username', 'currentScore', 'bestScore']
 );
+
+// Reference value can also traverse x:1 relations (compare against a related record's field).
+// The relation path is joined automatically; records without the related record (NULL) don't match.
+const usersEarningLessThanLeader = await system.storage.find(
+  'User',
+  MatchExp.atom({ 
+    key: 'salary', 
+    value: ['<', 'leader.salary'], 
+    isReferenceValue: true 
+  }),
+  {},
+  ['id', 'username', 'salary']
+);
 ```
 
 ## 11.3 Modifiers and Sorting

--- a/agentspace/output/deep-review-2026-07-10-r12.md
+++ b/agentspace/output/deep-review-2026-07-10-r12.md
@@ -1,0 +1,185 @@
+# 全代码库深度 Review 报告（2026-07-10 第十二轮）
+
+- 日期：2026-07-10
+- 基线：`main` @ `402df40f`（v2.0.3，r1–r11 的致命/重要修复全部落地）
+- 范围：四路并行深度探查历史冷区——storage 读路径与表达式层（QueryExecutor 分页/递归、MatchExp 引用值、Modifier、AttributeQuery/RecordQuery/SchemaDialect、objectstorage）/ runtime 并发·异步·调度（transaction、asyncContext、patch 应用链、ScopedSequence helper 栈）/ core 声明层与序列化管线（createClass 校验空洞、RefContainer、clone 语义、注册表完备性）/ builtins 执行链与 drivers 纵深（Activity 图形态、四驱动 feature parity、Gateway/Event/Data 死区、vscode-extension、scripts）
+- 方法：先对 r1–r11 全部报告做**逐条去重清单**（约三分之一的四路探查候选为既有遗留项重复，已剔除）→ 对每个致命/重要候选**编写最小复现测试实际运行**（PGLiteDB/SQLiteDB）。只有「已运行复现确认」的问题列为致命/重要；证伪或重新归类的候选明确记录（见第五节）。
+- 基线健康度：`npm run check` 通过；`npm test` 全量 1815 passed / 26 skipped。
+
+> **维护说明（2026-07-10）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r12-4298`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-10-r12.spec.ts`（9 用例）+ `tests/storage/review-fixes-2026-07-10-r12.spec.ts`（5 用例）。修复后 `npm run check` 通过；`npm test` 全量 **1829 passed / 26 skipped**（零既有用例回归——本轮修复的静默失效形态恰好没有任何测试固化过，佐证其「零告警」属性）。知识库 `usage/12-data-querying.md` 补充 isReferenceValue 跨关系路径示例。
+
+---
+
+## 一、结论摘要
+
+经十一轮修复，读写主路径、聚合增量、filtered/merged 编译、Activity 状态机、migration、json 等值匹配主干均已高度收敛。本轮在剩余冷区找到的新致命项集中在三类：
+
+1. **patch 应用链的形态漏洞**——`incrementalPatchCompute` 的 patch 信封在 global dict 分支被原样写入（其他分支都解析 `patch.type`/`patch.data`），任何 global 级 patch 计算的 dict 值全链路污染。现有测试恰好只断言"回调被调用过"，从未断言 dict 终值。
+2. **查询编译器只看 key 不看 value**——`isReferenceValue` 的引用路径（`value[1]`）从不参与 JOIN 树构建，跨关系的字段比较（文档已示例同行比较，跨关系是同一 API 的自然延伸）100% 裸崩 `missing FROM-clause entry`。
+3. **json 列的"值域 × 驱动"矩阵残缺**——r10/r11 修通了 object 等值匹配的主干，但（a）字符串 JSON 值在返回已解析值的驱动（PGlite/pg/mysql2）上**读回必炸**（读路径对所有 string 无条件二次 JSON.parse）；（b）update 路径不走 `prepareFieldValue`，字符串值存成非法 JSON 文本、对象存成非规范形；（c）SQLite 文本回退比较对键序敏感，同一模型同一查询在 SQLite/PG 系产出不同结果（静默漏命中）。
+
+另有一族「声明合法、语义静默蒸发」的声明期校验空洞（孤立 matchExpression、filtered+merged 模式叠加、computed+computation 双写通道、Activity 图节点实例复用），全部实测确认后以 fail-fast 收口。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修） | 3 | global patch 信封污染 dict、isReferenceValue 跨关系必崩、json 值域×驱动矩阵（字符串值读回炸 / update 形态漂移 / SQLite 键序静默漏命中） |
+| 重要（已复现，已修） | 5 | 见第三节 |
+| 证伪/重新归类 | 6 | 见第五节 |
+| 重要（探查/精读，高置信度，未修） | 9 | 见第四节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认，本轮已修复）
+
+### F-1 `applyResultPatch` global 分支把 patch 信封整个写进 dict：patch 模式的 global 计算全链路污染
+
+- 位置：`src/runtime/Controller.ts` `applyResultPatch`（global 分支 `dict.set(name, patch)`，对照 entity/relation/property 分支全部解析 `patch.type`/`patch.data`）。
+- 复现（实测输出）：
+
+```
+// global dict + Custom.incrementalPatchCompute 返回 {type:'insert', data: lastValue+1}
+create('PatchEntity', {...})
+dict.get('patchDict') → {"type":"insert","data":1}     ❌ 信封对象，不是值 1
+```
+
+- 影响：`incrementalPatchCompute` 是文档化的扩展点，global（dict）形态声明合法、同步与 asyncReturn 两条路径都路由到该分支。一旦使用，dict 里存的是信封对象——依赖该 dict 的所有下游计算（dataDeps global 引用）、`dict.get` 的业务读取全部拿到损坏值。现有 `customHandles.spec.ts` 的 global patch 用例只断言回调执行过、从未断言 dict 终值，缺陷因此十一轮未被发现。
+- 修复：global 分支解析信封——insert/update 写 `patch.data`，delete 写 `null`（与 property 分支的 delete → null 一致）；同时对**所有**分支增加信封形态校验（`patch.type` 不是 insert/update/delete 一律抛 `ComputationError`，指引「裸值请用 incrementalCompute」）——此前 entity/relation 分支对未知 type 也是静默跳过。
+
+### F-2 `isReferenceValue` 的引用路径不参与 JOIN 树：跨关系的字段比较 100% 裸崩
+
+- 位置：`src/storage/erstorage/MatchExp.ts` `buildQueryTree`（只遍历 atom.key，从不解析 `value[1]` 引用路径）；对照 `getReferenceFieldValue`（把 `leader.salary` 编译成 `"User_leader"."salary"` 列引用直接嵌入 WHERE）。
+- 复现（实测输出）：
+
+```
+find('User', MatchExp.atom({ key:'salary', value:['<','leader.salary'], isReferenceValue:true }))
+→ error: missing FROM-clause entry for table "RefUser7_leader"   ❌ 裸数据库错误
+```
+
+- 影响：`isReferenceValue` 是文档化 API（`usage/12-data-querying.md` 示例了同行字段比较）；跨 x:1 关系比较（"字段 A 小于关联实体的字段 B"）是同一声明形式的自然延伸——声明完全合法，运行 100% 崩溃，且错误信息与用户写法完全脱节。
+- 修复：`buildQueryTree` 对 `isReferenceValue` 且引用值为多段路径的 atom，把引用路径加入 query tree（JOIN 自动构建；NULL 关联行按 SQL 比较语义自然不匹配）。exist 子查询场景（`contextRootEntity` 指向外层查询的根、引用解析的是外层已在作用域内的别名）明确排除，不误加内层 JOIN。知识库补充跨关系引用示例。
+
+### F-3 json 列的「值域 × 驱动」矩阵残缺：字符串值读回必炸、update 形态漂移、SQLite 键序静默漏命中
+
+三个问题同根（json 列的序列化/反序列化在写路径、读路径、匹配路径、驱动行为四方不对齐），一并修复。
+
+- 位置：`src/storage/erstorage/QueryExecutor.ts` `structureRawReturns`（对 json 字段的所有 string 值无条件 `JSON.parse`）；`SQLBuilder.buildUpdateSQL`（不走 `prepareFieldValue`，由驱动兜底 `JSON.stringify`——字符串值原样绑定）；`MatchExp` json 文本回退比较与 `prepareFieldValue` 均用非规范 `JSON.stringify`。
+- 复现（实测输出）：
+
+```
+// (a) 字符串 JSON 值 + 返回已解析值的驱动（PGlite/pg/mysql2 均默认解析 json 列）
+create('Doc', { meta: 'plain-string' })   // type:'object' 的属性存字符串——合法 JSON 值
+findOne(...) → Failed to parse JSON field "Doc.meta": Unexpected token 'p'   ❌ 读回必炸
+
+// (b) update 路径（SQLite）
+update('Doc', ..., { meta: 'plain-string' })  → 存成 plain-string（非法 JSON 文本）
+findOne(...) → Failed to parse JSON field                                      ❌ 同炸
+
+// (c) SQLite 等值匹配键序敏感
+create('Doc', { meta: {a:1, b:2} })
+find(..., ['=', {b:2, a:1}]) → SQLite: 0 命中 / PGLite: 1 命中                 ❌ 跨驱动语义漂移
+```
+
+- 影响：(a) 是「合法值域必炸」——JSON 的值域包含字符串，任何在 json/object 属性里存字符串的应用在 PG 系/MySQL 上读回即崩（`'123'` 这类数字字符串则被静默变成数字，更隐蔽）；(b) 让 update 过的 json 行在 SQLite 上损坏或与 create 行形态漂移；(c) 是静默错误结果——测试（PGLite）通过、生产换 SQLite 后同一查询漏命中。
+- 修复（治理为「一种规范形 + 驱动声明」）：
+  1. 新增 `canonicalJSONStringify`（递归键排序的规范 JSON 序列化），`prepareFieldValue` 与 MatchExp 的 `=`/`!=`/`in`/`not in` 文本回退全部改用——写入与匹配两侧永远一致，SQLite 文本比较从此对键序不敏感，与 PG 系（`::jsonb`）/MySQL（`CAST AS JSON`）的语义相等对齐；
+  2. `buildUpdateSQL` 与 INSERT 一致走 `prepareFieldValue`（`UpdateExecutor` 透传 fieldType）；
+  3. `Database` 接口新增 `returnsParsedJSON` 能力声明（PGlite/pg/mysql2 为 true，better-sqlite3 缺省 false），读路径只对「返回原始 JSON 文本」的驱动做 `JSON.parse`——已解析驱动上的字符串 JSON 值不再被二次 parse。
+
+---
+
+## 三、重要问题（已复现，本轮已修复）
+
+### R-1 声明模式冲突静默蒸发：孤立 matchExpression / filtered+merged 叠加 / computed+computation 双写通道
+
+- 位置：`src/core/Entity.ts` / `Relation.ts` / `Property.ts` 的 create/构造校验空洞。
+- 复现（实测输出）：
+
+```
+Entity.create({ name:'X', matchExpression: {...} })            // 无 baseEntity
+→ setup 按普通实体建表，谓词从不生效，全量记录可见            ❌ 声明静默蒸发
+
+Entity.create({ name:'Y', baseEntity, matchExpression, inputEntities: [A,B] })
+→ merged 编译管线接管，filtered 语义（谓词）静默丢弃           ❌ 两种模式叠加取其一
+
+Property.create({ name:'x', computed: r=>r.n*2, computation: Custom.create(...) })
+→ 实测 computed 每次写入静默覆盖 computation 的输出（x=10/14 而非 105/107）❌ 双写通道竞争
+```
+
+- 修复：三处声明期 fail-fast（错误信息说明互斥语义与正确做法）。`defaultValue + computation` 的并存 r10 已证实有 setup 期拒绝，`computed + computation` 是同族漏项。内部管线核实不受影响（merged 的 transformMergedItem 在 create 后赋值 matchExpression，不走 create 参数；`Property.clone` 用 `new Property` 不过校验）。Relation 侧同步收口 `inputRelations + baseRelation` 与孤立 matchExpression。
+
+### R-2 Activity 图节点实例复用：静默覆盖图注册表
+
+- 位置：`src/builtins/interaction/activity/ActivityCall.ts` `buildGraph`——`uuidToNode.set`/`rawToNode.set` 无重复检测，同一 Interaction 实例出现两次时后写覆盖先写。
+- 复现：同一 interaction 同时挂在顶层与 group 子活动 → 实测抛出与声明完全脱节的 `start node must one, current: 2`（本形态碰巧被起点唯一性校验拦下；其他形态——如两个分支共享同一实例——会静默把 transfer/状态推进绑到错误节点）。
+- 修复：interaction/group 实例在图中重复出现即声明期抛错（指引「每个节点必须是独立的 Interaction.create 实例」）。
+
+### R-3 activity head 带 activityId 时不走 `fullGuardWithUserRef`：isRef attributive 落到误导性错误
+
+- 位置：`src/builtins/interaction/activity/ActivityManager.ts` `wrappedGuard`——head+activityId 分支调 `interaction.guard`（standalone 路径，无 `checkUserRef` 钩子）。
+- 复现：every 组两分支各有 head，分支一 head 保存 userRef 后，分支二 head（带 activityId、userAttributives 为 isRef attributive）dispatch → 修复前抛 `isRef... can only be checked inside an activity`（明明就在 activity 里）。
+- 修复：head+activityId 分支与非 head 一致走 `fullGuardWithUserRef`（refs 已存在，isRef 语义完整）；首个 head（无 activityId，refs 尚不存在）保持 standalone 校验。回归覆盖「错误用户被拒 + 正确用户放行」。
+
+### R-4 SQLite `open(forceDrop)` 忽略 forceDrop：文件库 `setup(true)` 二次运行即报错
+
+- 位置：`src/drivers/SQLite.ts` `open()`（无参实现）。`:memory:` 每次 new 都是新库掩盖了问题；文件库上第二次 `setup(true)` 在 CREATE TABLE 处抛 `table already exists`，与 PG（DROP DATABASE）/PGLite（drop 全表）的 forceDrop 语义不一致。
+- 修复：forceDrop 时枚举 `sqlite_master` 用户表并 drop（与 PGLite 同策略）。文件库回归用例。
+
+### R-5 小修集
+
+- `RecordQuery.derive` 不传 `alias`（filtered relation 的对外名），派生查询挂载名可能退回 base 属性名——补透传；
+- `Scheduler.runDirtyRecordsComputation` 注释声称"continue with other records"而实际 fail-fast 中断整批——注释改为与行为一致（部分成功的静默不一致比中断更危险，行为本身是对的）。
+
+---
+
+## 四、重要问题（探查/精读判定，高置信度，本轮未修）
+
+| # | 问题 | 位置 | 说明 |
+|---|------|------|------|
+| I-1 | **`setDictionaryValue` find-then-write 竞态**：并发 dispatch 双 miss 时两路 create（`_DICTIONARY_` 无唯一约束，产生双行）、双 hit 时 lost update | `MonoSystem.ts` L258–275 | 与 r3-R4/r5-I-12 同族的并发缺口；根治需要驱动级 UPSERT 原语 + dict key 唯一约束，建议与 activity refs CAS 一起做一轮并发治理 |
+| I-2 | **Klass.clone 注册表语义分裂**：Entity/Relation/Property 的 clone 显式不注册（r 系列修复的既定语义，源码有 CAUTION 注释），其余 25+ 个 Klass 的 clone 全部经 `create()` 注册进 `instances`——实测 `Count.clone` 后 `Count.instances` 增长 | 各 core/builtins Klass | 污染 `stringifyAllInstances` 输出（序列化管线是公开 API）、跨测试泄漏。框架内部当前零调用非 ER clone（RefContainer/MergedItemProcessor 只用 ER 三件套），无 live 触发路径，但公开 API 的语义分裂应统一为「clone 不注册」；改动面广（25+ 文件）建议独立 PR |
+| I-3 | **async task 无 failed 终态**：`handleAsyncReturn` 或 `applyResult*` 抛错（非 retryable）时事务回滚，task 永驻 `success`/`pending`，无失败标记、无重试退避、无告警钩子 | `Scheduler.ts` L993–1062、`markAsyncTaskStatus`（仅 applied/skipped） | 与 r2-I-6（task 表只增不减）叠加成运维债务；建议补 `failed` 状态 + 错误详情列 |
+| I-4 | **offset-only + x:n 路径全表拉取**：`needsPostPagination` 剥离 SQL 的 LIMIT/OFFSET 后内存 slice——`{offset: 1000}` 无 limit 时数据库返回全部扇出行 | `QueryExecutor.ts` L200–238 | r3-I-2（x:n+LIMIT 禁用下推）家族的具体形态；正确性无损（两段式语义正确），深分页大表上是性能悬崖 |
+| I-5 | **EXIST 子查询误触 post-pagination**：`queryTreeHasXToManyPath` 保守判定把纯 EXIST 过滤（无 join 扇出）也算作 x:n 路径，触发全量拉取+内存分页 | `QueryExecutor.ts` L343–354（注释自证保守） | 语义正确、性能保守；查询编译器级优化项 |
+| I-6 | **`contains` 四驱动语义不完全等价**：PG 系 `json_array_elements_text` 假设数组展开、MySQL `JSON_CONTAINS` 对 object/array/scalar 规则不同、SQLite `json_each` 再比 value——json 列存 object/scalar 混合值时行为漂移 | 四驱动 `parseMatchExpression` | F-3 治理了 `=`/`in` 的矩阵；contains 的跨驱动矩阵建议测试固化后文档化 |
+| I-7 | **SQLite 无行锁能力**：`supportsSelectForUpdate=false` 时 `lockRows`/`lockRecord` 实为普通 SELECT，asyncReturn/Transform 的锁语义在 SQLite 上不成立 | `SQLite.ts` L33、`MonoSystem.ts` lockRows | 驱动 notes 已声明无 PG 级隔离；建议在 `atomicSequenceCapability` 样式上补 `rowLocking` 能力位并文档化「SQLite=单进程串行」 |
+| I-8 | **`Event`/`Activity.events` 全链死 API**：Event 已注册 Klass、可序列化进 Activity graph，但执行链（ActivityCall/ActivityManager/Controller）零引用；`findRootActivity` 永久 `return null`；`ActivityManager.getActivityCall(activityId)` 参数名误导（key 实为定义 uuid，传运行期 activityId 恒 undefined） | `Event.ts`、`Activity.ts` L363–365、`ActivityManager.ts` L188–190 | r7-I-15 死代码族的 builtins 残余；删除是 breaking 决策，建议下一个 major 统一清理 |
+| I-9 | **head 无 activityId + isRef attributive 的错误信息误导**：首个 head 尚无 refs，isRef 检查落入 standalone 拒绝分支，错误说"can only be checked inside an activity"（用户明明在 activity 里）| `Interaction.ts` `checkUser` | R-3 修了带 activityId 的形态；无 activityId 的首 head 语义上确实无 refs 可查（永不可通过），建议错误信息区分「首个 head 没有先前保存的 refs」或声明期直接拒绝 head+isRef 组合 |
+
+另有低优先级项：`RecordBoundState.setInternal` 吞掉「目标行不存在」（并发删除宿主后 bound state 静默不更新，聚合模板有 fullRecompute 兜底、通用路径无）；`AttributeQuery.mergeAttributeQueryData` 合并重复关系键时丢第三元组 `onlyRelationData`（r3-I-4 的姊妹维度，正常路径未复现出错误结果）；`vscode-extension/` 的 webview 类型与主包 API 完全脱节（自定义 Interaction/PayloadField 形状，改 builtins 零编译反馈）；`scripts/update-coverage-badge.ts` 对缺失 coverage 文件裸崩。
+
+## 五、本轮证伪/重新归类的候选
+
+| 候选 | 结论 |
+|------|------|
+| 「PostgreSQL `pk` 列 `GENERATED ALWAYS AS IDENTITY` + 框架恒显式 INSERT id → 真 PG 上 create 全失败」（drivers 探查，初判致命） | 证伪：`Setup.assignTableAndField` 第一遍会用 `mapToDBFieldType('id')`（INT）覆盖 ID_ATTR 的初始 'pk' fieldType，最终只有从不显式插入的 `_rowId` 列是 IDENTITY；PostgreSQL Concurrency CI（真 PG16 + create 路径）持续绿灯 |
+| 「findOne/limit-1 下推 + orderBy 在 x:n 扇出下选错根记录」「post-pagination 不修正 ORDER BY」（storage 探查 #1/#2） | 证伪：实测（PGLite，n:n 扇出 ×2，orderBy age DESC）findOne 返回正确的最大值根记录、`limit:2 offset:1` 分页序正确——根字段排序下扇出行成组相邻，首行/首现顺序即根序 |
+| 「goto 无对应 label 时环检测失效 → 无限递归」（storage 探查 #5） | 证伪：`recordQueryRef.get(goto)` 为 undefined 时 `assert` 立即抛 `goto xxx not found` 受控错误，不会进入递归 |
+| 「global dataDep 的 create 事件缺 dict key 过滤 → 每个新 dict 键触发全部 global 计算」（runtime 探查 N-2） | 证伪：`shouldTriggerUpdateComputation` 的 dict key 过滤位于函数首行（早于 `source.type !== 'update'` 短路），对 create/update 事件同样生效 |
+| 「ScopedSequence match 未知算子静默判 false」（runtime 探查 N-10） | 证伪：`ScopedSequence.create`/round-trip 均经 `validateScopedSequenceMatchExpression` 白名单校验（6 算子），运行期 switch 覆盖白名单全集，非法算子到不了求值层 |
+| 「传播轨迹 trail 数组跨层级共享引用 → 兄弟分支污染」（runtime 探查 N-9） | 重新归类：共享是有意设计——trail 是跨传播链的调试面包屑（深度超限报错需要完整链路），兄弟残留只影响错误消息的「最近 32 条」窗口内容，深度计数本身按 ALS 隔离正确 |
+
+## 六、既有遗留项复确（r2–r11 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4-I-1）；`!=` 三值逻辑；dispatch 先持久化事件再 resolve（r9-I-2）；守卫非 boolean truthy 放行（r9-I-4）；payload 弱校验族 / `userRef`/`itemRef` 死 API（r7）；isRef 无行级授权 IDOR 面（r11-I-5）；GetAction 无 dataPolicy 全表可查（r1-R4，文档已警告）；StateMachine 单事件单跳（r7-I-8）；同批 property 计算无拓扑序（r7-I-9）。
+- **性能/资源**：global dict 变更宿主全表扫描（S3）；async task 表只增不减（r2-I-6）；storage 级联删除无深度上限（r2-I-5，r11-F1 只覆盖计算传播翼）；迁移全表载入内存（MIG-I3）；迁移锁无租约。
+- **并发**：activity `refs` 无版本 RMW（r5-I-12，本轮 I-1 的 dict.set 为同族新形态）；handleAsyncReturn find-then-lock 幻影行（r3-R4）；SERIALIZABLE 重试边界内 guard/afterDispatch 重放（S2）。
+- **migration**：rename = remove+add（r9-I-3）；迁移阶段顺序（r10-I-1）；merged input 移除孤儿数据（r10-I-2）；MySQL legacy log PG 方言（r10-I-3）。
+- **时间调度**：`nextRecomputeTime` 无消费方（r3-R5）。
+
+## 七、修复优先级建议（遗留项）
+
+1. **I-1 dict.set 竞态 + r5-I-12 refs RMW + r3-R4 asyncReturn 幻影行**——三者同属「READ COMMITTED 下的 find-then-write」家族，适合一轮集中的并发治理（驱动 UPSERT 原语 + 关键表唯一约束 + CAS 扩展）；
+2. **r10-I-1 迁移阶段顺序**（连续三轮位居榜首的未修项）——唯一可能产出「静默错误聚合值」的已知路径；
+3. **I-2 Klass.clone 注册语义统一**——公开序列化管线的正确性边界，机械改动、独立 PR；
+4. **I-3 async task failed 态**——可观测性缺口，改动小；
+5. **createClass 统一校验**（r7-I-13 未知参数 + r11-I-8 public.constraints 死元数据 + 本轮 R-1 三处手工校验）——R-1 又添三个手工 fail-fast，进一步佐证「声明校验应在 createClass 层统一执行」的一次性根治价值。
+
+## 附录：复现要点（验证用）
+
+- F-1：global dict + `incrementalPatchCompute` 返回 `{type:'insert', data:n}` → `dict.get` 应得 `n`；返回 `{type:'delete'}` → null；返回裸值 → 抛 `ComputationResultPatch envelope` 错误。
+- F-2：`MatchExp.atom({key:'salary', value:['<','leader.salary'], isReferenceValue:true})` → 应正确命中（无 leader 的行不匹配），不再报 missing FROM-clause。
+- F-3：json 属性存字符串 → PGLite/SQLite 读回原字符串；update 成字符串/换键序对象 → 读回与等值匹配正确；`['=', {b,a}]` 与 `['in', [{b,a}]]` 在 SQLite/PGLite 命中一致。
+- R-1：孤立 matchExpression / baseEntity+inputEntities / matchExpression 无 baseRelation / inputRelations+baseRelation / computed+computation → 均应声明期抛错。
+- R-2：同一 Interaction 实例挂两处 → `new ActivityManager` 抛 `appears more than once`。
+- R-3：every 组分支二 head 带 activityId + isRef userAttributives → 错误用户被拒（非 "outside activity" 错误）、正确用户放行。
+- R-4：文件库 SQLite `setup(true)` 连续两次 → 第二次应重建成功且表为空。

--- a/src/builtins/interaction/activity/ActivityCall.ts
+++ b/src/builtins/interaction/activity/ActivityCall.ts
@@ -216,6 +216,12 @@ export class ActivityCall {
         const seq = {}
 
         for(let interaction of activity.interactions!) {
+            // fail-fast: 图节点按 interaction 实例/uuid 索引（uuidToNode/rawToNode），同一实例
+            //  在活动图中出现两次会静默覆盖先注册的节点——transfer 解析、状态推进、guard 都可能
+            //  绑到错误的节点上（症状从误导性的 "start node must one" 到静默的错误状态推进不等）。
+            if (this.uuidToNode.has(interaction.uuid)) {
+                throw new Error(`Interaction "${interaction.name}" appears more than once in activity "${this.activity.name}". Each graph node must be a distinct Interaction instance — create a separate Interaction (a new Interaction.create call) for each step.`)
+            }
             const node: InteractionNode = { content: interaction, next: null, uuid: interaction.uuid, parentGroup, parentSeq: seq as Seq, }
             this.uuidToNode.set(interaction.uuid, node)
             this.rawToNode.set(interaction, node)
@@ -227,6 +233,10 @@ export class ActivityCall {
             if (!InteractionState.GroupStateNodeType.has(group.type!)) {
                 const supported = Array.from(InteractionState.GroupStateNodeType.keys()).map(t => `'${t}'`).join(', ')
                 throw new Error(`ActivityGroup type "${group.type}" in activity "${activity.name}" is not supported. Supported types: ${supported}.`)
+            }
+            // fail-fast: 与 interaction 同理，group 实例复用同样会静默覆盖图节点。
+            if (this.uuidToNode.has(group.uuid)) {
+                throw new Error(`ActivityGroup (type '${group.type}') appears more than once in activity "${this.activity.name}". Each graph node must be a distinct ActivityGroup instance.`)
             }
             // fail-fast: a group with no child activities can never complete (group state
             // only advances via child-branch onChange callbacks, and an empty group has no

--- a/src/builtins/interaction/activity/ActivityManager.ts
+++ b/src/builtins/interaction/activity/ActivityManager.ts
@@ -110,10 +110,11 @@ export class ActivityManager {
                 const created = await activityCall.create(this)
                 args.activityId = created.activityId
             } else if (isHeadInteraction && args.activityId) {
+                // CAUTION 带 activityId 的 head（如 every/race 组里第二个分支的 head）已经有
+                //  activity refs 可用，必须与非 head 一样走 fullGuardWithUserRef——否则 isRef
+                //  userAttributives 会落到 standalone guard 的 "isRef outside activity" 拒绝分支。
                 await activityCall.checkActivityState(this, args.activityId, interaction.uuid)
-                if (interaction.guard) {
-                    await interaction.guard.call(this, args)
-                }
+                await activityCall.fullGuardWithUserRef(this, interaction, args)
             } else {
                 if (!args.activityId) {
                     throw new Error('activityId must be provided for non-head interaction of an activity')

--- a/src/core/Entity.ts
+++ b/src/core/Entity.ts
@@ -140,6 +140,16 @@ export class Entity implements EntityInstance {
     if (args.baseEntity && !args.matchExpression) {
       throw new Error(`Filtered entity "${args.name}" declares baseEntity but no matchExpression. A filtered entity is a predicate view over its base — declare matchExpression, or use the base entity directly.`);
     }
+    // matchExpression 只在 filtered entity（有 baseEntity）上有语义。孤立的 matchExpression
+    // 会被 setup 静默忽略（按普通实体建表，谓词从不生效）——零告警的声明失效，必须 fail-fast。
+    if (args.matchExpression && !args.baseEntity) {
+      throw new Error(`Entity "${args.name}" declares matchExpression without baseEntity. matchExpression only has meaning on a filtered entity — declare baseEntity as well, or remove matchExpression.`);
+    }
+    // filtered（baseEntity + matchExpression）与 merged（inputEntities）是互斥的声明模式：
+    // 同时声明时 merged 编译管线会静默吞掉 filtered 语义（谓词从不生效），必须 fail-fast。
+    if (args.baseEntity && args.inputEntities) {
+      throw new Error(`Entity "${args.name}" declares both baseEntity (filtered entity) and inputEntities (merged entity). These are mutually exclusive declaration modes — to filter a merged entity, declare the merged entity first and create a separate filtered entity on top of it.`);
+    }
 
     const instance = new Entity(args, options);
     

--- a/src/core/Property.ts
+++ b/src/core/Property.ts
@@ -89,6 +89,13 @@ export class Property implements PropertyInstance {
     if (typeof args.name !== 'string' || !validNameFormatExp.test(args.name)) {
       throw new Error(`Property name "${args.name}" is invalid. Property names must match ${validNameFormatExp} (letters, numbers and underscore only).`);
     }
+    // computed（storage 写路径上按同行字段求值）与 computation（反应式计算写回）是两条
+    // 互相竞争的写通道：同时声明时 computed 会在每次写入时静默覆盖 computation 的输出，
+    // computation 声明形同虚设——零告警的声明失效，必须 fail-fast。
+    // （defaultValue + computation 的并存已在 Scheduler setup 期拒绝，语义同族。）
+    if (args.computed && args.computation) {
+      throw new Error(`Property "${args.name}" declares both computed and computation. They are competing write channels for the same column (computed re-evaluates on every write and silently overwrites the computation's output) — keep exactly one.`);
+    }
 
     const instance = new Property(args, options);
     

--- a/src/core/Relation.ts
+++ b/src/core/Relation.ts
@@ -77,7 +77,18 @@ export class Relation implements RelationInstance {
   constructor(args: RelationCreateArgs, options?: { uuid?: string }) {
     this._options = options;
     this.uuid = generateUUID(options);
-    
+
+    // filtered（baseRelation + matchExpression）与 merged（inputRelations）是互斥的声明模式：
+    // 同时声明时 merged 分支会静默吞掉 filtered 语义（谓词从不生效），必须 fail-fast。
+    if (args.inputRelations && args.baseRelation) {
+      throw new Error(`Relation${args.name ? ` "${args.name}"` : ''} declares both baseRelation (filtered relation) and inputRelations (merged relation). These are mutually exclusive declaration modes — to filter a merged relation, declare the merged relation first and create a separate filtered relation on top of it.`);
+    }
+    // matchExpression 只在 filtered relation（有 baseRelation）上有语义。孤立的 matchExpression
+    // 会被静默丢弃（实例上根本不会携带该字段）——零告警的声明失效，必须 fail-fast。
+    if (args.matchExpression && !args.baseRelation) {
+      throw new Error(`Relation${args.name ? ` "${args.name}"` : ''} declares matchExpression without baseRelation. matchExpression only has meaning on a filtered relation — declare baseRelation as well, or remove matchExpression.`);
+    }
+
     // For merged relation
     if (args.inputRelations) {
       // Validate inputRelations

--- a/src/drivers/Mysql.ts
+++ b/src/drivers/Mysql.ts
@@ -50,6 +50,8 @@ export class MysqlDB implements Database{
     supportsSelectForUpdate = true
     // MySQL prepared statement 的占位符数量上限为 65535；留出安全余量。
     maxQueryParams = 65000
+    // mysql2 默认解析 JSON 列（jsonStrings: false），读路径不得再 JSON.parse。
+    returnsParsedJSON = true
     transactionCapability: TransactionCapability = {
         transactions: false,
         isolationLevels: [],

--- a/src/drivers/PGLite.ts
+++ b/src/drivers/PGLite.ts
@@ -21,6 +21,8 @@ export class PGLiteDB implements Database{
     supportsSelectForUpdate = true
     // PostgreSQL wire protocol 的绑定参数数量是 Int16（65535）；留出安全余量。
     maxQueryParams = 65000
+    // PGlite 返回已解析的 JSON 列值（对象/数组/字符串原值），读路径不得再 JSON.parse。
+    returnsParsedJSON = true
     transactionCapability: TransactionCapability = {
         transactions: true,
         isolationLevels: ['READ COMMITTED', 'SERIALIZABLE'],

--- a/src/drivers/PostgreSQL.ts
+++ b/src/drivers/PostgreSQL.ts
@@ -105,6 +105,8 @@ export class PostgreSQLDB implements Database{
     supportsSelectForUpdate = true
     // PostgreSQL wire protocol 的绑定参数数量是 Int16（65535）；留出安全余量。
     maxQueryParams = 65000
+    // node-postgres 返回已解析的 JSON 列值（对象/数组/字符串原值），读路径不得再 JSON.parse。
+    returnsParsedJSON = true
     transactionCapability: TransactionCapability = {
         transactions: true,
         isolationLevels: ['READ COMMITTED', 'SERIALIZABLE'],

--- a/src/drivers/SQLite.ts
+++ b/src/drivers/SQLite.ts
@@ -62,8 +62,19 @@ export class SQLiteDB implements Database{
         this.idSystem = new IDSystem(this)
         this.logger = this.options?.logger || dbConsoleLogger
     }
-    async open() {
+    async open(forceDrop = false) {
         this.db = new SQLite(this.file, this.options)
+        // CAUTION forceDrop 必须真正清空已有表。忽略它的话 :memory: 库碰巧没问题（每次
+        //  new 都是新库），但文件库上 setup(true) 会在 CREATE TABLE 处报 "table already
+        //  exists"——与 PG/PGLite 的 forceDrop 语义（重建）不一致。
+        if (forceDrop) {
+            const tables = this.db.prepare(
+                `SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`
+            ).all() as Array<{ name: string }>
+            for (const table of tables) {
+                this.db.prepare(`DROP TABLE IF EXISTS "${table.name.replace(/"/g, '""')}"`).run()
+            }
+        }
         await this.idSystem.setup()
     }
     async openForSchemaRead() {

--- a/src/runtime/Controller.ts
+++ b/src/runtime/Controller.ts
@@ -15,7 +15,7 @@ import { RealTimeHandles } from "./computations/RealTime.js";
 import { StateMachineHandles } from "./computations/StateMachine.js";
 import { CustomHandles } from "./computations/Custom.js";
 import { ScopedSequenceHandles } from "./computations/ScopedSequence.js";
-import { SchedulerError, SideEffectError } from "./errors/index.js";
+import { ComputationError, SchedulerError, SideEffectError } from "./errors/index.js";
 import { assert } from "./util.js";
 import { asyncEffectsContext } from "./asyncEffectsContext.js";
 import { asyncInteractionContext } from "./asyncInteractionContext.js";
@@ -616,8 +616,20 @@ export class Controller {
 
         const patches = Array.isArray(patch) ? patch : [patch]
         for(const patch of patches) {
+            // fail fast：patch 必须是 {type: 'insert'|'update'|'delete', ...} 信封。
+            //  未知形态静默跳过（或对 global 直接写入信封对象）都是零告警的数据损坏。
+            if (!patch || (patch.type !== 'insert' && patch.type !== 'update' && patch.type !== 'delete')) {
+                throw new ComputationError(
+                    `incrementalPatchCompute must return ComputationResultPatch envelope(s) ({type: 'insert'|'update'|'delete', data?, affectedId?}), got: ${JSON.stringify(patch)?.slice(0, 200)}. To return a plain value, use incrementalCompute instead.`,
+                    { computationPhase: 'apply-result-patch' }
+                )
+            }
                 if (dataContext.type === 'global') {
-                    await this.system.storage.dict.set(dataContext.id.name, patch)
+                    // CAUTION global dict 只有一个值，patch 的语义是"新值在 patch.data 里"。
+                    //  直接把 patch 信封对象（{type, data, affectedId}）写进 dict 会污染所有
+                    //  下游读取方（依赖该 dict 的计算读到的是信封而不是值）。
+                    //  insert/update 写入 patch.data，delete 写入 null（与 property 路径一致）。
+                    await this.system.storage.dict.set(dataContext.id.name, patch.type === 'delete' ? null : patch.data)
             } else if (dataContext.type === 'entity'||dataContext.type === 'relation') {
                 const erDataContext = dataContext as EntityDataContext|RelationDataContext
                 if (patch.type === 'insert') {  

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -635,7 +635,8 @@ export class Scheduler {
                     try {
                         await this.runComputation(source.computation, erRecordMutationEvent, record)
                     } catch (e) {
-                        // Log the error but continue with other records to avoid blocking the entire batch
+                        // CAUTION 单条记录的计算失败会中断整批并使事务回滚（fail-fast）。
+                        //  绝不能"跳过失败的记录继续"——那会留下部分计算结果的静默不一致。
                         const error = new ComputationError('Failed to run computation for dirty record', {
                             handleName: source.computation.constructor.name,
                             computationName: source.computation.args.constructor.displayName,
@@ -644,7 +645,6 @@ export class Scheduler {
                             context: { recordId: record?.id },
                             causedBy: e instanceof Error ? e : new Error(String(e))
                         })
-                        // For now, re-throw to maintain existing behavior, but in production you might want to log and continue
                         throw error
                     }
                 }

--- a/src/runtime/System.ts
+++ b/src/runtime/System.ts
@@ -280,6 +280,11 @@ export type Database = {
     // 单条 SQL 允许的最大绑定参数数量（如 SQLite 的 SQLITE_MAX_VARIABLE_NUMBER、PG wire protocol 的 Int16 上限）。
     // 声明后，MatchExp 会在编译期对超限的 IN/NOT IN 列表抛出带指引的受控错误，而不是留给驱动抛裸错误。
     maxQueryParams?: number,
+    // 驱动是否把 JSON 列的值解析后返回（node-postgres/PGlite/mysql2 会，better-sqlite3 返回原始文本）。
+    // 读路径靠它区分「已解析的 JSON 字符串值」与「未解析的 JSON 文本」：不声明（默认 false）时
+    // 字符串一律按 JSON 文本解析——对返回已解析值的驱动，字符串类型的 JSON 值会被错误地二次
+    // JSON.parse 直接抛错。
+    returnsParsedJSON?: boolean,
     setupInternalComputationState?: () => Promise<void>,
     setupScopedSequenceState?: () => Promise<void>,
     atomicSequenceCapability?: AtomicSequenceCapability,

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -1,6 +1,6 @@
 import {BoolExp, BoolExpressionRawData, ExpressionData} from "@core";
 import {EntityToTableMap, RecordAttribute} from "./EntityToTableMap.js";
-import {assert} from "../utils.js";
+import {assert, canonicalJSONStringify} from "../utils.js";
 import {RecordQueryTree} from "./RecordQuery.js";
 import {Database} from "@runtime";
 import {PlaceholderGen} from "./SQLBuilder.js";
@@ -163,6 +163,19 @@ export class MatchExp {
             const namePath = [this.entityName].concat(matchAttributePath)
             const attributeInfo = this.map.getInfoByPath(namePath)!
 
+            // CAUTION isReferenceValue 的引用路径（value[1]，如 'leader.salary'）也会被编译成
+            //  列引用（getReferenceFieldValue），如果引用穿过关联实体而该关联没有出现在
+            //  attributeQuery 或 match key 里，JOIN 不会被构建，SQL 直接报
+            //  "missing FROM-clause entry"。这里把引用路径也加入 query tree。
+            //  例外：exist 子查询里 contextRootEntity 指向外层查询的根，引用解析的是外层
+            //  已在作用域内的别名，不能加进本层的 tree。
+            if (matchData.data.isReferenceValue && typeof matchData.data.value[1] === 'string' && !this.contextRootEntity) {
+                const referencePath = (matchData.data.value[1] as string).split('.')
+                if (referencePath.length > 1) {
+                    recordQueryTree.addField(referencePath)
+                }
+            }
+
             // 直接就是 value 的情况不用管，没有 query 其他的实体。
             //  CAUTION 还有最后路径是 entity 但是  match 值是 EXIST 的不用管，因为会生成 exist 子句。只不过这里也不用特别处理，join 的表没用到会自动数据库忽略。
             if ((matchAttributePath.length === 1 && attributeInfo.isValue)) {
@@ -246,18 +259,18 @@ export class MatchExp {
                 }
                 fieldParams = []
             } else if (fieldType?.toLowerCase() === 'json' && (value[0] === '=' || value[0] === '!=')) {
-                // CAUTION json 列的写入路径统一走 JSON.stringify（SQLBuilder.prepareFieldValue），
+                // CAUTION json 列的写入路径统一走规范序列化（SQLBuilder.prepareFieldValue），
                 //  匹配参数若不做同样的序列化：文本型存储（SQLite/MySQL 文本比较）恒零命中，
                 //  PG/PGLite 直接抛 "operator does not exist: json = unknown" 的裸数据库错误。
                 //  优先给驱动方言机会（PG 系需要 ::jsonb 做语义相等比较），否则退化为与写入
-                //  路径一致的序列化文本相等比较。
+                //  路径一致的规范序列化文本相等比较（键序不敏感，与 PG 系语义对齐）。
                 const dialectResult = db?.parseMatchExpression?.(key, value, fieldName, fieldType!, isReferenceValue, this.getReferenceFieldValue.bind(this), p)
                 if (dialectResult) {
                     fieldValue = dialectResult.fieldValue
                     fieldParams = dialectResult.fieldParams || []
                 } else {
                     fieldValue = `${value[0]} ${p()}`
-                    fieldParams = [JSON.stringify(value[1])]
+                    fieldParams = [canonicalJSONStringify(value[1])]
                 }
             } else {
                 fieldValue = `${value[0]} ${p()}`
@@ -290,17 +303,17 @@ export class MatchExp {
                 fieldValue = fieldType?.toLowerCase() === 'json' ? `IS NOT NULL AND 1=0` : `IN (NULL) AND 1=0`
                 fieldParams = []
             } else if (fieldType?.toLowerCase() === 'json') {
-                // CAUTION 与 =/!= 同理（见上）：json 列的写入路径统一 JSON.stringify，
+                // CAUTION 与 =/!= 同理（见上）：json 列的写入路径统一规范序列化，
                 //  IN/NOT IN 的元素参数不做同样的序列化会导致 PG 系裸报 "operator does not exist"、
                 //  SQLite 把数组元素展开成多余绑定参数直接崩溃。优先给驱动方言机会（PG 系 ::jsonb），
-                //  否则退化为与写入路径一致的序列化文本比较。
+                //  否则退化为与写入路径一致的规范序列化文本比较。
                 const dialectResult = db?.parseMatchExpression?.(key, value, fieldName, fieldType!, isReferenceValue, this.getReferenceFieldValue.bind(this), p)
                 if (dialectResult) {
                     fieldValue = dialectResult.fieldValue
                     fieldParams = dialectResult.fieldParams || []
                 } else {
                     fieldValue = `IN (${value[1].map((_x: unknown) => p()).join(',')})`
-                    fieldParams = value[1].map((item: unknown) => JSON.stringify(item))
+                    fieldParams = value[1].map((item: unknown) => canonicalJSONStringify(item))
                 }
             } else {
                 fieldValue = `IN (${value[1].map((_x: unknown) => p()).join(',')})`
@@ -325,7 +338,7 @@ export class MatchExp {
                     fieldParams = dialectResult.fieldParams || []
                 } else {
                     fieldValue = `NOT IN (${value[1].map((_x: unknown) => p()).join(',')})`
-                    fieldParams = value[1].map((item: unknown) => JSON.stringify(item))
+                    fieldParams = value[1].map((item: unknown) => canonicalJSONStringify(item))
                 }
             } else {
                 fieldValue = `NOT IN (${value[1].map((_x: unknown) => p()).join(',')})`

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -101,13 +101,18 @@ export class QueryExecutor {
             return result
         }
 
+        // CAUTION JSON 字符串值的归一化取决于驱动是否已解析 JSON 列：
+        //  - better-sqlite3 返回原始 JSON 文本，读到的 string 是"未解析的 JSON"，需要 JSON.parse；
+        //  - node-postgres/PGlite/mysql2 返回已解析的值，读到的 string 就是 JSON 值本身
+        //    （json 值恰好是字符串），再 parse 一次会把 'plain' 变成裸报错、把 '123' 静默变成数字 123。
+        const jsonAlreadyParsed = this.database.returnsParsedJSON === true
         return rawReturns.map(rawReturn => {
             const obj = {}
             Object.entries(rawReturn).forEach(([key, value]) => {
                 // CAUTION 注意这里去掉了最开始的 entityName
                 const attributePath = fieldAliasMap.getPath(key)!.slice(1, Infinity)
                 const valueType = resolveValueType(attributePath)
-                if (typeof value === 'string' && valueType === 'json') {
+                if (!jsonAlreadyParsed && typeof value === 'string' && valueType === 'json') {
                     try {
                         value = JSON.parse(value)
                     } catch (e) {

--- a/src/storage/erstorage/RecordQuery.ts
+++ b/src/storage/erstorage/RecordQuery.ts
@@ -89,9 +89,9 @@ export class RecordQuery {
         return new RecordQuery(
             this.recordName,
             this.map,
-matchExpression||this.matchExpression,
-attributeQuery||this.attributeQuery,
-     modifier||this.modifier,
+            matchExpression||this.matchExpression,
+            attributeQuery||this.attributeQuery,
+            modifier||this.modifier,
             this.contextRootEntity,
             this.parentRecord,
             this.attributeName,
@@ -99,7 +99,10 @@ attributeQuery||this.attributeQuery,
             this.allowNull,
             this.label,
             this.goto,
-            this.exit
+            this.exit,
+            // CAUTION alias（filtered relation 的对外名）必须随派生保留，
+            //  否则结果挂载会退回 base 属性名。
+            this.alias
         )
     }
 }

--- a/src/storage/erstorage/SQLBuilder.ts
+++ b/src/storage/erstorage/SQLBuilder.ts
@@ -1,5 +1,6 @@
 import { Database } from "@runtime";
 import { BoolExp } from "@core";
+import { canonicalJSONStringify } from "../utils.js";
 import { EntityToTableMap } from "./EntityToTableMap.js";
 import { FieldMatchAtom, MatchExp } from "./MatchExp.js";
 import { AttributeQuery } from "./AttributeQuery.js";
@@ -483,12 +484,15 @@ VALUES
     }
     
     /**
-     * 构建 UPDATE 语句
+     * 构建 UPDATE 语句。
+     * CAUTION 与 INSERT 一致走 prepareFieldValue：否则 json 列在 update 路径上由驱动
+     *  兜底 JSON.stringify（非规范形、且字符串值不 stringify），与 create 路径的存储形态
+     *  漂移——字符串值甚至会让读路径的 JSON.parse 直接报错。
      */
     buildUpdateSQL(
         entityName: string,
         idRef: { id: string | number },
-        columnAndValue: Array<{ field: string, value: unknown }>
+        columnAndValue: Array<{ field: string, value: unknown, fieldType?: string }>
     ): [string, unknown[]] {
         if (!columnAndValue.length) {
             return ['', []]
@@ -502,7 +506,7 @@ UPDATE "${entityInfo.table}"
 SET ${columnAndValue.map(({ field }) => `"${field}" = ${p()}`).join(',')}
 WHERE "${entityInfo.idField}" = (${p()})
 `
-        const params = [...columnAndValue.map(({ value }) => value), idRef.id]
+        const params = [...columnAndValue.map(({ value, fieldType }) => this.prepareFieldValue(value, fieldType)), idRef.id]
         
         return [sql, params]
     }
@@ -557,11 +561,13 @@ WHERE "${recordInfo.idField}" = ${p()}
     }
     
     /**
-     * 准备字段值（处理 JSON 等特殊类型）
+     * 准备字段值（处理 JSON 等特殊类型）。
+     * CAUTION json 用规范序列化（键排序）：等值匹配的文本比较回退路径（MatchExp）
+     *  依赖写入与匹配两侧的序列化一致，非规范形会让键序不同的等价对象匹配失败。
      */
     prepareFieldValue(value: unknown, fieldType?: string): unknown {
         if (fieldType?.toLowerCase() === 'json') {
-            return JSON.stringify(value)
+            return canonicalJSONStringify(value)
         }
         return value
     }

--- a/src/storage/erstorage/UpdateExecutor.ts
+++ b/src/storage/erstorage/UpdateExecutor.ts
@@ -146,12 +146,13 @@ export class UpdateExecutor {
         // 2. 分配 id,处理需要 flash out 的数据等，事件也是这里面记录的。这里面会有抢夺关系，所以也可能会有删除事件。
         const newEntityDataWithIdsWithFlashOutRecords = await this.agent.preprocessSameRowData(newEntityDataWithDep, true, events, matchedEntity)
         const allSameRowData = newEntityDataWithIdsWithFlashOutRecords.getSameRowFieldAndValue(matchedEntity)
-        const columnAndValue = allSameRowData.map(({field, value}: { field: string, value: string }) => (
+        const columnAndValue = allSameRowData.map(({field, value, fieldType}: { field: string, value: string, fieldType?: string }) => (
             {
                 field,
                 /// TODO value 要考虑引用自身或者 related entity 其他 field 的情况？例如 age+5
-                // value: JSON.stringify(value)
-                value: value
+                value: value,
+                // fieldType 让 buildUpdateSQL 走 prepareFieldValue（json 规范序列化），与 create 路径一致。
+                fieldType
             }
         ))
 

--- a/src/storage/utils.ts
+++ b/src/storage/utils.ts
@@ -54,3 +54,23 @@ export function deepMerge(a: ObjectContainer, b: ObjectContainer) {
 export function indexBy(arr: Record<string, unknown>[], key: string) {
 return Object.fromEntries(arr.map(o => [o[key], o]))
 }
+
+/**
+ * 与 JSON.stringify 等价，但对象键按字典序排序（递归），产出规范形（canonical form）。
+ *
+ * json 列的写入与等值匹配都用这个序列化：文本型比较的驱动（SQLite 未实现 json 方言时的
+ * 回退路径）对键序不再敏感，与 PG 系（::jsonb）/ MySQL（CAST AS JSON）的语义相等比较对齐。
+ * 数组顺序是 JSON 语义的一部分，保持不变。
+ */
+export function canonicalJSONStringify(value: unknown): string {
+    return JSON.stringify(sortObjectKeysDeep(value))
+}
+
+function sortObjectKeysDeep(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(item => sortObjectKeysDeep(item))
+    if (value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+        const record = value as Record<string, unknown>
+        return Object.fromEntries(Object.keys(record).sort().map(key => [key, sortObjectKeysDeep(record[key])]))
+    }
+    return value
+}

--- a/tests/runtime/review-fixes-2026-07-10-r12.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-10-r12.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * 第十二轮深度 review 修复的回归测试（runtime/core/builtins 部分）。
+ * 对应报告：agentspace/output/deep-review-2026-07-10-r12.md
+ */
+import { describe, expect, test } from "vitest";
+import {
+    Action,
+    Activity,
+    ActivityGroup,
+    ActivityManager,
+    Controller,
+    createUserRoleAttributive,
+    Custom,
+    Dictionary,
+    Entity,
+    Interaction,
+    KlassByName,
+    MatchExp,
+    MonoSystem,
+    Property,
+    Relation,
+    Transfer,
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+describe('r12 F-1: global dict incrementalPatchCompute applies patch.data, not the envelope', () => {
+    test('insert/update patches write data; delete writes null', async () => {
+        const TestEntity = Entity.create({
+            name: 'R12PatchEntity',
+            properties: [Property.create({ name: 'name', type: 'string' })],
+        });
+
+        const dict = Dictionary.create({
+            name: 'r12PatchDict',
+            type: 'number',
+            defaultValue: () => 0,
+            computation: Custom.create({
+                name: 'R12PatchCustom',
+                dataDeps: {
+                    records: { type: 'records', source: TestEntity, attributeQuery: ['name'] },
+                },
+                incrementalDataDeps: [],
+                compute: async function (this: any, dataDeps: any) {
+                    return (dataDeps.records || []).length;
+                },
+                incrementalPatchCompute: async function (this: any, lastValue: any, mutationEvent: any) {
+                    if (mutationEvent?.type === 'create') {
+                        return { type: 'insert', data: (lastValue ?? 0) + 1 };
+                    }
+                    if (mutationEvent?.type === 'delete') {
+                        return { type: 'delete' };
+                    }
+                    return undefined;
+                },
+                getInitialValue: function () { return 0; },
+            }),
+        });
+
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [TestEntity], relations: [], dict: [dict] });
+        await controller.setup(true);
+
+        await system.storage.create('R12PatchEntity', { name: 'a' });
+        // 修复前：dict 里存的是 {type:'insert', data:1} 信封对象
+        expect(await system.storage.dict.get('r12PatchDict')).toBe(1);
+
+        await system.storage.create('R12PatchEntity', { name: 'b' });
+        expect(await system.storage.dict.get('r12PatchDict')).toBe(2);
+
+        await system.storage.delete('R12PatchEntity', MatchExp.atom({ key: 'name', value: ['=', 'a'] }));
+        expect(await system.storage.dict.get('r12PatchDict')).toBe(null);
+
+        await system.destroy();
+    });
+
+    test('malformed patch envelope fails fast instead of silently corrupting', async () => {
+        const TestEntity = Entity.create({
+            name: 'R12PatchEntity2',
+            properties: [Property.create({ name: 'name', type: 'string' })],
+        });
+
+        const dict = Dictionary.create({
+            name: 'r12PatchDict2',
+            type: 'number',
+            defaultValue: () => 0,
+            computation: Custom.create({
+                name: 'R12PatchCustom2',
+                dataDeps: {
+                    records: { type: 'records', source: TestEntity, attributeQuery: ['name'] },
+                },
+                incrementalDataDeps: [],
+                compute: async function (this: any, dataDeps: any) {
+                    return (dataDeps.records || []).length;
+                },
+                incrementalPatchCompute: async function () {
+                    // 忘了信封，直接返回裸值
+                    return 42 as any;
+                },
+                getInitialValue: function () { return 0; },
+            }),
+        });
+
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [TestEntity], relations: [], dict: [dict] });
+        await controller.setup(true);
+
+        await expect(system.storage.create('R12PatchEntity2', { name: 'a' }))
+            .rejects.toThrow(/ComputationResultPatch envelope/);
+
+        await system.destroy();
+    });
+});
+
+describe('r12 R-1: declaration-mode conflicts fail fast', () => {
+    test('Entity matchExpression without baseEntity is rejected', () => {
+        expect(() => Entity.create({
+            name: 'R12OrphanMatch',
+            properties: [Property.create({ name: 'status', type: 'string' })],
+            matchExpression: MatchExp.atom({ key: 'status', value: ['=', 'active'] }),
+        })).toThrow(/matchExpression without baseEntity/);
+    });
+
+    test('Entity baseEntity + inputEntities is rejected', () => {
+        const Base = Entity.create({ name: 'R12ModeBase', properties: [Property.create({ name: 'kind', type: 'string' })] });
+        const In1 = Entity.create({ name: 'R12ModeIn1', properties: [Property.create({ name: 'a', type: 'string' })] });
+        expect(() => Entity.create({
+            name: 'R12ModeBoth',
+            baseEntity: Base,
+            matchExpression: MatchExp.atom({ key: 'kind', value: ['=', 'x'] }),
+            inputEntities: [In1],
+        })).toThrow(/mutually exclusive/);
+    });
+
+    test('Relation matchExpression without baseRelation is rejected', () => {
+        const A = Entity.create({ name: 'R12RelA', properties: [] });
+        const B = Entity.create({ name: 'R12RelB', properties: [] });
+        expect(() => Relation.create({
+            source: A, sourceProperty: 'bs',
+            target: B, targetProperty: 'as',
+            type: 'n:n',
+            matchExpression: MatchExp.atom({ key: 'status', value: ['=', 'active'] }),
+        })).toThrow(/matchExpression without baseRelation/);
+    });
+
+    test('Relation baseRelation + inputRelations is rejected', () => {
+        const A = Entity.create({ name: 'R12RelA2', properties: [] });
+        const B = Entity.create({ name: 'R12RelB2', properties: [] });
+        const r1 = Relation.create({ source: A, sourceProperty: 'x1', target: B, targetProperty: 'y1', type: 'n:n' });
+        const r2 = Relation.create({ source: A, sourceProperty: 'x2', target: B, targetProperty: 'y2', type: 'n:n' });
+        expect(() => Relation.create({
+            name: 'R12MergedFiltered',
+            inputRelations: [r1, r2],
+            baseRelation: r1,
+            matchExpression: MatchExp.atom({ key: 'status', value: ['=', 'active'] }),
+            sourceProperty: 'merged', targetProperty: 'mergedRev',
+        })).toThrow(/mutually exclusive/);
+    });
+
+    test('Property computed + computation is rejected', () => {
+        const E = Entity.create({ name: 'R12CompHost', properties: [] });
+        expect(() => Property.create({
+            name: 'x',
+            type: 'number',
+            computed: (r: any) => 1,
+            computation: Custom.create({
+                name: 'R12XComp',
+                dataDeps: { _current: { type: 'property', attributeQuery: ['n'] } },
+                compute: async () => 2,
+            }),
+        })).toThrow(/competing write channels/);
+    });
+});
+
+describe('r12 R-5: duplicate node instances in one activity graph fail fast', () => {
+    test('same Interaction instance in two places is rejected with a clear error', () => {
+        const stepA = Interaction.create({ name: 'r12StepA', action: Action.create({ name: 'r12StepA' }) });
+        const shared = Interaction.create({ name: 'r12Shared', action: Action.create({ name: 'r12Shared' }) });
+        const sub1 = Activity.create({ name: 'r12Sub1', interactions: [shared] });
+        const activity = Activity.create({
+            name: 'R12ReuseActivity',
+            interactions: [stepA, shared],
+            groups: [ActivityGroup.create({ type: 'every', activities: [sub1] })],
+            transfers: [Transfer.create({ name: 't1', source: stepA, target: shared })],
+        });
+        expect(() => new ActivityManager([activity]))
+            .toThrow(/appears more than once/);
+    });
+});
+
+describe('r12 R-6: activity head with activityId resolves isRef attributives via refs', () => {
+    test('second branch head with isRef userAttributives checks saved refs', async () => {
+        // every 组的两个分支各自有 head：分支一 head 保存 userRef，
+        // 分支二 head 用 isRef attributive 要求必须是同一个用户。
+        const starterRef = createUserRoleAttributive({ name: 'r12Starter', isRef: true });
+        const branch1Head = Interaction.create({
+            name: 'r12Branch1',
+            action: Action.create({ name: 'r12Branch1' }),
+            userRef: starterRef,
+        });
+        const branch2Head = Interaction.create({
+            name: 'r12Branch2',
+            action: Action.create({ name: 'r12Branch2' }),
+            userAttributives: starterRef,
+        });
+        const sub1 = Activity.create({ name: 'r12BranchSub1', interactions: [branch1Head] });
+        const sub2 = Activity.create({ name: 'r12BranchSub2', interactions: [branch2Head] });
+        const group = ActivityGroup.create({ type: 'every', activities: [sub1, sub2] });
+        const endStep = Interaction.create({ name: 'r12End', action: Action.create({ name: 'r12End' }) });
+        const activity = Activity.create({
+            name: 'R12HeadRefActivity',
+            interactions: [endStep],
+            groups: [group],
+            transfers: [Transfer.create({ name: 'toEnd', source: group, target: endStep })],
+        });
+
+        const UserE = Entity.create({ name: 'User', properties: [Property.create({ name: 'name', type: 'string' })] });
+        const manager = new ActivityManager([activity]);
+        const output = manager.getOutput();
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({
+            system,
+            entities: [UserE, ...output.entities],
+            relations: [...output.relations],
+            eventSources: [...output.eventSources],
+        });
+        await controller.setup(true);
+
+        const userA = await system.storage.create('User', { name: 'A' });
+        const userB = await system.storage.create('User', { name: 'B' });
+        const branch1ES = controller.findEventSourceByName('R12HeadRefActivity:r12Branch1')!;
+        const branch2ES = controller.findEventSourceByName('R12HeadRefActivity:r12Branch2')!;
+
+        // 分支一：创建 activity 并保存 starter ref = userA
+        const res1 = await controller.dispatch(branch1ES, { user: userA });
+        expect(res1.error).toBeUndefined();
+        const activityId = res1.context!.activityId as string;
+
+        // 分支二 + 错误用户：isRef 检查应失败（修复前是 "isRef outside activity" 的误导错误）
+        const res2 = await controller.dispatch(branch2ES, { user: userB, activityId });
+        expect(res2.error).toBeDefined();
+        expect(String((res2.error as any).message ?? res2.error)).not.toMatch(/outside an? activity/);
+
+        // 分支二 + 正确用户：通过
+        const res3 = await controller.dispatch(branch2ES, { user: userA, activityId });
+        expect(res3.error).toBeUndefined();
+
+        await system.destroy();
+    });
+});

--- a/tests/storage/review-fixes-2026-07-10-r12.spec.ts
+++ b/tests/storage/review-fixes-2026-07-10-r12.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * 第十二轮深度 review 修复的回归测试（storage/drivers 部分）。
+ * 对应报告：agentspace/output/deep-review-2026-07-10-r12.md
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import {
+    clearAllInstances,
+    Controller,
+    Entity,
+    KlassByName,
+    MatchExp,
+    MonoSystem,
+    Property,
+    Relation,
+} from 'interaqt';
+import { PGLiteDB, SQLiteDB } from '@drivers';
+
+afterEach(() => {
+    clearAllInstances(Entity, Relation, Property);
+});
+
+describe('r12 F-2: isReferenceValue across relation paths joins automatically', () => {
+    test('salary < leader.salary matches without pre-declared join', async () => {
+        const UserE = Entity.create({
+            name: 'R12RefUser',
+            properties: [
+                Property.create({ name: 'name', type: 'string' }),
+                Property.create({ name: 'salary', type: 'number' }),
+            ],
+        });
+        const LeaderRel = Relation.create({
+            source: UserE, sourceProperty: 'leader',
+            target: UserE, targetProperty: 'subordinates',
+            type: 'n:1',
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [UserE], relations: [LeaderRel] });
+        await controller.setup(true);
+
+        const boss = await system.storage.create('R12RefUser', { name: 'boss', salary: 100 });
+        await system.storage.create('R12RefUser', { name: 'low', salary: 50, leader: { id: boss.id } });
+        await system.storage.create('R12RefUser', { name: 'high', salary: 200, leader: { id: boss.id } });
+
+        // 修复前：missing FROM-clause entry for table "R12RefUser_leader"
+        const result = await system.storage.find('R12RefUser',
+            MatchExp.atom({ key: 'salary', value: ['<', 'leader.salary'], isReferenceValue: true }),
+            undefined, ['name', 'salary']);
+        expect(result.map((r: any) => r.name)).toEqual(['low']);
+
+        await system.destroy();
+    });
+});
+
+describe('r12 R-3: json canonical form — cross-driver equality parity', () => {
+    test('object equality is key-order insensitive on SQLite (text fallback) and PGLite (jsonb)', async () => {
+        for (const makeDb of [() => new SQLiteDB(':memory:'), () => new PGLiteDB()]) {
+            const E = Entity.create({
+                name: 'R12JsonDoc',
+                properties: [Property.create({ name: 'meta', type: 'object' })],
+            });
+            const system = new MonoSystem(makeDb() as any);
+            system.conceptClass = KlassByName;
+            const controller = new Controller({ system, entities: [E], relations: [] });
+            await controller.setup(true);
+            await system.storage.create('R12JsonDoc', { meta: { a: 1, b: 2 } });
+
+            const reordered = await system.storage.find('R12JsonDoc',
+                MatchExp.atom({ key: 'meta', value: ['=', { b: 2, a: 1 }] }), undefined, ['id']);
+            expect(reordered.length).toBe(1);
+
+            const reorderedIn = await system.storage.find('R12JsonDoc',
+                MatchExp.atom({ key: 'meta', value: ['in', [{ b: 2, a: 1 }, { c: 3 }]] }), undefined, ['id']);
+            expect(reorderedIn.length).toBe(1);
+
+            await system.destroy();
+            clearAllInstances(Entity, Relation, Property);
+        }
+    });
+
+    test('update path serializes json like create: string values survive read-back, reordered keys still match', async () => {
+        for (const makeDb of [() => new SQLiteDB(':memory:'), () => new PGLiteDB()]) {
+            const E = Entity.create({
+                name: 'R12JsonUp',
+                properties: [Property.create({ name: 'meta', type: 'object' })],
+            });
+            const system = new MonoSystem(makeDb() as any);
+            system.conceptClass = KlassByName;
+            const controller = new Controller({ system, entities: [E], relations: [] });
+            await controller.setup(true);
+
+            const rec = await system.storage.create('R12JsonUp', { meta: { a: 1 } });
+            // 修复前（SQLite）：update 存原始文本 'plain-string'，读回 JSON.parse 直接抛错
+            await system.storage.update('R12JsonUp', MatchExp.atom({ key: 'id', value: ['=', rec.id] }), { meta: 'plain-string' });
+            const r1 = await system.storage.findOne('R12JsonUp', MatchExp.atom({ key: 'id', value: ['=', rec.id] }), undefined, ['*']);
+            expect(r1.meta).toBe('plain-string');
+
+            await system.storage.update('R12JsonUp', MatchExp.atom({ key: 'id', value: ['=', rec.id] }), { meta: { b: 2, a: 1 } });
+            const hits = await system.storage.find('R12JsonUp',
+                MatchExp.atom({ key: 'meta', value: ['=', { a: 1, b: 2 }] }), undefined, ['id']);
+            expect(hits.length).toBe(1);
+
+            await system.destroy();
+            clearAllInstances(Entity, Relation, Property);
+        }
+    });
+
+    test('json string values created on parsed-JSON drivers read back as the string itself', async () => {
+        const E = Entity.create({
+            name: 'R12JsonStr',
+            properties: [Property.create({ name: 'meta', type: 'object' })],
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        system.conceptClass = KlassByName;
+        const controller = new Controller({ system, entities: [E], relations: [] });
+        await controller.setup(true);
+        const rec = await system.storage.create('R12JsonStr', { meta: 'just-a-string' });
+        // 修复前：PGlite 返回已解析的 'just-a-string'，读路径再 JSON.parse 一次直接抛错
+        const r = await system.storage.findOne('R12JsonStr', MatchExp.atom({ key: 'id', value: ['=', rec.id] }), undefined, ['*']);
+        expect(r.meta).toBe('just-a-string');
+        await system.destroy();
+    });
+});
+
+describe('r12 R-4: SQLite open(forceDrop) rebuilds file-based databases', () => {
+    test('setup(true) twice on the same file works', async () => {
+        const file = path.join(os.tmpdir(), `r12-sqlite-forcedrop-${process.pid}-${Date.now()}.db`);
+        try {
+            const E1 = Entity.create({
+                name: 'R12FileDoc',
+                properties: [Property.create({ name: 'title', type: 'string' })],
+            });
+            const system1 = new MonoSystem(new SQLiteDB(file));
+            system1.conceptClass = KlassByName;
+            const controller1 = new Controller({ system: system1, entities: [E1], relations: [] });
+            await controller1.setup(true);
+            await system1.storage.create('R12FileDoc', { title: 'one' });
+            await system1.destroy();
+
+            clearAllInstances(Entity, Relation, Property);
+
+            const E2 = Entity.create({
+                name: 'R12FileDoc',
+                properties: [Property.create({ name: 'title', type: 'string' })],
+            });
+            const system2 = new MonoSystem(new SQLiteDB(file));
+            system2.conceptClass = KlassByName;
+            const controller2 = new Controller({ system: system2, entities: [E2], relations: [] });
+            // 修复前：CREATE TABLE 抛 "table already exists"
+            await controller2.setup(true);
+            const rows = await system2.storage.find('R12FileDoc', undefined, undefined, ['*']);
+            expect(rows.length).toBe(0);
+            await system2.destroy();
+        } finally {
+            if (fs.existsSync(file)) fs.unlinkSync(file);
+        }
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Twelfth-round deep review of the whole codebase, focused on cold zones untouched by r1–r11 (query-compiler reference values, patch application chain, json value-domain × driver matrix, declaration-mode validation gaps, activity graph identity, driver parity). Full report: `agentspace/output/deep-review-2026-07-10-r12.md`.

Method: deduplicated against all r1–r11 reports first, then wrote and ran minimal reproductions for every fatal/important candidate before fixing. 6 candidates were falsified by reproduction and are documented to prevent re-investigation.

### Fatal (reproduced, fixed)

- **F-1** `Controller.applyResultPatch` global branch persisted the whole patch envelope `{type, data}` into the dict instead of `patch.data` — any global computation using `incrementalPatchCompute` corrupted its dict value for all downstream readers. Insert/update now write `patch.data`, delete writes `null`, and malformed envelopes fail fast on every branch (entity/relation silently skipped unknown types before).
- **F-2** `MatchExp` never added `isReferenceValue` reference paths (`value[1]`, e.g. `'leader.salary'`) to the JOIN tree — cross-relation field comparison, a natural extension of the documented API, crashed 100% with `missing FROM-clause entry`. Reference paths now join automatically; exist-subquery outer references are correctly excluded.
- **F-3** json column value-domain × driver matrix: (a) string JSON values crashed on read for drivers returning parsed JSON (PGlite/pg/mysql2) because the read path unconditionally re-parsed strings — drivers now declare `returnsParsedJSON`; (b) the update path bypassed `prepareFieldValue`, storing corrupt/non-canonical json text; (c) SQLite text-fallback equality was key-order sensitive, silently missing matches that PG-family drivers found. Writes and text-fallback matching now use canonical (sorted-key) serialization.

### Important (reproduced, fixed)

- **R-1** Declaration-mode conflicts silently evaporated: `matchExpression` without `baseEntity`/`baseRelation` (predicate never applied), `baseEntity`+`inputEntities` / `baseRelation`+`inputRelations` (merged pipeline silently swallowed filtered semantics), `computed`+`computation` (computed silently overwrote the computation's output on every write). All fail fast at declaration time now.
- **R-2** Reusing one Interaction/ActivityGroup instance in two places of an activity graph silently overwrote graph-node registrations — now rejected with a clear error.
- **R-3** Activity head dispatched *with* `activityId` (second branch head of every/race groups) ran the standalone guard, so `isRef` user attributives hit a misleading "outside an activity" rejection — now runs `fullGuardWithUserRef` like non-head steps.
- **R-4** `SQLiteDB.open(forceDrop)` ignored `forceDrop`; file-based databases failed `setup(true)` on the second run with "table already exists" — now drops user tables like PGLite.
- **R-5** `RecordQuery.derive` dropped `alias` (filtered-relation display name); `Scheduler` batch-computation comment contradicted its fail-fast behavior.

### Falsified candidates (documented in report §5)

PostgreSQL IDENTITY vs explicit id INSERT (fieldType is overwritten in `assignTableAndField`; real-PG CI green), findOne/orderBy root selection under fan-out (verified correct), goto-without-label infinite recursion (controlled assert), dict create-event key filtering (filter applies to create), ScopedSequence unknown-operator silent mismatch (declaration whitelist), propagation-trail sharing (intentional design).

### Backlog (report §4/§7)

9 important-but-unfixed items documented with locations and reasoning, headed by: `dict.set` find-then-write race (concurrency family with r5-I-12/r3-R4), `Klass.clone` registry-semantics split across 25+ classes, async task missing `failed` state, and the recurring recommendation to unify declaration validation in `createClass`.

## Testing

- ✅ `npm run check`
- ✅ `npm test` — 1829 passed / 26 skipped (baseline 1815 + 14 new regression tests, zero regressions)
- New regression suites: `tests/runtime/review-fixes-2026-07-10-r12.spec.ts` (9 cases), `tests/storage/review-fixes-2026-07-10-r12.spec.ts` (5 cases)
- Every fatal/important finding was first reproduced with a failing test against the baseline before the fix was written
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3b736eb-2f0e-4a6b-a32f-108bddeb4298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3b736eb-2f0e-4a6b-a32f-108bddeb4298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

