### PR TITLE
fix: r15 deep review — StateMachine computeValue contract, migration cross-process resume, ComputationResult envelope guard

### DIFF
--- a/agentspace/output/deep-review-2026-07-10-r15.md
+++ b/agentspace/output/deep-review-2026-07-10-r15.md
@@ -1,0 +1,168 @@
+# 全代码库深度 Review 报告（2026-07-10 第十五轮）
+
+- 日期：2026-07-10
+- 基线：`main` @ `99fe23ba`（v3.0.0，r1–r14 全部致命/重要修复及 Attributive 概念废弃已落地）
+- 基线健康度：`npm run check` 通过；`npm test` 全量 **1836 passed / 26 skipped**
+- 范围：四路并行深度探查 + 亲自精读验证——runtime 引擎（Scheduler 事件路由 / Controller applyResult 链 / r14 新增 teardown·dict 回退·lockRows 稳定化）/ storage 读路径（QueryExecutor 批量分组、AttributeQuery 合并）/ computations 语义一致性（StateMachine 提交顺序、ComputationResult 协议面）/ builtins 守卫链（Attributive 拆除后的回归面）/ migration（跨进程 resume、dict 回退一致性）
+- 方法：与 r1–r14 全部报告逐条去重（四路探查候选中过半为既有遗留项或已修项，全部剔除）→ 对每个致命/重要候选**编写最小复现测试实际运行**（PGLiteDB）。「已复现确认」才列为致命/重要；证伪/降级的候选明确记录（见第五节）。
+
+> **维护说明（2026-07-10）**：本报告的致命项与重要项已在同分支（`cursor/deep-code-review-r15-43e1`）全部修复。回归测试：`tests/runtime/review-fixes-2026-07-10-r15.spec.ts`（8 用例）。修复后 `npm run check` 通过，`npm test` 全量通过（净 +8 回归用例，零既有用例回归）。
+
+---
+
+## 一、结论摘要
+
+r1–r14 十四轮修复后，读写主路径、聚合增量一致性（r6 矩阵 `KNOWN_BROKEN_CELLS = []`）、filtered/merged 编译、守卫链严格 boolean 契约、migration 主流程都已高度收敛。本轮找到的新问题集中在两类：
+
+1. **「先提交内部状态、再校验输出值」的顺序缺口**——StateMachine 在调用 `computeValue` **之前**就用 `setInternal` 推进了 bound `currentState`，而 r13-F-2 让 `applyResult` 对 undefined 统一 skip。两个各自正确的行为组合出新的脱钩形态：`computeValue` 漏写 return 时，**状态机内部已前进、可见属性原地不动**，下一个事件从新状态出发做转移，读方却仍看到旧值——比写穿 undefined 更隐蔽（值"看起来没坏"）。
+2. **ComputationResult 协议信封的处理不对称**——增量路径（`executeDataBasedComputation`）会拆解 `fullRecompute` 信封，`compute()` 全量路径与 `asyncReturn` 路径却把信封当普通值直通 `applyResult` 原样落库（dict 值变成 `{"reason":"..."}`）。
+3. **迁移跨进程 resume 的进程内状态缺口**——`phase >= schema-applied` 时跳过 `applyMigrationSchema`，但该函数同时承担「初始化本进程 queryHandle」的职责；崩溃后在全新进程 resume 时带着未初始化的 queryHandle 进重算事务，抛裸 TypeError 且每次重试都一样——迁移永久卡死。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修） | 2 | StateMachine bound state 与可见属性脱钩、迁移 resume 永久卡死 |
+| 重要（已复现，已修） | 4 | ComputationResult 信封写穿、dict 默认值工厂漂移、teardown 残留回退、context.skip 未集中收口 |
+| 重要（代码证据，已修） | 4 | 迁移期 dict 回退缺失、migrate 无监听防御、批量 1:n id 类型归一、Condition 声明期校验 |
+| 证伪/降级 | 5 | 见第五节 |
+| 遗留项复确 | — | 见第六节 |
+
+---
+
+## 二、致命问题（已编写复现测试运行确认，本轮已修复）
+
+### F-1 StateMachine `computeValue` 返回 undefined：bound state 已推进、可见属性不动——状态机内外脱钩
+
+- 位置：`src/runtime/computations/StateMachine.ts` `PropertyStateMachineHandle.incrementalCompute` / `GlobalStateMachineHandle.incrementalCompute`（`setInternal(nextState.name)` 在 `computeValue` 调用**之前**）；`src/runtime/Controller.ts` `applyResult`（r13-F-2 起对 undefined 统一 skip）。
+- 复现（实测输出，pending → approved → done 三态机，approved 的 `computeValue` 漏写 return）：
+
+```
+dispatch(advance) → { error: undefined }               // 第一跳"成功"
+task.status → 'pending'                                 ❌ 可见属性没动
+dispatch(advance) → { error: undefined }               // 第二跳
+task.status → 'done'                                    ❌ 直接跳到 done——
+                                                        //  内部 bound state 早已是 approved
+```
+
+- 影响：`computeValue` 漏写 return / 分支遗漏是与 r13-F-2（compute 漏写 return）完全同族的最常见用户错误。r13 把 applyResult 的 undefined 从「写穿抹值」改为「skip 保值」是正确的，但 StateMachine 的 bound `currentState` 在那之前就已用 `setInternal`（原子 replace，随事务提交）推进——**转移的判定基础（bound state）与转移的输出（可见属性）从此各说各话**：后续 `findNextState` 按新状态取转移、审计/查询读到旧值。存量测试全部显式 return，十四轮未暴露。
+- 修复：新增 `resolveComputeValue` 统一执行四个调用点（global/property × getInitialValue/incrementalCompute）的 computeValue，**undefined 返回值一律 `ComputationProtocolError` fail-fast**——dispatch 事务整体回滚（bound state 推进一并回滚，内外保持一致），错误信息指引「返回要持久化的值 / `return lastValue` 保值 / `return null` 清空」。合法形态（返回值、null、无 computeValue 用状态名）不受影响。
+- 回归：漏写 return 的三态机两次 dispatch 均受控失败且 status 恒为 pending（绝不出现 pending→done 跳变）；值/null 两种合法 computeValue 照常工作。
+
+### F-2（升级自探查判定）迁移跨进程 resume 永久卡死：`schema-applied` 跳过的不只是 DDL，还有本进程 queryHandle 初始化
+
+- 位置：`src/runtime/Controller.ts` `migrate()`（`if (!reached(phase, 'schema-applied')) applyMigrationSchema(...)`）；`src/runtime/MonoSystem.ts` `applyMigrationAdditivePlan`（末四行初始化 `queryHandle/map/schema`——进程内状态）。
+- 复现（实测输出）：v1 install → v2 approvedDiff → 手工应用 preRecomputeDDL + 迁移日志记 `phase='schema-applied', status='failed'`（模拟崩溃）→ **全新 MonoSystem/Controller** resume：
+
+```
+controllerV3.migrate({ approvedDiff })
+→ Cannot read properties of undefined (reading 'find')   ❌ 重算事务第一次 storage 读即裸崩
+→ finishMigration('failed') → 下次 resume 同样路径同样崩溃  ❌ 不可恢复的 resume 循环
+```
+
+- 影响：迁移的 resume 能力正是为「进程崩溃后换进程重试」设计的（beginMigration 按 modelHash+diffHash 找 resumable 行），但 phase 记录的是**数据库**状态，queryHandle 是**进程**状态——按 phase 跳过 applyMigrationSchema 把两者混为一谈。带 rebuildPlan 的迁移（加 computed property、改 computation——最常见的迁移形态）在此场景必然卡死，只能人工清理迁移日志。既有 resume 测试全部复用同进程 system（queryHandle 已由 v1 setup 初始化），未覆盖跨进程形态。
+- 修复：`applyMigrationSchema` 改为**无条件执行**——DDL 经 operation log + 每次 migrate 重新 diff（已应用的列不再出现在 plan 中）双重幂等，重复执行零成本；phase 判定只保留「是否要写 phase 记录」。同时 migrate 在进入重算前 `scheduler.teardown()`（防御本 controller 曾 setup 过的反应式监听干扰重算，fresh controller 上是 no-op）并 `registerDictDefaults()`（见 R-3）。
+- 回归：同复现场景在全新 system 上 resume 成功，`doubled` 重算值正确（[2, 10]）。
+
+---
+
+## 三、重要问题（本轮已修复）
+
+### R-1 `compute()` / `asyncReturn()` 返回 ComputationResult 信封被当普通值写穿（已复现）
+
+- 位置：`src/runtime/Scheduler.ts` `executeDataBasedComputation` 全量分支（L894 直通）对照增量分支（L933 拆解 `ComputationResultFullRecompute`）；`handleAsyncReturn`（L1042 `asyncReturn` 返回值直通 applyResult）。
+- 复现：global Custom 的 `compute` 返回 `ComputationResult.fullRecompute('confused user')` → dict 值变成 `{"reason":"confused user"}`，所有下游读取方拿到信封对象，零告警。
+- 影响：`ComputationResult` 是文档化的计算返回值词汇表；增量路径拆解、全量路径写穿的**不对称**让「从 incrementalCompute 复制逻辑到 compute」这类自然重构直接产出脏数据。fullRecompute 从 compute 返回本身是协议误用（compute 就是全量重算），应 fail-fast 而非落库。
+- 修复：`Controller.applyResult` / `applyInitialValue` 收口——Skip/undefined 检查之后，任何残余的 `ComputationResult` 实例一律 `ComputationError`（指引「返回计算值本身或 skip；fullRecompute 只在增量路径有意义；async/resolved 应在应用前拆解」）。单一 choke point 同时覆盖 compute 全量路径、asyncReturn 路径、migration writeComputationResult 路径。
+
+### R-2 dict `defaultValue` 工厂在读回退路径每次 miss 重新求值：非幂等工厂产出漂移的"事实"（已复现）
+
+- 位置：`src/runtime/MonoSystem.ts` `dict.get`（r14-I-4 引入的回退每次调用 `defaultValueFn()`）；`src/runtime/Scheduler.ts` setup 注册处。
+- 复现：`defaultValue: () => ({seq: ++n})` + 删除持久化行 → 连续两次 `dict.get` 返回 `{seq:2}`、`{seq:3}`——同一事务内两个计算读同一 key 拿到不同值。
+- 影响：`Dictionary.defaultValue` 在 install 路径的既有语义是**求值一次、持久化**（setupDictDefaultValue）；r14 的读回退把工厂下放到每次 miss 求值，`() => Date.now()`、对象字面量等非幂等工厂在回退路径与 install 路径行为分裂。
+- 修复：`Scheduler.registerDictDefaults()`（从 setup 中提取，migrate 亦复用）在注册时**求值一次**、注册求出的值；`MonoStorage.dict.get` miss 时返回该值的 JSON round-trip 副本（与存储路径「每次读经 JSON codec 产出独立副本」的语义对齐，避免多读方共享可变引用）。`registerDefaults` 契约类型同步为 `Map<string, unknown>`。
+
+### R-3 迁移期 global dataDep 读不到声明的 dict 默认值（代码证据）
+
+- 位置：`src/runtime/migration.ts` `resolveDataDepsForMigration` global 分支（只读存储行）；migrate 重算期间 scheduler.setup 未运行、读回退未注册。
+- 影响：v2 新增「带 defaultValue 的 dict + 依赖它的 computation」时，迁移重算读到 undefined、迁移后运行时读到声明默认值——重算结果与运行时语义不一致（错误值被永久固化）。dry-run / destructive-scope 评估同理。
+- 修复：`migrate()` 进入重算前调用 `scheduler.registerDictDefaults()`（运行时路径生效）；`resolveDataDepsForMigration` global 分支无存储行时回退 `controller.dict` 声明的 defaultValue（readHandle 路径生效）。
+
+### R-4 `context.skip` 依赖 planIncremental 自觉遵守：自定义 planner 忽略时用无关事件跑增量（已复现）
+
+- 位置：`src/runtime/Scheduler.ts` `executeDataBasedComputation`（构建 context 后直接交给 planIncremental）；内置 planner（`defaultDataBasedIncrementalPlan`、Custom 的 incrementalDataDeps 路径）遵守 skip，自定义 `planIncremental` 回调无任何强制。
+- 影响：`skip: true` 只在「事件记录对 records 依赖的 match **确定性地**新旧都不匹配」时给出（本地无法确定走 requiresFullRecompute），即该事件不可能影响计算结果。自定义 planner 忽略它返回 incremental 时，增量计算拿无关事件跑出错误值且零告警（复现：match 排除的记录 create 事件把 sum 从 10 抬到 1009——修复前形态）。
+- 修复：框架在调用 planIncremental **之前**集中收口 `context.skip`（顺带修正既有优先级瑕疵：unsafe modifier + 排除事件此前会走不必要的 fullRecompute）。
+- 回归：故意忽略 skip 的 planner，match 外记录的 create 不触发 incrementalCompute、值不变。
+
+### R-5 `teardown()` 残留 dict 读回退（代码证据）
+
+- 位置：`src/runtime/Scheduler.ts` `teardown`（r14-I-2 只注销 mutation listener）。
+- 影响：teardown 后 storage 若继续被使用（多租户单进程、热重载的窗口期），dict.get 仍按旧 controller 的声明回退——I-2 生命周期修复的另一半。
+- 修复：teardown 一并 `registerDefaults(new Map())`。回归：teardown 前回退 42、teardown 后 undefined。
+
+### R-6 批量 1:n 分组的父 id 裸值 Map 匹配：id 类型混用时子记录静默丢失（代码证据，防御性收口）
+
+- 位置：`src/storage/erstorage/QueryExecutor.ts` `findRelatedRecordsInBatch`（`parentById.set(parent.id, ...)` / `.get(item[reverse].id)` 裸值匹配）。
+- 影响：父记录 id 与子记录反向端点 id 以不同 JS 类型返回时（整型发号驱动 number/string 混用、BIGINT 字符串化），Map 匹配失败的子记录被**静默丢弃**（父记录拿到空集合、无报错）。r5-I-6 首次记录；同文件 `NewRecordData.dedupeRefItems` 已有 `String(id)` 归一化先例，批量路径是漏项。
+- 修复：两端 `String(id)` 归一化（类型一致时零行为变化，既有全部 1:n 测试通过）。
+
+### R-7 `Condition.create` 不校验 content：配置错误延迟到第一次 dispatch 才暴露（代码证据）
+
+- 位置：`src/builtins/interaction/Condition.ts` `create`（`public.content` 声明 `required: true` 但无运行校验）。
+- 影响：`content: undefined`（typo / 代码生成缺陷）的 Condition 挂上守卫链后，运行期被 checkCondition fail-closed 拒绝（安全），但错误暴露点与声明处脱节——每个用户请求都失败，而非应用启动时失败。与 r10 对 `Conditions` 容器的既有校验不对称。
+- 修复：声明期校验 content 必须是函数，错误信息含示例写法。回归：undefined 与非函数两种形态均声明期抛出。
+
+### 连带小修
+
+- `ActivityManager` head-无-activityId 分支统一走 `activityCall.fullGuard`（此前直调 `interaction.guard`，行为等价但三分支两套写法，留下未来 guard 逻辑漂移面）；
+- `ActivityCall.completeInteractionState` 注释中残留的 `saveUserRefs`（Attributive 拆除遗漏）清除；
+- `src/core/README.md` 中不存在的 `InteractionCall` 引用修正。
+
+---
+
+## 四、重要观察（高置信度，本轮不修，含设计权衡记录）
+
+| # | 观察 | 位置 | 说明 |
+|---|------|------|------|
+| O-1 | **PHASE_AFTER_ALL 不等待同事件触发的 async 计算**：NORMAL 相位的计算返回 `ComputationResult.async` 时只创建 task 行，AFTER_ALL 相位的 Transform 快照看不到 task 之后应用的结果 | `Scheduler.ts` 相位循环 | 这是 async 计算「最终一致」语义的固有推论（结果在独立事务、可能由外部 worker 完成，无法在当前事务内等待）。建议知识库在 async computation 章节明确「相位序只约束同步计算」 |
+| O-2 | **group-as-root 的多分支 head 均可隐式建活动实例**：every/race 组作根时，任一分支 head 不带 activityId dispatch 都会 create 新 `_Activity_` 实例 | `ActivityManager.ts` `isHeadInteraction` | 与单 head 活动「head 不带 id = 开新实例」语义一致（多实例并存合法，第二分支加入既有实例必须显式传 activityId），不是缺陷；但客户端漏传 id 会静默 fork 工作流，值得在 activity 文档中示警 |
+| O-3 | **`lockRows` 稳定化 5 轮上限后按当前锁集返回**：持续高并发插入下返回覆盖不全的行集，无告警 | `MonoSystem.ts` L1090 | 与 SQL `SELECT ... FOR UPDATE` 的幻影语义一致（锁定后插入的行本就不在任何锁定方案的覆盖内），r14 注释已记录该边界；无行为缺陷，维持现状 |
+| O-4 | **函数体 toString 哈希进 modelHash**：bundler/压缩/Node 版本差异可让语义相同的部署产生 manifest mismatch | `migration.ts` L728/L791 | 函数语义等价判定不可计算，现设计（文本哈希 + 显式 approvedDiff 流程）是正确的保守选择；跨构建产物部署的 ops 文档值得提示「以同一构建产物跑迁移」 |
+| O-5 | **propagation trail 数组同深度共享**：批内多计算并发时深度守卫错误的 trail 可能混入无关计算名 | `Scheduler.ts` L411 | 仅影响诊断信息精度，不影响判定；留待与可观测性改造一轮做 |
+| O-6 | **`retrieveLastValue` property 分支 truthy 判断**：`if (record![name])` 对 false/0/'' 走冗余重查；宿主行恰在中途被删时裸 TypeError | `Controller.ts` L559 | 值域正确性不受影响（重查返回同值）；TypeError 窗口极窄且事务会回滚。与 I-1（entity/relation lastValue 全表）同属 lastValue 语义家族，留待该家族收口轮 |
+
+## 五、本轮证伪/降级的候选
+
+| 候选 | 结论 |
+|------|------|
+| 「storage.dispatch 不把 listener 返回的衍生事件喂给同轮其他 listener」（migration 探查 #5，初判重要） | 证伪：listener 回调返回的 events 只用于 effects 汇总；listener 内部的 storage 写入本身走 `callWithEvents` 递归 dispatch，所有 listener 都能看到衍生 mutation。无缺口 |
+| 「批量 1:n 孤儿子记录静默丢弃掩盖数据损坏」（storage 探查 #4） | 降级为既有遗留（r9-I-5 已记录 assert/warn 建议）；孤儿 FK 本身是上游损坏，读路径不新增损坏 |
+| 「查询结果 SQL NULL 键缺失」（storage 探查 #1） | 既有遗留 r4-I-1 原样复确，非新发现（探查报告自己也标注了）|
+| 「mergeAttributeQueryData 丢弃重复键的 modifier/match」（storage 探查 #3） | 既有遗留（r5-I-4/r12 记录）复确，未在本轮升级：触发面要求同名关系键在合并流中带 modifier/match，主路径（reliance 合并）不产出该形态 |
+| 「migrate() 时其他 controller 的旧监听器污染重算」（migration 探查 #2） | 部分成立、按边界修复：本 controller 的监听已在 migrate 前 teardown（本轮修复）；**其他** controller 的监听器框架层无从辨识（app 级 storage.listen 是文档化用法，不能一刀切清空），操作契约（migrate 前 teardown 旧 controller）已写入 migrate 的注释 |
+
+## 六、既有遗留项复确（r2–r14 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4-I-1）；`!=` 三值逻辑；dispatch 先持久化事件再 resolve（r9-I-2）；payload 弱校验族；isRef 无行级授权 IDOR 面（r11-I-5）；StateMachine 单事件单跳（r7-I-8）；同批 property 计算无拓扑序（r7-I-9）；`Event`/`Activity.events` 死 API（r12-I-8）；Custom 多 dataDeps 每 dep 各触发一次（r11-I-2）；数组 pattern 前缀匹配；RealTime NaN；ScopedSequence scope 更新语义（r11-I-6/I-7）。
+- **性能/资源**：global dict 变更宿主全表扫描（S3）；async task 表只增不减 + 无 failed 终态（r2-I-6/r12-I-3）；级联删除无深度上限（r2-I-5）；offset-only 全表拉取 / EXIST 误触 post-pagination（r12-I-4/I-5）；迁移全表载入内存（MIG-I3）；retrieveLastValue entity/relation 全表（r13-I-1，Custom 默认关闭后仅显式 opt-in 面残留）。
+- **并发**：`setDictionaryValue` find-then-write（r12-I-1）；handleAsyncReturn find-then-lock 幻影行（r3-R4）；SERIALIZABLE 重试边界内 guard/afterDispatch 重放（S2）。
+- **migration**：迁移阶段顺序（r10-I-1）；rename = remove+add（r9-I-3）；merged input 移除孤儿数据（r10-I-2）。
+- **驱动**：contains 四驱动语义矩阵（r12-I-6）；SQLite 无行锁能力位（r12-I-7）；Klass.clone 注册表语义分裂（r12-I-2）。
+- **时间调度**：`nextRecomputeTime` 无消费方（r3-R5）。
+
+## 七、修复优先级建议（遗留项，更新）
+
+1. **并发治理专轮**（r12-I-1 dict.set 竞态 + r3-R4 幻影行 + lockRows 覆盖语义文档化）——「READ COMMITTED 下的 find-then-write/lock」家族，需要驱动级 UPSERT/单语句锁原语 + 关键表唯一约束；
+2. **r10-I-1 迁移阶段顺序**——连续五轮位居榜首的未修项，唯一可能产出「静默错误聚合值」的已知路径；
+3. **lastValue/默认值语义收口轮**（r13-I-1 entity/relation lastValue 全表 opt-in 面 + 本轮 O-6 truthy 判断 + r4-I-1 NULL 键缺失）——三者同属「值缺失/值形态」语义家族；
+4. **createClass 统一校验**（r7-I-13 + r11-I-8 + r12-R-1 + r13-R-2 + 本轮 R-7 的手工 fail-fast）——第五轮佐证「声明校验应在 createClass 层统一执行」的一次性根治价值；
+5. **async task 生命周期**（r2-I-6 + r12-I-3 + O-1 文档化）——增加 failed 终态与清理策略，同时把「相位序不覆盖 async」写进知识库。
+
+## 附录：复现要点（验证用）
+
+- F-1：`StateNode.create({name:'approved', computeValue: async () => { /* 漏写 return */ }})` 的转移 → dispatch 受控失败（错误含 `returned undefined`），status 恒为初始态；`computeValue: () => null` / `() => 'lit'` 照常。
+- F-2：v1 install → v2 approvedDiff → 手工应用 preRecomputeDDL + 迁移日志 `phase='schema-applied', status='failed'` → 全新 MonoSystem resume `migrate({approvedDiff})` → 成功且重算值正确。
+- R-1：global Custom `compute: () => ComputationResult.fullRecompute('x')` → create 触发时受控失败（错误含 `envelope where a plain value is expected`），dict 零污染。
+- R-2：`defaultValue: () => ({seq: ++n})` + 删行 → 两次 `dict.get` 同值、副本独立、工厂不再被读路径调用。
+- R-4：自定义 `planIncremental: () => ({type:'incremental', ...})`（忽略 context.skip）+ match 排除的记录 create → incrementalCompute 不执行、值不变。
+- R-5：teardown 后 `dict.get` 不再返回旧 controller 声明的默认值。
+- R-7：`Condition.create({name:'x'})`（无 content）→ 声明期抛 `requires a function "content"`。

--- a/src/builtins/interaction/Condition.ts
+++ b/src/builtins/interaction/Condition.ts
@@ -42,6 +42,15 @@ export class Condition implements ConditionInstance {
   };
   
   static create(args: ConditionCreateArgs, options?: { uuid?: string }): ConditionInstance {
+    // fail-fast：content 是守卫的可执行体。缺失/非函数的 content 在运行期会被 checkCondition
+    //  fail-closed 拒绝（每次 dispatch 都报错），但错误暴露点与声明处脱节——配置错误应在
+    //  声明期发现，而不是等到第一个用户请求。
+    if (typeof args.content !== 'function') {
+      throw new Error(
+        `Condition${args.name ? ` "${args.name}"` : ''} requires a function "content" (got ${args.content === undefined ? 'undefined' : typeof args.content}). ` +
+        `Provide the guard callback, e.g. Condition.create({ name, content: async function(event) { return !!event.user.isAdmin } }).`
+      );
+    }
     const instance = new Condition(args, options);
     
     // 检查 uuid 是否重复

--- a/src/builtins/interaction/activity/ActivityCall.ts
+++ b/src/builtins/interaction/activity/ActivityCall.ts
@@ -400,8 +400,7 @@ export class ActivityCall {
         //  compare-and-set under READ COMMITTED (both concurrent transactions can pass the
         //  non-locking find). Use the atomic CAS primitive (single conditional UPDATE, whose
         //  WHERE clause is re-evaluated after lock waits) to advance the version; a loser
-        //  gets zero rows and aborts this transaction — including its saveUserRefs write —
-        //  instead of silently losing an update.
+        //  gets zero rows and aborts this transaction instead of silently losing an update.
         const currentVersion = activity.stateVersion ?? 0
         const won = await storage.system.storage.atomic.compareAndSet(
             { recordName: ActivityCall.ACTIVITY_RECORD, id: activityId, field: 'stateVersion' },

--- a/src/builtins/interaction/activity/ActivityManager.ts
+++ b/src/builtins/interaction/activity/ActivityManager.ts
@@ -100,9 +100,8 @@ export class ActivityManager {
 
         const wrappedGuard = async function(this: Controller, args: InteractionEventArgs) {
             if (isHeadInteraction && !args.activityId) {
-                if (interaction.guard) {
-                    await interaction.guard.call(this, args)
-                }
+                // 与其余两个分支同走 fullGuard（runInteractionGuard）：三条路径的守卫语义不允许漂移。
+                await activityCall.fullGuard(this, interaction, args)
                 const created = await activityCall.create(this)
                 args.activityId = created.activityId
             } else if (isHeadInteraction && args.activityId) {

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -53,7 +53,7 @@
 ### runtime 模块
 - 使用 shared 中定义的类型来：
   - 创建控制器(Controller)管理实体、关系、交互
-  - 执行交互调用(InteractionCall)
+  - 分发事件源(Controller.dispatch / runInteractionGuard)
   - 管理活动流程(ActivityManager)
   - 调度计算任务(Scheduler)
 

--- a/src/runtime/Controller.ts
+++ b/src/runtime/Controller.ts
@@ -486,6 +486,16 @@ export class Controller {
             const order: MigrationPhase[] = ['pending', 'schema-applied', 'computation-applied', 'constraints-applied', 'manifest-written', 'succeeded']
             return order.indexOf(phase) >= order.indexOf(target)
         }
+        // CAUTION 迁移重算期间不允许本 controller 的反应式监听在场：重算顺序由 rebuildPlan
+        //  显式管理，监听器对重算写入的即时反应会与之互相干扰（双重计算、阶段乱序）。
+        //  fresh controller 上这是 no-op；对已 setup 过的 controller 是必要的防御。
+        //  同一 system 上其他 controller 的监听器无法从这里注销——共享 system 的进程必须
+        //  在 migrate 前对旧 controller 调用 teardown()。迁移成功后 scheduler.setup(false)
+        //  会重新注册监听。
+        this.scheduler.teardown()
+        // 迁移重算读取 global dataDeps 时走 dict.get，声明了 defaultValue 的新字典此时还没有
+        //  存储行（setup 尚未运行）——先注册声明驱动的读回退，保证重算与迁移后运行时读到同一批默认值。
+        this.scheduler.registerDictDefaults()
         try {
             migrationRun = await migrationSystem.beginMigration?.(
                 nextManifest.modelHash,
@@ -494,8 +504,14 @@ export class Controller {
                 approvedDiff.decisions.length,
             )
             const phase = migrationRun?.phase || 'pending'
+            // CAUTION applyMigrationSchema 必须无条件执行：它除了 DDL（经 operation log 幂等，
+            //  已完成的操作会被跳过）之外还初始化本进程的 storage queryHandle/map/schema。
+            //  此前按 phase 跳过它时，跨进程 resume（DDL 已应用、phase 已记 schema-applied、
+            //  进程崩溃后在全新进程上重试）会带着未初始化的 queryHandle 进入重算事务，
+            //  在第一次 storage 读写处抛出与迁移无关的 "Cannot read properties of undefined"，
+            //  迁移永久卡死在不可恢复的 resume 循环里。
+            await migrationSystem.applyMigrationSchema(executionSchemaPlan, migrationRun?.id)
             if (!reached(phase, 'schema-applied')) {
-                await migrationSystem.applyMigrationSchema(executionSchemaPlan, migrationRun?.id)
                 if (migrationRun) await migrationSystem.updateMigrationPhase?.(migrationRun.id, 'schema-applied')
             }
             if (!reached(phase, 'manifest-written')) {
@@ -569,6 +585,11 @@ export class Controller {
         //  incrementalCompute 漏写 return 时，dict 值与 property 列被静默抹掉（数据损坏且零告警）。
         //  null 是合法值域（可显式清空 global/property），继续写入。
         if (result === undefined) return
+        // fail fast：能到达这里的 ComputationResult 只剩协议误用形态——fullRecompute 只能由
+        //  增量路径返回（compute() 本身就是全量重算）、async/resolved 应已被 Scheduler 拆解。
+        //  此前 compute()/asyncReturn() 返回这些信封对象时会被当作普通值原样写进 dict/property
+        //  （如 dict 值变成 {"reason":"..."}），污染所有下游读取方且零告警。
+        this.assertNotComputationEnvelope(dataContext, result)
 
         if (dataContext.type === 'global') {
             return this.system.storage.dict.set(dataContext.id.name, result)
@@ -615,8 +636,22 @@ export class Controller {
      * record), so downstream consumers observe the initial value as part of the create event.
      * Derived events (e.g. filtered-entity membership changes) are still dispatched normally.
      */
+    private assertNotComputationEnvelope(dataContext: DataContext, result: unknown) {
+        if (result instanceof ComputationResult) {
+            const contextName = dataContext.type === 'property'
+                ? `${(dataContext as PropertyDataContext).host.name}.${dataContext.id.name}`
+                : `${dataContext.type}:${(dataContext.id as { name?: string })?.name ?? String(dataContext.id)}`
+            throw new ComputationError(
+                `Computation for ${contextName} returned a ${result.constructor.name} envelope where a plain value is expected. ` +
+                `ComputationResult.fullRecompute() is only meaningful as an incrementalCompute return value (compute() IS the full recomputation); ` +
+                `ComputationResult.async()/resolved() must be resolved before the result is applied. Return the computed value itself (or ComputationResult.skip()).`,
+                { computationPhase: 'result-application' }
+            )
+        }
+    }
     async applyInitialValue(dataContext: PropertyDataContext, result: unknown, record: Record<string, unknown>) {
         if (result instanceof ComputationResultSkip) return
+        this.assertNotComputationEnvelope(dataContext, result)
 
         if (dataContext.id.name === HARD_DELETION_PROPERTY_NAME && result) {
             await this.system.storage.delete(dataContext.host.name!, BoolExp.atom({key: 'id', value: ['=', record.id]}))

--- a/src/runtime/MonoSystem.ts
+++ b/src/runtime/MonoSystem.ts
@@ -77,15 +77,16 @@ class MonoStorage implements Storage{
         tables: [],
         constraints: []
     }
-    public dict: { get: (key: string) => Promise<unknown>, set: (key: string, value: unknown) => Promise<void>, setInternal?: (key: string, value: unknown) => Promise<void>, registerDefaults?: (defaults: Map<string, () => unknown>) => void }
+    public dict: { get: (key: string) => Promise<unknown>, set: (key: string, value: unknown) => Promise<void>, setInternal?: (key: string, value: unknown) => Promise<void>, registerDefaults?: (defaults: Map<string, unknown>) => void }
     public atomic: AtomicStorage
     private transactionContext = new AsyncLocalStorage<StorageTransactionContext>()
-    // 声明驱动的 dict 读回退（Scheduler.setup 从 Dictionary 声明注册）。
+    // 声明驱动的 dict 读回退（Scheduler 从 Dictionary 声明求值一次后注册）。
     //  install 时 setupDictDefaultValue 会把默认值持久化；但 setup(false) 路径下新增声明、
     //  或行被手工删除时，get 返回 undefined 会让下游计算静默走偏——按声明回退更符合
     //  「声明了 defaultValue 就应生效」的直觉。只在**无存储行**时回退：已存储的 null
-    //  是显式值，不回退。
-    private dictDefaults: Map<string, () => unknown> = new Map()
+    //  是显式值，不回退。注册的是**已求值**的默认值（非工厂）：每次读 miss 重新求值会让
+    //  非幂等工厂（Date.now、对象字面量）在同一事务内产出漂移的"事实"。
+    private dictDefaults: Map<string, unknown> = new Map()
     
     constructor(public db: Database) {
         // Initialize dict property with get/set methods
@@ -94,8 +95,12 @@ class MonoStorage implements Storage{
                 const match = MatchExp.atom({key: 'key', value: ['=', key]})
                 const record = await this.queryHandle!.findOne(DICTIONARY_RECORD, match, undefined, ['value'])
                 if (!record) {
-                    const defaultValueFn = this.dictDefaults.get(key)
-                    return defaultValueFn ? defaultValueFn() : undefined
+                    if (!this.dictDefaults.has(key)) return undefined
+                    const defaultValue = this.dictDefaults.get(key)
+                    // 与存储路径的读语义对齐：存储值每次读都经 JSON codec 产出独立副本，
+                    // 回退值同样按 JSON round-trip 复制，避免多个读方共享同一可变对象引用。
+                    if (defaultValue === undefined || defaultValue === null || typeof defaultValue !== 'object') return defaultValue
+                    return JSON.parse(JSON.stringify(defaultValue))
                 }
                 return record.value?.raw
             },
@@ -105,7 +110,7 @@ class MonoStorage implements Storage{
             setInternal: async (key: string, value: unknown): Promise<void> => {
                 await this.setDictionaryValue(key, value, false)
             },
-            registerDefaults: (defaults: Map<string, () => unknown>) => {
+            registerDefaults: (defaults: Map<string, unknown>) => {
                 this.dictDefaults = defaults
             }
         }

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -332,9 +332,27 @@ export class Scheduler {
      * 长生命周期进程（热重载、多租户单进程）反复 new Controller + setup 时，
      * 不 teardown 会让旧 controller 的计算闭包永驻 storage 的回调集合——内存泄漏，
      * 且旧计算仍会被新写入触发。
+     * dict 读回退一并清除：teardown 后 storage 若继续被使用（如另一个 controller
+     * setup 之前的窗口期），不应再返回本 controller 声明的默认值。
      */
     teardown() {
         this.removeRegisteredMutationListeners()
+        this.controller.system.storage.dict.registerDefaults?.(new Map())
+    }
+    /**
+     * 把声明的 Dictionary.defaultValue 注册为 dict 读回退（无存储行时生效）。
+     * CAUTION 工厂在这里**求值一次**、注册求出的值——与 install 路径（setupDictDefaultValue
+     * 求值一次并持久化）语义对齐。若把工厂原样下放到每次读 miss 时求值，非幂等工厂
+     * （`() => Date.now()`、`() => ({...})`）会让同一事务内的两次读拿到不同的"事实"。
+     */
+    registerDictDefaults() {
+        const dictDefaults = new Map<string, unknown>()
+        for (const dict of this.controller.dict) {
+            if (dict.defaultValue !== undefined) {
+                dictDefaults.set(dict.name, dict.defaultValue())
+            }
+        }
+        this.controller.system.storage.dict.registerDefaults?.(dictDefaults)
     }
     private buildPropertyDefaultValueListeners(): RecordMutationCallback[] {
         const listeners: RecordMutationCallback[] = []
@@ -895,6 +913,14 @@ export class Scheduler {
         }
 
         const context = this.buildDataDepEventContext(computation, erRecordMutationEvent)
+        // CAUTION context.skip 由框架集中执行，不依赖 planIncremental 自觉遵守：
+        //  skip 只在「事件记录对该 records 依赖的 match 确定性地新旧都不匹配」时为 true
+        //  （本地无法确定时走 requiresFullRecompute，不走 skip），即该事件不可能影响计算结果。
+        //  自定义 planIncremental 忽略 context.skip 返回 incremental 时，增量计算会拿着
+        //  无关事件产出错误值且零告警——这里先于 planIncremental 收口。
+        if (context.skip) {
+            return { mode: 'skip' }
+        }
         const plan = computation.planIncremental?.(erRecordMutationEvent, record, context)
         if (!plan) {
             throw new ComputationProtocolError('Incremental data-based computation must implement planIncremental()', {
@@ -1344,14 +1370,8 @@ export class Scheduler {
             for (const listener of listeners) {
                 this.registerMutationListener(listener)
             }
-            // 把声明的 dict defaultValue 注册为读回退（无存储行时按声明求值）。
-            const dictDefaults = new Map<string, () => unknown>()
-            for (const dict of this.controller.dict) {
-                if (dict.defaultValue !== undefined) {
-                    dictDefaults.set(dict.name, dict.defaultValue as () => unknown)
-                }
-            }
-            this.controller.system.storage.dict.registerDefaults?.(dictDefaults)
+            // 把声明的 dict defaultValue 注册为读回退（无存储行时返回声明的默认值）。
+            this.registerDictDefaults()
             if (createDefaultDictValue) {   
                 // 一定要先把 bound state default value 设置后，因为后面开始设置 dict default value 时，可能触发 computation。可能要读 state。
                 await this.setupGlobalBoundStateDefaultValues()

--- a/src/runtime/System.ts
+++ b/src/runtime/System.ts
@@ -153,8 +153,9 @@ export type Storage = {
         get: (key: string) => Promise<unknown>
         set: (key: string, value: unknown) => Promise<void>
         setInternal?: (key: string, value: unknown) => Promise<void>
-        // 声明驱动的读回退：key 无存储行时求值声明的 defaultValue（见 MonoStorage.dict.get）。
-        registerDefaults?: (defaults: Map<string, () => unknown>) => void
+        // 声明驱动的读回退：key 无存储行时返回注册的默认值（声明的 defaultValue 工厂
+        // 由 Scheduler 求值一次后注册，见 MonoStorage.dict.get）。
+        registerDefaults?: (defaults: Map<string, unknown>) => void
     }
 
     get: (itemName: string, id: string, initialValue?: unknown) => Promise<unknown>

--- a/src/runtime/computations/StateMachine.ts
+++ b/src/runtime/computations/StateMachine.ts
@@ -76,6 +76,34 @@ type EntityTargetResult = EntityIdRef|EntityIdRef[]|undefined
 type ComputeSourceResult = ComputeRelationTargetResult| EntityTargetResult
 
 /**
+ * 执行 StateNode.computeValue 并校验返回值。
+ * CAUTION 必须拒绝 undefined：调用方（incrementalCompute）在调用本函数**之前**已通过
+ *  setInternal 推进了 bound currentState，而 applyResult 对 undefined 统一 skip（r13 F-2）。
+ *  若放行 undefined，本次转移就变成「内部状态已推进、可见属性没写」——状态机后续按新状态
+ *  取转移，读方却仍看到旧值，两者静默脱钩且无任何告警。抛错会让整个 dispatch 事务回滚
+ *  （bound state 的推进一并回滚），保持一致。保留上一个值请显式 `return lastValue`；
+ *  清空请 `return null`。
+ */
+async function resolveComputeValue(
+    controller: Controller,
+    state: StateNodeInstance,
+    previousValue: unknown,
+    event: unknown,
+    describeContext: () => string
+): Promise<unknown> {
+    if (!state.computeValue) return state.name
+    const value = await state.computeValue.call(controller, previousValue, event)
+    if (value === undefined) {
+        throw new ComputationProtocolError(
+            `StateMachine ${describeContext()}: computeValue of state "${state.name}" returned undefined (did you forget a return statement?). ` +
+            `Return the value to persist, "return lastValue" to keep the previous value, or "return null" to clear it.`,
+            { handleName: 'StateMachine', computationPhase: 'compute-value' }
+        )
+    }
+    return value
+}
+
+/**
  * 归一化 computeTarget 的返回值为 `{id}[]`。
  * 支持的形态：`{id}`、`{id}[]`、`undefined/null`（skip）；
  * 宿主为 relation 时额外支持按端点定位：`{source, target}`（source/target 为 `{id}` 或 `{id}[]`，取笛卡尔积）
@@ -164,7 +192,10 @@ export class GlobalStateMachineHandle implements EventBasedComputation {
         }
     }
     async getInitialValue(event:any) {
-        return this.initialState.computeValue ? await this.initialState.computeValue.call(this.controller, undefined, event) : this.initialState.name
+        return resolveComputeValue(this.controller, this.initialState, undefined, event, () => this.describeContext())
+    }
+    private describeContext() {
+        return `of global dictionary "${(this.dataContext.id as {name?: string})?.name ?? String(this.dataContext.id)}"`
     }
     async incrementalCompute(lastValue: string, mutationEvent: EtityMutationEvent, dirtyRecord: any) {
         // Now we can handle any mutationEvent, not just interaction events
@@ -175,7 +206,7 @@ export class GlobalStateMachineHandle implements EventBasedComputation {
         await this.state.currentState.setInternal(nextState.name)
 
         const previousValue = await this.controller.retrieveLastValue(this.dataContext)
-        return nextState.computeValue? (await nextState.computeValue.call(this.controller, previousValue, mutationEvent)) : nextState.name
+        return resolveComputeValue(this.controller, nextState, previousValue, mutationEvent, () => this.describeContext())
     }
 }
 
@@ -228,11 +259,10 @@ if you want to save the use the initial value, you need to define computeValue i
 Or if you want to use state name as value, you should not set ${this.dataContext.host.name}.${this.dataContext.id.name} when ${this.dataContext.host.name} created.
 `
         )
-        if (lastValue !== undefined || this.initialState.computeValue) {
-            return await this.initialState.computeValue!.call(this.controller, lastValue, undefined)
-        } else {
-            return this.initialState.name
-        }
+        return resolveComputeValue(this.controller, this.initialState, lastValue, undefined, () => this.describeContext())
+    }
+    private describeContext() {
+        return `of property "${this.dataContext.host.name}.${this.dataContext.id.name}"`
     }
     async computeDirtyRecords(mutationEvent: RecordMutationEvent) {
         // Now directly use mutationEvent for matching
@@ -271,7 +301,7 @@ Or if you want to use state name as value, you should not set ${this.dataContext
 
         await this.state.currentState.setInternal(lockedRecord, nextState.name)
         const previousValue = lockedRecord[this.dataContext.id.name]
-        return nextState.computeValue? (await nextState.computeValue.call(this.controller, previousValue, mutationEvent)) : nextState.name
+        return resolveComputeValue(this.controller, nextState, previousValue, mutationEvent, () => this.describeContext())
     }
     // 给外部用的，因为可能在 Transform 里面设置初始值。
     async createStateData(state: StateNodeInstance) {

--- a/src/runtime/migration.ts
+++ b/src/runtime/migration.ts
@@ -2755,7 +2755,11 @@ async function resolveDataDepsForMigration(controller: Controller, computation: 
         }
         if (dep.type === "global") {
             const stored = await readHandle.findOne(DICTIONARY_RECORD, MatchExp.atom({ key: "key", value: ["=", dep.source.name!] }), undefined, ["value"]);
-            return [name, (stored?.value as { raw?: unknown } | undefined)?.raw];
+            if (stored) return [name, (stored.value as { raw?: unknown } | undefined)?.raw];
+            // 与运行时 dict.get 的声明驱动回退对齐：无存储行时按 Dictionary.defaultValue 求值，
+            // 否则 dry-run / destructive-scope 评估读到 undefined，与迁移后运行时的取值不一致。
+            const declared = controller.dict.find(dictionary => dictionary.name === dep.source.name);
+            return [name, declared?.defaultValue !== undefined ? declared.defaultValue() : undefined];
         }
         throw new MigrationError(`Unknown data dependency type '${(dep as { type?: string }).type}' for ${dataContextPath(computation.dataContext)}`);
     }));

--- a/src/storage/erstorage/QueryExecutor.ts
+++ b/src/storage/erstorage/QueryExecutor.ts
@@ -397,11 +397,15 @@ export class QueryExecutor {
         const reverseAttributeName = info.getReverseInfo()?.attributeName!
         const resultKey = relatedRecordQuery.alias || relatedRecordQuery.attributeName!
 
-        // 保证每个父记录都有数组（没有子记录的父记录也一样）
+        // 保证每个父记录都有数组（没有子记录的父记录也一样）。
+        // CAUTION key 一律 String(id)：父记录 id 与子记录反向端点 id 可能以不同 JS 类型返回
+        //  （整型发号驱动 number/string 混用、BIGINT 以字符串返回等），裸值 Map 匹配失败时
+        //  子记录会被**静默丢弃**（父记录拿到空集合、无任何报错）。与 NewRecordData.dedupeRefItems
+        //  的既有归一化策略一致。
         const parentById = new Map<string, Record>()
         for (const parent of parentRecords) {
             parent[resultKey] = []
-            parentById.set(parent.id, parent)
+            parentById.set(String(parent.id), parent)
         }
 
         // 分组需要每条子记录带上父 id。如果用户没有查询反向属性，这里追加 [reverseAttr, {attributeQuery: ['id']}]
@@ -444,7 +448,7 @@ export class QueryExecutor {
 
             for (const item of data) {
                 const parentId = item[reverseAttributeName]?.id
-                const parent = parentId !== undefined ? parentById.get(parentId) : undefined
+                const parent = parentId !== undefined ? parentById.get(String(parentId)) : undefined
 
                 // 和 findXToManyRelatedRecords 一致：把和父亲的关系数据挂到 & 上，并去掉临时的反向属性
                 if (shouldQueryParentLink) {

--- a/tests/runtime/review-fixes-2026-07-10-r15.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-10-r15.spec.ts
@@ -1,0 +1,418 @@
+import { describe, expect, test } from "vitest";
+import {
+    Controller, MonoSystem, Entity, Property, Dictionary,
+    StateMachine, StateNode, StateTransfer,
+    Interaction, InteractionEventEntity, Action, Payload, PayloadItem, Condition,
+    Custom, MatchExp, DICTIONARY_RECORD, KlassByName,
+    ComputationResult, createMigrationManifest, hashMigrationDiff,
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+
+// 第十五轮 review 修复回归（deep-review-2026-07-10-r15.md）
+describe('r15 review fixes', () => {
+
+    // F-1: StateNode.computeValue 返回 undefined（漏写 return）必须 fail-fast。
+    //  此前 bound currentState 已 setInternal 推进、applyResult 对 undefined skip，
+    //  可见属性与状态机内部状态静默脱钩（下一跳从新状态出发，读方还看到旧值）。
+    test('F-1 property statemachine computeValue returning undefined fails fast and keeps state consistent', async () => {
+        const pendingState = StateNode.create({ name: 'r15pending' })
+        const approvedState = StateNode.create({
+            name: 'r15approved',
+            computeValue: async function () {
+                // 用户漏写 return 的形态
+            }
+        })
+        const doneState = StateNode.create({ name: 'r15done' })
+
+        const taskEntity = Entity.create({
+            name: 'R15Task',
+            properties: [
+                Property.create({
+                    name: 'status',
+                    type: 'string',
+                    computation: StateMachine.create({
+                        states: [pendingState, approvedState, doneState],
+                        initialState: pendingState,
+                        transfers: [
+                            StateTransfer.create({
+                                current: pendingState,
+                                next: approvedState,
+                                trigger: {
+                                    recordName: InteractionEventEntity.name,
+                                    type: 'create',
+                                    record: { interactionName: 'r15advance' }
+                                },
+                                computeTarget: (event: any) => ({ id: event.record.payload.content.id })
+                            }),
+                            StateTransfer.create({
+                                current: approvedState,
+                                next: doneState,
+                                trigger: {
+                                    recordName: InteractionEventEntity.name,
+                                    type: 'create',
+                                    record: { interactionName: 'r15advance' }
+                                },
+                                computeTarget: (event: any) => ({ id: event.record.payload.content.id })
+                            })
+                        ]
+                    })
+                }),
+                Property.create({ name: 'title', type: 'string' })
+            ]
+        })
+
+        const advanceInteraction = Interaction.create({
+            name: 'r15advance',
+            action: Action.create({ name: 'r15advance' }),
+            payload: Payload.create({
+                items: [PayloadItem.create({ name: 'content', type: 'object', isRef: true, base: taskEntity })]
+            })
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [taskEntity],
+            relations: [],
+            eventSources: [advanceInteraction],
+        })
+        await controller.setup(true)
+
+        const task = await system.storage.create('R15Task', { title: 't1' })
+        const user = { id: 'u1' }
+
+        // 第一跳触发 computeValue 返回 undefined → dispatch 必须失败（事务回滚，含 bound state 推进）
+        const r1 = await controller.dispatch(advanceInteraction, { user, payload: { content: { id: task.id } } })
+        expect(r1.error).toBeDefined()
+        expect(String((r1.error as any)?.causedBy?.message ?? r1.error)).toMatch(/computeValue of state "r15approved" returned undefined/)
+
+        // 可见属性保持初始值，且状态机内部没有偷偷前进：再次 dispatch 仍然从 pending 出发（同样失败），
+        // 绝不允许出现「第一跳没生效、第二跳直接到 done」的脱钩序列。
+        const after1 = await system.storage.findOne('R15Task', MatchExp.atom({ key: 'id', value: ['=', task.id] }), undefined, ['*'])
+        expect(after1.status).toBe('r15pending')
+        const r2 = await controller.dispatch(advanceInteraction, { user, payload: { content: { id: task.id } } })
+        expect(r2.error).toBeDefined()
+        const after2 = await system.storage.findOne('R15Task', MatchExp.atom({ key: 'id', value: ['=', task.id] }), undefined, ['*'])
+        expect(after2.status).toBe('r15pending')
+
+        await system.destroy()
+    })
+
+    // F-1 正向：合法的 computeValue（返回值 / null）不受影响
+    test('F-1 legal computeValue forms still work (value and null)', async () => {
+        const offState = StateNode.create({ name: 'r15off', computeValue: () => null })
+        const onState = StateNode.create({ name: 'r15on', computeValue: (lastValue: unknown) => 'lit' })
+
+        const lampEntity = Entity.create({
+            name: 'R15Lamp',
+            properties: [
+                Property.create({
+                    name: 'display',
+                    type: 'string',
+                    computation: StateMachine.create({
+                        states: [offState, onState],
+                        initialState: offState,
+                        transfers: [
+                            StateTransfer.create({
+                                current: offState,
+                                next: onState,
+                                trigger: {
+                                    recordName: InteractionEventEntity.name,
+                                    type: 'create',
+                                    record: { interactionName: 'r15toggle' }
+                                },
+                                computeTarget: (event: any) => ({ id: event.record.payload.lamp.id })
+                            })
+                        ]
+                    })
+                })
+            ]
+        })
+        const toggleInteraction = Interaction.create({
+            name: 'r15toggle',
+            action: Action.create({ name: 'r15toggle' }),
+            payload: Payload.create({
+                items: [PayloadItem.create({ name: 'lamp', type: 'object', isRef: true, base: lampEntity })]
+            })
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [lampEntity],
+            relations: [],
+            eventSources: [toggleInteraction],
+        })
+        await controller.setup(true)
+
+        const lamp = await system.storage.create('R15Lamp', {})
+        const created = await system.storage.findOne('R15Lamp', MatchExp.atom({ key: 'id', value: ['=', lamp.id] }), undefined, ['*'])
+        // SQL NULL 在读取形态中表现为键缺失（既有读语义，r4-I-1）——断言不是状态名即可
+        expect(created.display ?? null).toBeNull()
+
+        const r = await controller.dispatch(toggleInteraction, { user: { id: 'u1' }, payload: { lamp: { id: lamp.id } } })
+        expect(r.error).toBeUndefined()
+        const after = await system.storage.findOne('R15Lamp', MatchExp.atom({ key: 'id', value: ['=', lamp.id] }), undefined, ['*'])
+        expect(after.display).toBe('lit')
+
+        await system.destroy()
+    })
+
+    // F-2: compute() 返回 ComputationResult 信封（fullRecompute 等）必须 fail-fast，
+    //  不允许把信封对象当值写进 dict/property（此前 dict 值会变成 {"reason":"..."}）。
+    test('F-2 compute returning a ComputationResult envelope fails fast instead of writing it raw', async () => {
+        const itemEntity = Entity.create({
+            name: 'R15EnvelopeItem',
+            properties: [Property.create({ name: 'val', type: 'number' })]
+        })
+        const trapDict = Dictionary.create({
+            name: 'r15TrapValue',
+            type: 'number',
+            collection: false,
+            computation: Custom.create({
+                name: 'R15TrapCompute',
+                dataDeps: {
+                    items: { type: 'records', source: itemEntity, attributeQuery: ['val'] }
+                },
+                compute: async function () {
+                    return ComputationResult.fullRecompute('confused user')
+                },
+            })
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [itemEntity],
+            relations: [],
+            dict: [trapDict],
+        })
+        await controller.setup(true)
+
+        await expect(system.storage.create('R15EnvelopeItem', { val: 5 })).rejects.toThrow(/ComputationResultFullRecompute envelope where a plain value is expected/)
+        // dict 未被信封污染（保持 install 时的初始计算值）
+        const value = await system.storage.dict.get('r15TrapValue')
+        expect(typeof value === 'object' && value !== null && 'reason' in (value as object)).toBe(false)
+
+        await system.destroy()
+    })
+
+    // S-2: dict defaultValue 工厂在注册时求值一次；读 miss 返回稳定值（且对象为独立副本）
+    test('S-2 dict defaultValue read-fallback is evaluated once and stable across reads', async () => {
+        let invocations = 0
+        const cfgDict = Dictionary.create({
+            name: 'r15CfgObject',
+            type: 'object',
+            collection: false,
+            defaultValue: () => {
+                invocations++
+                return { seq: invocations }
+            }
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [],
+            relations: [],
+            dict: [cfgDict],
+        })
+        await controller.setup(true)
+        const invocationsAfterSetup = invocations
+
+        // 删除持久化行，模拟 setup(false) 下新增声明未 migrate / 行被手工删除
+        await system.storage.delete(DICTIONARY_RECORD, MatchExp.atom({ key: 'key', value: ['=', 'r15CfgObject'] }))
+
+        const v1 = await system.storage.dict.get('r15CfgObject') as { seq: number }
+        const v2 = await system.storage.dict.get('r15CfgObject') as { seq: number }
+        // 读 miss 不再重新求值工厂
+        expect(invocations).toBe(invocationsAfterSetup)
+        // 两次读到同一个稳定值
+        expect(v1.seq).toBe(v2.seq)
+        // 且是独立副本（与存储路径的 JSON codec 读语义一致），互不共享可变引用
+        v1.seq = 999
+        const v3 = await system.storage.dict.get('r15CfgObject') as { seq: number }
+        expect(v3.seq).toBe(v2.seq)
+
+        await system.destroy()
+    })
+
+    // S-3: teardown 清除 dict 读回退（旧 controller 的声明不再影响后续读取）
+    test('S-3 teardown unregisters dict default read-fallback', async () => {
+        const cfgDict = Dictionary.create({
+            name: 'r15TeardownCfg',
+            type: 'number',
+            collection: false,
+            defaultValue: () => 42
+        })
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [],
+            relations: [],
+            dict: [cfgDict],
+        })
+        await controller.setup(true)
+        await system.storage.delete(DICTIONARY_RECORD, MatchExp.atom({ key: 'key', value: ['=', 'r15TeardownCfg'] }))
+
+        expect(await system.storage.dict.get('r15TeardownCfg')).toBe(42)
+        controller.teardown()
+        expect(await system.storage.dict.get('r15TeardownCfg')).toBeUndefined()
+
+        await system.destroy()
+    })
+
+    // S-4: context.skip 由框架集中收口——自定义 planIncremental 忽略 skip 也不会用无关事件跑增量
+    test('S-4 framework enforces context.skip even when a custom planIncremental ignores it', async () => {
+        let incrementalRuns = 0
+        const itemEntity = Entity.create({
+            name: 'R15SkipItem',
+            properties: [
+                Property.create({ name: 'kind', type: 'string' }),
+                Property.create({ name: 'val', type: 'number' })
+            ]
+        })
+        const sumDict = Dictionary.create({
+            name: 'r15IgnorantSum',
+            type: 'number',
+            collection: false,
+            computation: Custom.create({
+                name: 'R15IgnorantSum',
+                useLastValue: true,
+                dataDeps: {
+                    matched: {
+                        type: 'records',
+                        source: itemEntity,
+                        match: MatchExp.atom({ key: 'kind', value: ['=', 'counted'] }),
+                        attributeQuery: ['val', 'kind']
+                    }
+                },
+                getInitialValue: () => 0,
+                compute: async function (deps: any) {
+                    return (deps.matched ?? []).reduce((acc: number, item: any) => acc + (item.val ?? 0), 0)
+                },
+                // 有意忽略 context.skip 的错误实现
+                planIncremental: () => ({ type: 'incremental', dataDepKeys: [], needsLastValue: { mode: 'normal' } }),
+                incrementalCompute: async function (lastValue: number, event: any) {
+                    incrementalRuns++
+                    if (event.type === 'create') return (lastValue ?? 0) + (event.record?.val ?? 0)
+                    return lastValue
+                }
+            })
+        })
+
+        const system = new MonoSystem(new PGLiteDB())
+        system.conceptClass = KlassByName
+        const controller = new Controller({
+            system,
+            entities: [itemEntity],
+            relations: [],
+            dict: [sumDict],
+        })
+        await controller.setup(true)
+
+        await system.storage.create('R15SkipItem', { kind: 'counted', val: 10 })
+        expect(await system.storage.dict.get('r15IgnorantSum')).toBe(10)
+        const runsAfterMatched = incrementalRuns
+
+        // match 之外的记录（kind !== 'counted'）：框架必须在 planIncremental 之前 skip
+        await system.storage.create('R15SkipItem', { kind: 'ignored', val: 999 })
+        expect(incrementalRuns).toBe(runsAfterMatched)
+        expect(await system.storage.dict.get('r15IgnorantSum')).toBe(10)
+
+        await system.destroy()
+    })
+
+    // S-7: Condition.create 声明期校验 content
+    test('S-7 Condition.create rejects missing content at declaration time', async () => {
+        expect(() => Condition.create({ name: 'r15Broken' } as any)).toThrow(/requires a function "content"/)
+        expect(() => Condition.create({ name: 'r15Broken2', content: 'not-a-function' as any })).toThrow(/requires a function "content"/)
+    })
+})
+
+// S-1: 迁移跨进程 resume（DDL 已应用、phase 已记 schema-applied、进程崩溃）
+//  必须在全新进程（queryHandle 未初始化）上完成重算——此前会抛
+//  "Cannot read properties of undefined (reading 'find')" 并永久卡死。
+describe('r15 migration resume on a fresh process', () => {
+    async function approveGeneratedMigrationDiff(controller: Controller) {
+        const diff = await controller.generateMigrationDiff({ includeFunctionText: true, includeDestructiveScope: true });
+        const decisions = [
+            ...diff.decisions,
+            ...diff.requiredDecisions.map((requirement: any) => {
+                if (requirement.kind === "computation") {
+                    return {
+                        kind: "computation" as const,
+                        id: requirement.id,
+                        dataContext: requirement.dataContext,
+                        decision: requirement.recommendedDecision,
+                        reason: "approved by r15 regression",
+                    };
+                }
+                return { ...requirement, reason: "approved by r15 regression" };
+            }),
+        ];
+        return { ...diff, status: "approved" as const, decisions };
+    }
+
+    test('S-1 crash-resume with a non-empty rebuild plan recomputes on a fresh system', async () => {
+        const db = new PGLiteDB();
+
+        const ItemV1 = new Entity({
+            name: 'R15ResumeItem',
+            properties: [new Property({ name: 'score', type: 'number' }, { uuid: 'r15-resume-score' })]
+        }, { uuid: 'r15-resume-item' });
+        const systemV1 = new MonoSystem(db);
+        systemV1.conceptClass = KlassByName;
+        const controllerV1 = new Controller({ system: systemV1, entities: [ItemV1], relations: [] });
+        await controllerV1.setup(true);
+        await systemV1.storage.create('R15ResumeItem', { score: 1 });
+        await systemV1.storage.create('R15ResumeItem', { score: 5 });
+
+        const buildV2Entity = () => new Entity({
+            name: 'R15ResumeItem',
+            properties: [
+                new Property({ name: 'score', type: 'number' }, { uuid: 'r15-resume-score' }),
+                new Property({
+                    name: 'doubled',
+                    type: 'number',
+                    computation: new Custom({
+                        name: 'R15ResumeDoubleScore',
+                        dataDeps: { _self: { type: 'property', attributeQuery: ['score'] } },
+                        compute: async function (deps: any) {
+                            return (deps._self?.score ?? 0) * 2
+                        }
+                    }, { uuid: 'r15-resume-custom' })
+                }, { uuid: 'r15-resume-doubled' })
+            ]
+        }, { uuid: 'r15-resume-item' });
+
+        // 迁移规划进程：拿到 approvedDiff 并模拟「DDL 已应用、phase 已记 schema-applied 后进程崩溃」
+        const ItemV2 = buildV2Entity();
+        const systemV2 = new MonoSystem(db);
+        systemV2.conceptClass = KlassByName;
+        const controllerV2 = new Controller({ system: systemV2, entities: [ItemV2], relations: [] });
+        const approvedDiff = await approveGeneratedMigrationDiff(controllerV2);
+        const dryPlan = await controllerV2.migrate({ approvedDiff, dryRun: true });
+        for (const operation of dryPlan.schemaPlan!.preRecomputeDDL) {
+            if ((operation as any).sql) await db.scheme((operation as any).sql);
+        }
+        const states = controllerV2.scheduler.createStates();
+        const schemaPlan = await (systemV2 as any).prepareMigrationSchema(controllerV2.entities, controllerV2.relations, states);
+        const modelHash = createMigrationManifest(controllerV2, schemaPlan.schema).modelHash;
+        await db.scheme(`INSERT INTO "__interaqt_migration_log" ("id", "modelHash", "approvedDiffHash", "phase", "status", "createdAt", "updatedAt") VALUES ('r15-crashed-resume', '${modelHash}', '${hashMigrationDiff(approvedDiff)}', 'schema-applied', 'failed', 'now', 'now')`);
+
+        // 全新进程（fresh MonoSystem，queryHandle 未初始化）resume：必须成功并完成重算
+        const systemV3 = new MonoSystem(db);
+        systemV3.conceptClass = KlassByName;
+        const controllerV3 = new Controller({ system: systemV3, entities: [ItemV2], relations: [] });
+        await controllerV3.migrate({ approvedDiff });
+
+        const items = await systemV3.storage.find('R15ResumeItem', undefined, undefined, ['score', 'doubled'])
+        expect(items.map((item: any) => item.doubled).sort((a: number, b: number) => a - b)).toEqual([2, 10])
+        await db.close();
+    }, 60000)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

第十五轮全代码库深度 review（基线 `main` @ v3.0.0，r1–r14 修复全部落地）。四路并行探查 + 对每个致命/重要候选编写最小复现测试实际运行确认。完整报告见 `agentspace/output/deep-review-2026-07-10-r15.md`。

## 致命问题（已复现，已修）

### F-1 StateMachine `computeValue` 返回 undefined：内部状态与可见属性脱钩

`incrementalCompute` 在调用 `computeValue` **之前**已用 `setInternal` 推进 bound `currentState`，而 r13-F-2 起 `applyResult` 对 undefined 统一 skip。`computeValue` 漏写 return 时：内部状态已前进、可见属性原地不动——下一个事件从新状态出发做转移，读方仍看到旧值（实测：status 显示 `pending`，第二次 dispatch 直接跳到 `done`）。

修复：四个调用点（global/property × initial/incremental）统一经 `resolveComputeValue` 校验，undefined 一律 `ComputationProtocolError` fail-fast（事务整体回滚，bound state 推进一并回滚）。

### F-2 迁移跨进程 resume 永久卡死

`phase >= schema-applied` 时跳过 `applyMigrationSchema`，但该函数同时初始化本进程的 storage `queryHandle`。崩溃后在**全新进程** resume 时带着未初始化的 queryHandle 进重算事务，第一次 storage 读即抛 `Cannot read properties of undefined (reading 'find')`，且每次重试同样崩溃——不可恢复。

修复：`applyMigrationSchema` 无条件执行（DDL 经 operation log + 每轮重新 diff 双重幂等）；migrate 进入重算前 `scheduler.teardown()` + `registerDictDefaults()`。

## 重要修复

- **R-1** `applyResult`/`applyInitialValue` 拒绝残余 `ComputationResult` 信封——此前 `compute()`/`asyncReturn()` 返回 `fullRecompute` 等信封会被当普通值原样写进 dict/property（实测 dict 值变成 `{"reason":"..."}`）
- **R-2** dict `defaultValue` 读回退改为注册时求值一次（与 install 语义对齐），读返回 JSON round-trip 副本——非幂等工厂不再在同一事务内产出漂移值
- **R-3** 迁移重算与 readHandle 依赖解析尊重声明的 `Dictionary.defaultValue`
- **R-4** `context.skip` 由框架在 `planIncremental` 之前集中收口——自定义 planner 忽略 skip 不再用无关事件跑增量
- **R-5** `teardown()` 一并注销 dict 读回退
- **R-6** 批量 1:n 分组父 id `String()` 归一化（id 类型混用时子记录静默丢失）
- **R-7** `Condition.create` 声明期校验 content 为函数
- 一致性清理：activity head 守卫路径统一走 `fullGuard`；清除 Attributive 拆除后残留的 `saveUserRefs` 注释；修正 core README 中不存在的 `InteractionCall` 引用

## 证伪/降级候选（详见报告第五节）

storage.dispatch 衍生事件链（证伪）、批量 1:n 孤儿丢弃（既有遗留降级）、group-root 多分支 head 隐式建实例（by-design，文档示警项）等 5 项。

## 测试

- ✅ `npm run check`
- ✅ `npm test` 全量 **1844 passed / 26 skipped**（净 +8 回归用例，零既有用例回归）
- ✅ `npm run build`
- 新增回归：`tests/runtime/review-fixes-2026-07-10-r15.spec.ts`（8 用例，覆盖 F-1 双向、F-2 跨进程 resume、R-1/R-2/R-4/R-5/R-7）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-186fecd6-cb01-4e3a-937e-d629363c43e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-186fecd6-cb01-4e3a-937e-d629363c43e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

