### PR TITLE
r18 deep review: filtered update routing for event-based computations, migration argsSignature, namespace guards, ScopedSequence scope immutability

### DIFF
--- a/.cursor/rules/interaqt-project.mdc
+++ b/.cursor/rules/interaqt-project.mdc
@@ -48,6 +48,14 @@ All core concepts use a consistent pattern:
 ## Explicit Control Principle
 This project follows "explicit control" — never add implicit behavior, auto-completion, or magic defaults. All behavior must be explicitly declared by the user.
 
+## Bug Fixing: Fix the Class, Not the Instance
+When fixing any bug (mandatory checklist — see `AGENTS.md` § "Bug fixing" for details):
+1. **Enumerate all readers** of the affected declaration surface / event namespace / code path (data-based track, event-based track, migration signature, public producer APIs) — verify each, not just the one the repro walked.
+2. **Prefer convergence-point fixes** (one shared pipeline / choke point / source of truth) over per-branch patches.
+3. **Promote universal rules to checked invariants** — a "this never happens" that only lives in a comment must become a declaration-time guard or setup-time fail-fast.
+4. **Scan sibling cells and backfill the dimension registry** (`tests/runtime/WritingComputationTests.md`) with any new dimension the bug reveals.
+5. **Fatal bugs that escaped tests need an escape analysis** in `agentspace/output/` whose lesson lands as a mechanism (axis / oracle / invariant), not prose.
+
 ## Knowledge Base
 - `agentspace/knowledge/` — Technical docs on filtered entities, cascade, storage, etc.
 - `agent/agentspace/knowledge/usage/` — Usage guides (00–19)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,17 @@ Core types use: interface → CreateArgs → `Entity.create(args)` → static re
 - File naming: `*.spec.ts`
 - Do not manually set entity IDs — let the framework generate them
 - Always `await controller.setup(true)` before dispatching
+- When adding a test **matrix**, consult the dimension registry in `tests/runtime/WritingComputationTests.md` — every dimension (including degenerate values and the mechanism axes) must be explicitly decided
+
+### Bug fixing: fix the class, not the instance
+
+Eighteen review rounds show the dominant failure mode is a **point fix for a reproduced instance while the bug's family lives on** (same rule, different topology / consumer track / view form). When you find and fix a bug, this is the mandatory checklist:
+
+1. **Enumerate all readers of the declaration surface.** If the bug is in how a declaration (`recordName`, trigger, dataDep, payload shape, ...) is consumed, list every consumer of that surface — data-based track, event-based track, migration signature, public producer APIs (`addSourceMap`, ...) — and verify each one. The fix that motivated the repro covers exactly one reader by construction; the siblings are where the next fatal bug lives.
+2. **Prefer convergence-point fixes over per-branch patches.** Route all consumers through one shared pipeline (normalization, guard, choke point) instead of patching the branch the repro walked. One source of truth; duplicated resolution logic *will* drift (e.g. hand-walking the entity graph vs the compiled storage schema).
+3. **Promote known rules to checked invariants.** If the fix relies on a universal statement ("update events never fire under view names", "reliance is always 1:x"), assert it — declaration-time guard or setup-time invariant with a clear error. Comments have no enforcement power; a fail-fast protects users who hit the case before any test does.
+4. **Scan the neighborhood and backfill the registry.** Fix regressions must cover sibling cells (adjacent topology / operation / track values), and any new dimension the bug reveals must be added to the dimension registry in `tests/runtime/WritingComputationTests.md`.
+5. **For fatal bugs that escaped existing tests, record the escape analysis.** Write *why the test system missed it* (retrospective in `agentspace/output/`), and turn the lesson into a mechanism — a new axis, an oracle, an invariant — not prose. See `agentspace/output/r17-test-blindness-retrospective.md` and `r18-test-blindness-retrospective.md` for the method and precedents.
 
 ## Common patterns
 
@@ -360,6 +371,8 @@ npm run build               # vite library build → dist/
 | `agentspace/knowledge/` | Technical deep-dives (filtered entities, cascade, storage) |
 | `src/storage/USAGE_GUIDE.md` | Storage layer usage |
 | `src/storage/IMPLEMENTATION_DETAILS.md` | Storage internals |
+| `tests/runtime/WritingComputationTests.md` | Computation test guide + **dimension registry** (mandatory for new test matrices and bug-fix regressions) |
+| `agentspace/output/r17-test-blindness-retrospective.md`, `.../r18-test-blindness-retrospective.md` | Why fatal bugs escaped the test system — structural blind spots and the systemic-fix method |
 
 Start with:
 

--- a/agent/agentspace/knowledge/usage/04-reactive-computations.md
+++ b/agent/agentspace/knowledge/usage/04-reactive-computations.md
@@ -137,6 +137,8 @@ Rules:
 - Do not set a `defaultValue` on the same property. The allocator supplies the value after the create mutation and before commit.
 - Scope paths can only read stable primitive/ref values already present on the created record.
 - Missing or type-mismatched scope values are errors.
+- **Scope inputs are immutable after numbering.** Updating a scope value field, or removing/replacing a scope ref relation, on a record that already holds a sequence number fails fast — the number is allocated once per scope at creation, and re-scoping would silently duplicate numbers in the target scope (permanently violating the `UniqueConstraint` there). Delete and recreate the record in the new scope, or model the mutable dimension outside the sequence scope. Records the `match` predicate skipped (no number assigned) can move freely.
+- `match` predicate fields are also expected to be create-time stable: a record that starts non-matching and later mutates into the predicate does **not** get a number retroactively.
 - `allowManualValue: true` is for import/backfill and does not advance the counter.
 - Existing data migration should use `initializeFrom` to seed every scope with `MAX(serialNumber)`.
 - Keep the `UniqueConstraint`; the allocator prevents normal duplicates, and the constraint is the integrity backstop.

--- a/agent/agentspace/knowledge/usage/09-filtered-entities.md
+++ b/agent/agentspace/knowledge/usage/09-filtered-entities.md
@@ -533,6 +533,10 @@ A filtered entity name carries three event shapes, for both data-based computati
 
 So a `StateMachine` transfer like `trigger: { recordName: 'ActiveTicket', type: 'update', keys: ['title'] }` fires exactly for title changes of tickets that are and remain active.
 
+The same three-shape semantics apply to **merged input views** (`inputEntities`/`inputRelations` declarations) and to nested filtered chains — every view name resolves to its physical base through the compiled storage schema.
+
+Additionally, every declared listener is validated at setup: a `recordName` that no record in the storage schema carries (a typo, an entity not registered on the Controller, or a global dictionary name — dictionary changes are emitted on the `_Dictionary_` record with `record: { key: '<dictName>' }`) fails fast with a `ComputationProtocolError` instead of becoming a silent dead listener.
+
 ### Automatic Update Mechanism
 
 ```javascript

--- a/agent/agentspace/knowledge/usage/09-filtered-entities.md
+++ b/agent/agentspace/knowledge/usage/09-filtered-entities.md
@@ -523,6 +523,16 @@ const CategoryStats = Entity.create({
 
 ## Real-time Updates and Event Handling
 
+### Event Semantics on Filtered Entity Names
+
+A filtered entity name carries three event shapes, for both data-based computations (`dataDeps`) and event-based computations (`StateMachine` triggers, `Transform` `eventDeps`):
+
+- `create` — a record **entered** the filtered set (created as a member, or updated into the predicate);
+- `delete` — a record **left** the filtered set (deleted, or updated out of the predicate);
+- `update` — a member's fields changed **while staying in** the set. The framework routes the base record's physical update event to listeners declared on the filtered name and rewrites `event.recordName` to the filtered name; enter/exit updates are delivered as the membership `create`/`delete` above (never double-fired as `update`).
+
+So a `StateMachine` transfer like `trigger: { recordName: 'ActiveTicket', type: 'update', keys: ['title'] }` fires exactly for title changes of tickets that are and remain active.
+
 ### Automatic Update Mechanism
 
 ```javascript

--- a/agent/agentspace/knowledge/usage/19-common-anti-patterns.md
+++ b/agent/agentspace/knowledge/usage/19-common-anti-patterns.md
@@ -55,15 +55,47 @@ import { InteractionEventEntity } from 'interaqt';
 ```javascript
 // ❌ WRONG: identifier property doesn't exist
 Property.create({ 
-  name: 'id', 
+  name: 'externalId', 
   type: 'string',
   identifier: true  // This doesn't exist!
 });
 
 // ✅ CORRECT: ID uniqueness is handled by storage layer
 Property.create({ 
-  name: 'id', 
+  name: 'externalId', 
   type: 'string'
+});
+```
+
+### ❌ Declaring Reserved Property Names
+
+```javascript
+// ❌ WRONG: 'id' is the framework-managed primary key — Entity.create rejects it.
+// The same applies to '_rowId', and to 'source'/'target' on relation properties.
+Property.create({ name: 'id', type: 'string' });
+
+// ✅ CORRECT: use an explicit business identifier name
+Property.create({ name: 'externalId', type: 'string' });
+```
+
+### ❌ Relation Property Name Colliding with a Value Property
+
+```javascript
+// ❌ WRONG: sourceProperty 'email' collides with the scalar property 'email' —
+// they share one attribute namespace per record; setup fails fast.
+const User = Entity.create({
+  name: 'User',
+  properties: [Property.create({ name: 'email', type: 'string' })]
+});
+Relation.create({
+  source: User, sourceProperty: 'email',  // collides!
+  target: Contact, targetProperty: 'owner', type: '1:n'
+});
+
+// ✅ CORRECT: pick distinct names for value properties and relation properties
+Relation.create({
+  source: User, sourceProperty: 'contacts',
+  target: Contact, targetProperty: 'owner', type: '1:n'
 });
 ```
 

--- a/agentspace/output/deep-review-2026-07-11-r18.md
+++ b/agentspace/output/deep-review-2026-07-11-r18.md
@@ -1,0 +1,170 @@
+# 全代码库深度 Review 报告（2026-07-11 第十八轮）
+
+- 日期：2026-07-11
+- 基线：`main` @ `19cb5f14`（v3.1.0，r1–r17 全部致命/重要修复已落地）
+- 基线健康度：`npm run check` 通过；`npm test` 全量 **1871 passed / 26 skipped**
+- 范围：四路并行深度探查（storage 写路径与 SQL 编译 / runtime 调度与增量计算 / **migration+ScopedSequence+RefContainer 专项**（本轮新增的最少覆盖面）/ core+builtins+drivers）+ 对全部致命候选**亲自编写最小复现实际运行**（PGLiteDB / SQLiteDB）
+- 方法：与 r1–r17 全部报告逐条去重；每个候选先做代码路径二次追踪，再以运行时复现定谳（本轮 1 项候选被复现证伪、1 项被架构追踪证伪，见第四节）。「已复现确认」才列为致命。
+- 修复状态：**四个致命项 + 两个重要项已在本分支（`cursor/deep-code-review-r18-7a3e`）全部修复**，回归固化于 `tests/runtime/review-fixes-2026-07-11-r18.spec.ts`（11 用例）与 `tests/storage/review-fixes-2026-07-11-r18.spec.ts`（9 用例）。修复后 `npm run check` 通过，`npm test` 全量通过（含新增回归）。
+
+---
+
+## 一、结论摘要
+
+r1–r17 修复后，storage 写路径、聚合增量一致性、对称关系、filtered 成员资格等高风险面已高度收敛（本轮 storage 探查未发现新致命项，印证矩阵体系生效）。本轮四个新致命问题全部落在**上一轮结构层没有铺到的三个面**：
+
+1. **事件驱动计算轨道与数据驱动轨道的 filtered 路由不对称**（F-1）——r16 修了「视图成员资格事件的契约」、结构层给**数据驱动**计算修了 filtered update 路由（`normalizeFilteredUpdateSourceMap`），但**事件驱动**计算（StateMachine trigger / Transform eventDeps）没有走这条归一化：在 filtered 名上声明 `update` 监听是死监听，转移/派生永不触发、零告警。「双轨必须同构」的架构义务此前只在一条轨道上兑现。
+2. **migration manifest 的签名采集对「普通值参数」全盲**（F-2）——十七轮建立的签名体系覆盖了函数文本（functionSignature）、数据/事件依赖（deps/eventDeps）、绑定状态（stateSignature），但 trigger.keys、trigger.record 模式、状态图拓扑（next 状态名）、Every.notEmpty、Transform eventDeps 的 record 模式这些**改了就改变存量数据语义**的普通值参数不进任何签名——迁移零感知、审阅零条目、存量数据带旧语义静默放行。这是对 Phase 1.5「审阅即契约」承诺的系统性破坏。
+3. **声明期命名空间守卫的剩余缺口**（F-3）+ **ScopedSequence 的 create-time-stable 假设无执行力**（F-4）——前者是「值属性 vs 关系属性」共享命名空间的静默覆盖（实测标量字符串被逐字符摊开成假关联记录，**仓库自己的 activity 测试夹具就带着这个冲突**）；后者是 scope 字段编号后仍可变，配合文档推荐的 UniqueConstraint 会把目标 scope 的 create **永久堵死**（计数器随事务回滚，不可自愈）。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修复） | 4 | filtered update 死监听（事件驱动轨）、migration 普通值参数零感知、值/关系属性命名空间静默覆盖、ScopedSequence scope 可变导致重复编号+scope 永久堵死 |
+| 重要（已修复） | 2 | 保留名/重复属性名声明期守卫、retrieveLastValue 真值短路 |
+| 重要（记录，本轮不修） | 若干 | 见第三节 |
+| 证伪/降级 | 2+ | 见第四节 |
+
+---
+
+## 二、致命问题（全部已复现确认并修复）
+
+### F-1 事件驱动计算在 filtered entity/relation 名上的 `update` 监听是死监听——StateMachine 转移/Transform 派生永不触发
+
+- 位置：`src/runtime/ComputationSourceMap.ts` `initialize`（eventDeps 分支直接按声明的 recordName 注册，不经过 `normalizeFilteredUpdateSourceMap`——该函数此前有 `!('dataDep' in source)` 早退）；`src/runtime/Scheduler.ts` `resolveFilteredUpdateEvent`（同样早退）。
+- 机理：storage 的字段 update 事件**只以物理 base 记录名**发出（`RecordQuery.create` 把 filtered 名解析为 `resolvedBaseRecordName`）；filtered 名下只有成员资格 create/delete 事件。`findSourceMapsForMutation` 按事件的 recordName 精确查表——挂在 filtered 名上的 update 监听永远查不到。
+- 复现（实测，PGLite）：
+
+```
+ActiveTicket = filtered(Ticket, isActive=true)
+StateMachine trigger: { recordName:'ActiveTicket', type:'update', keys:['title'] }
+update(Ticket, {title:'b'})   → 事件 {recordName:'Ticket', ...}
+phase 停在 'active'           ❌ 转移永不触发（期望 'done'）
+Transform eventDeps 同构      ❌ AuditLog 零条目
+对照：type:'create' 的 trigger（成员资格事件以 filtered 名发出）正常触发 ✓
+```
+
+- 影响：在「视图」上声明状态转移/事件派生是完全自然的声明形态（"只关心活跃工单的标题变更"）。数据驱动计算（Count/Summation over filtered）r17 结构层已修，事件驱动轨道是平行漏网——同一声明形态在两条轨道上行为静默分裂，正中 explicit control 的反面。
+- 修复：`normalizeFilteredUpdateSourceMap` 去掉 dataDep 限定，事件驱动 update 监听同样挂到物理名 + 携带 `filteredRecordName`；`resolveFilteredUpdateEvent` 对事件驱动源做同一套成员资格守卫（同批次成员资格事件驱动 enter/exit、stay-in 改写事件名后放行、非成员跳过）。改写后的事件以 filtered 名到达 TransitionFinder/callback，模式匹配命中。
+- 回归：转移触发/非成员不触发/enter 场景由成员资格 create 驱动不双跳、Transform 派生（含事件名断言），共 3 用例。
+
+### F-2 migration manifest 对「普通值参数」全盲：改 trigger 模式/状态图拓扑/notEmpty 等，迁移零感知
+
+- 位置：`src/runtime/migration.ts`——`serializeEventDeps` 只取 recordName/type/phase（丢 trigger.keys、record 模式）；`OWN_FUNCTION_FIELDS` 对 StateTransfer 只采集 computeTarget（丢 current/next 拓扑）；`createComputationManifest` 的 structuralSignature 输入里没有任何普通值参数通道。
+- 复现（实测，四个子形态签名逐一对比）：
+
+```
+v1: trigger.keys ['title']  → v2: ['priority']        签名相同 ❌
+v1: transfer next='closed'  → v2: next='archived'      签名相同 ❌
+v1: Every notEmpty:false    → v2: true                 签名相同 ❌
+v1: eventDep record {interactionName:'CreatePost'} → 'DeletePost'  签名相同 ❌
+```
+
+- 影响：`signature` 相同 ⇒ `getChangedComputations` 判 unchanged ⇒ 无 diff 条目、无审阅决策、无 rebuild；manifest 逐字段进 `modelHash` ⇒ `setup(false)` 直接放行。存量 `status` 列保留旧状态机语义下的值，新代码按新 trigger/新状态图运行——例如旧图写入的 'closed' 状态在新图（open→archived）下永远无转移可走，且用户在迁移审阅中**看不到任何变更**。这是「审阅即契约」的系统性破坏，且是一个**家族**（任何 klass 上的普通值参数），不是四个孤立点。
+- 修复：新增 `argsSignature` 进入 structuralSignature——对 `computation.args` 做规范化序列化：函数 → 位置标记 `[Function]`（**不含**文本哈希：函数文本由 functionSignature 单独覆盖进 `signature`，混入 structuralSignature 会把 createState 文本变化误判为结构变更、破坏 state-only 分类——首版实现踩中此坑，被既有 state-only 测试抓出后修正）；模型引用（Entity/Relation/Property/Dictionary）→ `[<type>:<name>]` 截断（身份由 deps 覆盖，深入遍历会卷入整个模型图）；其他 klass 实例（StateNode/StateTransfer/BoolExp 节点）遍历自有语义字段；uuid/_type/_options 一律剔除（uuid 逐进程随机，进签名会让未变更模型被误判）；键排序 + 循环守卫。**manifest generator 版本 2 → 3**（按既定「不同代版本互不采信、拒绝并指引重建基线」政策处置——升级方需重建 manifest 基线）。
+- 回归：四个子形态变更可见 + 未变更模型跨进程签名稳定（uuid 不泄漏）+ 函数文本-only 变更不动 structuralSignature（state-only 分类保持），共 6 用例；全部 90 个既有 migration 测试通过。
+
+### F-3 值属性与关系属性同名：Setup 静默覆盖，标量写入被摊开成假关联记录
+
+- 位置：`src/storage/erstorage/Setup.ts` `populateRecordAttributes` L694/L722——关系属性**无条件**写入端点 record 的属性表；`validateRelations` 此前只查「filtered 端点 vs base 链上的关系属性」与「同家族多关系同名」，**不查值属性 vs 关系属性**。
+- 复现（实测，PGLite）：
+
+```
+User { email: string }  +  Relation(User.email → Contact, 1:n)
+setup 零报错
+create('User', {email:'a@b.c'}) 返回：
+  email: [{"0":"a","1":"@","2":"b","3":".","4":"c", owner:{...}, id:...}]
+  ❌ 字符串被逐字符摊开成对象、创建了假 Contact 关联记录
+findOne(..., ['*']) → {id}   ❌ email 数据面完全消失
+```
+
+- 影响：零告警 schema 损坏 + 写入路径数据损坏。**仓库自己的 `tests/runtime/data/activity/index.ts` 夹具就带着这个冲突**（Request 的标量 `message` 被 `messageToRequestRelation.sourceProperty='message'` 覆盖，标量声明是死代码）——守卫落地后夹具立即被抓出，佐证该形态在真实代码里自然出现。
+- 修复：`validateRelations` 增加家族级「值属性登记表」（entity/relation 全量 + filtered 变体共享命名空间），关系端点属性命中即 fail-fast；activity 夹具删除死标量声明。
+- 回归：source 侧/target 侧/filtered 变体家族三向冲突 fail-fast + 无冲突对照组，共 4 用例。
+
+### F-4 ScopedSequence 的 scope 输入编号后仍可变：目标 scope 重复编号；配合文档推荐的唯一约束，目标 scope 的 create 永久失败
+
+- 位置：`src/runtime/computations/ScopedSequence.ts`——分配只发生在 `getInitialValue`（create 时），无任何 update/unlink 钩子；scope 字段是宿主上的普通属性/关系，写路径不设防。
+- 复现（实测，PGLite，文档 `usage/04` 推荐的 `UniqueConstraint(project, seq)` 形态）：
+
+```
+A#1 A#2 B#1 已编号
+update(A#2, {project:'B'})     → 静默成功，B 内出现 [1, 2(迁入), ...]
+create({project:'B'})           → 计数器发 2 → 撞唯一约束 ❌
+再次 create                     → 计数器随上次事务回滚，仍发 2 ❌
+scope B 从此永久不可创建（不可自愈）
+```
+
+- 影响：两个面——（a）无唯一约束时同 scope 重复编号（静默破坏「按 scope 单调唯一」语义）；（b）有唯一约束时**目标 scope 的 create 操作永久不可用**，与 r17-F-3「删除操作不可用」同级别的硬故障。触发操作（改工单所属项目）完全常规。
+- 修复：Scheduler mutation 监听层新增 scope 输入不可变守卫（`buildScopedSequenceScopeGuards` / `assertScopedSequenceScopeUnchanged`）——值型 scope 字段的宿主 update 实际变更、ref 型 scope 关系的 delete（解除/替换必先删旧链）均 fail-fast（事务回滚，错误信息给出「删除重建」与「把可变维度移出 scope」两条出路）；**未编号记录（match 未命中）不受限制**；宿主整体删除的级联解链不受影响（届时宿主行已不存在）。知识库 `usage/04` 补齐「scope 输入 create-time stable」契约与 match 字段的同族说明。
+- 回归：值型 scope 拒改 + scope 保持可用 + 非 scope 字段照常可更新；ref 型 scope 拒替换 + 宿主删除不受影响 + 后续编号连续，共 2 用例。
+
+---
+
+## 三、重要问题
+
+### 已修复（本轮随手收口）
+
+- **R-1 保留属性名与重复属性名无声明期守卫**：`Property.create({name:'id'})` 被框架主键静默覆盖（含其 defaultValue/computation——声明形同虚设）；同实体重复属性名 `Object.fromEntries` 静默保留最后一个、但**两个计算句柄都注册**（争用一列），此前仅靠 migration 的 "Migration identity is ambiguous" 意外拦截（报错点与病因相距甚远）。修复：`Entity.create`/`Relation.create` 声明期拒绝 `id`/`_rowId`（relation 另加 `source`/`target`）与重复名；`DBSetup.validatePropertyNames` 兜底（覆盖 create 后 push 属性、直接 new 构造等旁路）。非 merged 实体的自定义 `__type` 维持 r9 判定（合法）。`Entity.public.constraints.eachNameUnique` 元数据从「从不执行的死代码」变为有实际执行点。
+- **R-2 `retrieveLastValue` 属性分支真值短路**：`if (record![prop])` 把 0/false/'' 误判为缺失而绕查数据库——多数时候是浪费一次查询，record 快照比库新时会拿到错误 lastValue。改为 `!== undefined`。
+
+### 记录，本轮不修（按影响排序）
+
+1. **迁移子系统的三个审阅完整性缺口**（migration 专项探查产出，均有代码证据）：
+   - 事实属性/Dictionary 的 `defaultValue` 变更不进 manifest（property 只记录 type/collection/computed）——存量行保持旧默认语义、审阅不可见；与 r16 的「新增属性 backfill」形成不对称。建议：property manifest 增加 `defaultValueSignature`（与 boundStates 的 `[Function:hash]` 同模式），可随下一次 generator 版本变更一并处置。
+   - manifest 持久化的 `computation.deps` 剥离了 match/modifier（签名用完整 deps、落盘用裁剪版）——signature 能检测变更，但审阅者在 diff 文件里看不到「哪个 match 变了」。建议落盘保留完整 deps。
+   - 重算阶段无 per-computation operation log（整包单事务）——大规模迁移失败需整段重跑，生产可恢复性差（非正确性问题）。
+2. **`RefContainer.replaceEntity/replaceRelation` 不 clone 传入实例**（与 `addEntity` 的 clone 语义不一致）——调用方后续 mutate 会污染容器内图。当前主路径多用 add，风险偏低，属 API 契约脆弱性。
+3. **Scheduler `computeDirtyDataDepRecords` 中间对称段 TODO**（L546，r17 复确项）——正确性由 `relatedAttribute.length>3 → fullRecompute` 兜底（r16-O-5），代价是重算风暴；建议与 storage 的路径变体展开对齐后移除兜底。
+4. **core 声明期守卫的低成本补洞**（core 探查产出）：`Property.create` 不校验 type 白名单（`'varchar'` 静默产出畸形 DDL、报错点远离声明点）；`Payload.create` 不查 items 重名；Activity `transfers` 无环检测（`A→B→C→A` 声明期接受，流程无「完成」语义——与 r9 的 goto 环检测形成对比）；Interaction 对 `event.user`/`user.id` 缺失无 fail-closed（残缺事件写入 `_Interaction_` 表，下游 StateMachine 按 user.id 匹配时静默不触发）。均为一两行守卫，建议随下一轮 createClass 统一校验（r16 建议 4）一并处置。
+5. **对称 n:n 的 link 级 API 不做端点归一化**（r4-I-17/r7-I-2 遗留复确，storage 探查再次命中）：`addLink(A,B)` 后 `addLink(B,A)` 产出两条物理行（Count 双计）；`removeRelation` 反向 endpoint 匹配不到（"删不掉"）。需产品决策（无向边唯一 → 归一化/fail-fast；否则文档强制固定方向）。
+6. **测试矩阵两个空白格**（storage 探查产出，防回归性价比最高）：`物理拓扑 × filtered entity` 交叉格（writePathTopologyMatrix 全文无 filtered）；`updateRelationByName ⟺ 宿主同 id + '&'` 的事件等价性对账（r17-F-2 的同族风险面，两种合法写法的事件契约无结构性断言）。
+7. **`Event`/`Gateway` 死 API 仍在公开导出面**（r12-I-8 复确）——建议 `@deprecated` 标注或移出主入口。
+
+---
+
+## 四、证伪/降级的候选（本轮探查结论被推翻的）
+
+| 候选 | 证伪证据 |
+|------|----------|
+| 「迁移 DDL 在 `db.scheme()` 成功与 operation log 写入之间崩溃 → `ADD COLUMN` 无 IF NOT EXISTS → resume 永久撞列已存在」（migration 探查 F-3，初判中置信致命） | resume 路径**每次重新生成 plan**（`Controller.migrate` → `prepareMigrationAdditive` → `createAdditiveSchemaPlan` 按 `getExistingColumns` 现查）——崩溃窗口内已加的列在重算 plan 时被识别为已存在、不再进 plan，operation log 只是同一次 plan 内的幂等加速。自愈，非致命 |
+| 「StateMachine 的 create trigger 挂 filtered 名也不触发」（F-1 的扩大化推断） | 复现实验证伪：成员资格 create/delete 事件本就以 filtered 名发出，create trigger 正常触发（`review-fixes-2026-07-11-r18.spec.ts` enter 用例同时固化了这一边界） |
+| 「MySQL 声明 ScopedSequence 要到运行期才失败」（core 探查 S-6） | `PropertyScopedSequenceHandle` 构造器（Controller 构造时）即检查 `db.atomicSequenceCapability`/`setupScopedSequenceState` 并抛明确错误——声明邻近期已 fail-fast，降级为文档补充项 |
+
+另有一项按建议**文档处置而非守卫**：ScopedSequence 的 `match` 谓词字段事后可变（记录后来才满足谓词不会补编号）——与 scope 不同，match 字段（如 kind 归档）与业务生命周期常有正当重叠，一刀切 fail-fast 会阻断合法操作；已在 `usage/04` 写明 create-time-stable 期望。
+
+---
+
+## 五、既有遗留项复确（r2–r17 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4-I-1）；update/create 返回值三态（r16-O-2/r17-R-4，F-2 修复时再次绕行）；`Custom.asyncReturn` 2 参（r5-I-15）；StateMachine 单事件单跳 + 宿主自更新回声匹配（r7-I-8 家族——本轮 enter 用例的 keys 限定即为规避回声；无 keys 的宿主 update trigger 会连状态机自己写回结果的事件也匹配，属既有语义，建议文档提示）；`func::` 信任边界、`ignoreGuard`（文档化）。
+- **性能/资源**：global dict 变更宿主全表扫描（S3）；async task 表只增不减（r2-I-6）；级联删除无深度上限（r2-I-5）；offset-only 全量拉取（r12-I-4）；EXIST 误触 post-pagination（r12-I-5）。
+- **并发**：`setDictionaryValue` find-then-write（r12-I-1）；lockRows 5 轮上限（r15-O-3）；Activity every 组 CAS 不自动重试（r16-O-7）。
+- **时间调度**：`nextRecomputeTime` 全链无消费方——RealTime 的时间驱动重算仍不存在（r3-R5）。
+- **驱动**：MySQL 无事务（文档化）；contains 四驱动语义矩阵（r12-I-6）；PGLite UUID id vs 其他 INT。
+
+---
+
+## 六、修复优先级与后续建议
+
+本轮四个致命项已全部修复。后续轮次建议：
+
+1. **矩阵补格**（第三节第 6 条）——`filtered × 拓扑` 与 `updateRelationByName 事件等价` 两格是 r17 复盘「维度回灌义务」的直接应用，成本低、防回归收益最高。
+2. **migration 审阅完整性三缺口**（第三节第 1 条）——defaultValueSignature 可与下一次 generator 版本变更合并处置，避免两次基线重建。
+3. **createClass 统一声明期校验**（r16 建议 4 + 本轮第三节第 4 条清单）——本轮的保留名/重复名守卫又新增了两处手写校验点，「public.constraints 元数据 → create 自动执行」的统一机制能一次性消化 Property.type 白名单、Payload 重名、Activity 环检测等积压项。
+4. **对称 link API 语义产品决策**（r4-I-17/r7-I-2，三轮复确）——建议下轮直接定谳。
+
+### 升级注意（behavior-tightening，供 CHANGELOG 参考）
+
+- **manifest generator 2 → 3**：既有 migration 基线需按错误信息指引重建（与 r14 确立的「不同代版本拒绝采信」政策一致）。
+- **新增声明期 fail-fast**：值/关系属性同名、`id`/`_rowId`/`source`/`target` 保留名、同记录重复属性名——此前被静默接受（并静默损坏）的声明现在 setup/create 期报错。
+- **新增运行期 fail-fast**：编号后的 ScopedSequence scope 输入变更被拒绝（此前静默重复编号）。
+- **行为激活**：filtered 名上的事件驱动 `update` 监听从死监听变为按成员资格语义触发——依赖「永不触发」旧行为的声明（不应存在）会开始收到事件。
+
+## 附录：复现要点（验证用）
+
+全部固化在 `tests/runtime/review-fixes-2026-07-11-r18.spec.ts` 与 `tests/storage/review-fixes-2026-07-11-r18.spec.ts`：
+
+- F-1：filtered 名 update trigger → 成员字段更新触发转移/派生；非成员不触发；enter 由成员资格 create 驱动不双跳。
+- F-2：trigger.keys / next 状态 / notEmpty / eventDep record 四形态签名可见；未变更模型签名稳定；函数文本-only 不动 structuralSignature。
+- F-3：三向命名空间冲突 setup fail-fast；无冲突对照组照常建表。
+- F-4：值型/ref 型 scope 变更 fail-fast；scope 保持可用（编号连续）；宿主删除不受影响。

--- a/agentspace/output/deep-review-2026-07-11-r18.md
+++ b/agentspace/output/deep-review-2026-07-11-r18.md
@@ -7,6 +7,12 @@
 - 方法：与 r1–r17 全部报告逐条去重；每个候选先做代码路径二次追踪，再以运行时复现定谳（本轮 1 项候选被复现证伪、1 项被架构追踪证伪，见第四节）。「已复现确认」才列为致命。
 - 修复状态：**四个致命项 + 两个重要项已在本分支（`cursor/deep-code-review-r18-7a3e`）全部修复**，回归固化于 `tests/runtime/review-fixes-2026-07-11-r18.spec.ts`（11 用例）与 `tests/storage/review-fixes-2026-07-11-r18.spec.ts`（9 用例）。修复后 `npm run check` 通过，`npm test` 全量通过（含新增回归）。
 
+> **维护说明（2026-07-11，结构层轮）**：F-1 的复盘（`agentspace/output/r18-test-blindness-retrospective.md`——为什么 17 轮 + 结构层没测出死监听）产出三项结构层改造，已在同分支落地：
+> - **事件命名空间统一**：视图名→物理名解析改以 storage 编译结果（`storage.schema.records.resolvedBaseRecordName`）为唯一事实源，替换 controller 实例图手工行走。首跑即消灭一个同族亲缘 bug——**merged input 视图（inputEntities/inputRelations）的 update 监听在两条轨道上都是死监听**（storage 编译期才转换 filtered 形态，实例图上看不到；实测 `Summation over input view` 永久陈旧、input 名上的 update trigger 永不触发）。
+> - **死监听不变量（订阅面守卫）**：`assertListenerReachable`——归一化后每个监听的 recordName 必须 ∈ storage 已知记录名（typo/dict 名误用/未注册实体 → setup 期受控错误，dict 场景给出 `_Dictionary_` + `record:{key}` 正确写法）；update 监听不得以视图名为键（防绕过归一化的未来生产者）；`addSourceMap(s)` 并入同一管线。顺带暴露并清除了历史上一直静默注册的死监听：relation 嵌套端点的虚拟 link（`${relation}_source/_target`）create/delete 监听（storage 从不以虚拟 link 名发事件，实测确认）。
+> - **登记册本体升级**：`WritingComputationTests.md` 新增两根机制轴（计算轨道、监听名形态）+「路由类修复必须枚举同一声明面全部读者」清单义务。
+> - 行为收紧：指向未知记录名的 dataDep/eventDep 从静默死监听变为 setup 期报错（`schedulerEdgeCases.spec.ts` 相应用例已翻转为断言 fail-fast）。回归 +5（structural 组），全量通过。
+
 ---
 
 ## 一、结论摘要

--- a/agentspace/output/r18-test-blindness-retrospective.md
+++ b/agentspace/output/r18-test-blindness-retrospective.md
@@ -1,0 +1,101 @@
+# 深度反思:为什么复杂的测试体系没有覆盖住「事件驱动计算的 filtered update 死监听」(r18 F-1)
+
+- 日期:2026-07-11
+- 关联:`deep-review-2026-07-11-r18.md`(问题发现与修复)、`r17-test-blindness-retrospective.md`(上一轮复盘)
+- 性质:测试体系的结构性复盘 + 本轮已落地的结构层改造记录。所有关键论断均有提交历史/代码原文考证。
+
+---
+
+## 〇、先给结论
+
+这个 bug 能穿过 1871 个用例和 r17 建立的结构层,不是因为测试"写少了",而是因为**测试体系的全部坐标系都建立在"数据形态"上,而这个 bug 生活在"机制形态"里**——同一个声明面(`recordName + type`)背后有两套消费机制(数据驱动轨 / 事件驱动轨),整个体系没有任何一根轴、任何一个预言机、任何一条断言是沿着"机制"这个维度铺设的。
+
+更尖锐的是:**通用规则早在 2026-07-09(r5 修复轮)就被完整写进了注释,修复却只落在了一条轨道上**——知识是全称的,执行是存在的,而没有任何机制检查两者的差距。
+
+---
+
+## 一、直接层面:那个格子恰好是空的
+
+| 格子 | 覆盖情况 |
+|------|----------|
+| filtered × **数据驱动** × update | ✅ r5-F-1 修复 + `aggregationConsistencyMatrix`(25 格) |
+| **base 名** × 事件驱动 × update | ✅ 大量 StateMachine/Transform 测试 |
+| filtered × 事件驱动 × **create** | ✅(碰巧健康:成员资格事件本就以 filtered 名发出) |
+| **filtered × 事件驱动 × update** | ❌ 零用例,零告警死监听 |
+
+最扎心的证据:`tests/runtime/stateMachineInitialValue.spec.ts` 的 filtered 用例中,**同一个夹具里同时出现了全部三种原料**(StateMachine、filtered entity、对 filtered entity 的 Count),但 trigger 写的是 base 名 `SMFilteredItem`——filtered 名只被数据驱动的 Count 消费。**离死格只差一个字符串**。
+
+为什么作者会写 base 名?因为该测试的目的是回归另一个 bug(初始值回填),作者是知道事件系统内幕的人,下意识写了"能工作"的形态。**实现者写的测试编码的是实现的 happy path,而不是文档读者的心智模型**——一个读了"filtered entity 用起来和普通 entity 一样"的用户会自然把 trigger 写在视图名上。这是测试作者的知识诅咒。
+
+## 二、修复考古:通用规则与局部修复的裂缝在同一天形成
+
+提交 `0f3dfb3e`(2026-07-09,r5-F-1 修复)当时的代码原文:
+
+```ts
+// 注释(全称命题):"…注册在 filtered 名上的 update 监听是死监听——…"
+private normalizeFilteredUpdateSourceMap(source) {
+    if (source.type !== 'update' || !('dataDep' in source)) return source   // ← 修复(存在命题)
+```
+
+三个机制叠加造成裂缝:
+
+1. **复现宇宙决定修复范围,修复范围决定验证范围——闭环自洽**。触发 r5-F-1 的是聚合 bug,复现矩阵全部是数据驱动计算;修复让矩阵变绿,验证闭环完成。没有任何流程要求问:「**这个事件命名空间还有谁在订阅?**」——答案在 `initialize()` 里肉眼可见(恰好两个生产者)。
+2. **类型边界塑造了修复边界**。`!('dataDep' in source)` 本质是 TS 类型收窄便利;修窄的路径在类型系统里顺滑,修全的要处理两个类型。类型边界不是语义边界,但它给修复范围导了流。事后类型定义留下铁证:`EntityUpdateEventsSourceMap` 有 `filteredRecordName` 字段和整段注释,`EventBasedEntityEventsSourceMap` 什么都没有——不对称写在类型里,没人做过双轨类型对称性审计。
+3. **同一天、相邻代码、相反假设**。同日提交 `28366353` 的 `validateTriggerKeys` 专门沿 baseEntity/baseRelation 链遍历收集合法属性名——说明"trigger.recordName 可以是 filtered 名"在校验层是被承认的用户模式;而路由层修复同日把事件驱动轨排除。两处代码对同一声明面持相反假设,无机制强迫对齐。
+
+## 三、为什么 r17 刚建的结构层也没接住
+
+F-1 完全符合 r17 已诊断的模式(盲区 3 交叉格空白 + 盲区 4 注释化假设),但每件设施都差半步:
+
+1. **维度登记册的坐标系继承了 storage 的本体论**。七根轴(关系类型/物理拓扑/逐项状态/载荷形态/操作/路径跳数/观察面)全部是**数据声明形态**;「计算轨道」「监听名形态」是**机制维度**,不在任何轴上。登记册从 storage 写路径 bug 归纳而来,每一份登记册都在为上一场战争建防线——"新维度必须回灌"条款是反应式的,维度积从未被先验枚举。
+2. **事件完备性预言机守的是"发射面",不是"路由面"**。F-1 场景下事件存在且正确(以 base 名发出),预言机绿灯;失效发生在订阅匹配——声明的监听器永远不可达。这是第四个观察面(**订阅面**),与 r17 论证事件面同构:「死监听」是否定形命题,逐点正向断言列不完,只能结构性检查。
+3. **假设审计的网眼是词法的**。r17 审计用 `rg "只可能|不可能"` 扫描;那条关键注释写的是「是死监听」——事实陈述,不含模态词,词法网捞不到。它最危险的地方恰恰是:不是"假设",是**已知事实 + 未完成的执行**。若当时升格为初始化后的不变量断言,哪怕零测试,第一个用户也会在 setup 期拿到受控错误。
+
+## 四、更深一层:这类 bug 的公共形状
+
+> **一个统一的声明面,多个分叉的消费机制,不变量只在其中一条分支上被执行。**
+
+用户看到的是一个语言:`{ recordName, type }`。框架内部有两条轨道读它(dataDeps 编译管线 / eventDeps 直通管线),外加 migration 的第三个读者(manifest 签名——r18-F-2「普通值参数零感知」是同一形状:运行时读 trigger 全部字段,签名器只读两个字段)。凡是"同一声明在不同读者那里语义分叉"的地方都是持续生产 bug 的机器:
+
+- 测试按**特性**组织,而 bug 住在**读者之间的差集**里;
+- 行覆盖率完全失明——两条轨道各自行覆盖都高,缺的是交互,交互不是行;
+- 修复的最小化美德(只动复现走过的路径)在这里成为缺陷:天然只修一个读者。
+
+最有杠杆的防线不是更多格子,而是**消灭分叉或在汇合点断言**。
+
+---
+
+## 五、本轮已落地的结构层改造
+
+### 5.1 事件命名空间统一(消灭分叉的事实源)
+
+`ComputationSourceMapManager.buildEventNamespace`:视图名→物理名的解析改以 **storage 编译结果**(`storage.schema.records` 的 `resolvedBaseRecordName`)为唯一事实源,替换原先"沿 controller 实例图行走 baseEntity/baseRelation 链"的手工重建。
+
+**立即收益(改造首跑抓出的同族亲缘 bug)**:merged input 视图(`inputEntities`/`inputRelations` 声明)是在 storage 编译期才转换成 filtered 形态的——controller 侧实例图看不到这层关系,手工行走把 input 视图当成物理记录,其 update 监听(**数据驱动与事件驱动两轨都**)全部是死监听:`Summation over input view` 对成员字段更新永久陈旧、input 名上的 StateMachine update trigger 永不触发(复现实测后由本改造直接消灭,回归见 `review-fixes-2026-07-11-r18.spec.ts` structural 组)。
+
+### 5.2 死监听不变量(订阅面守卫,setup 期结构性检查)
+
+`assertListenerReachable`,对**归一化后**的每一个监听:
+
+1. `recordName` 必须 ∈ storage 已知记录名——typo、把 global dict 名当 recordName、引用未注册进 Controller 的实体,全部从"永久静默陈旧"变为 setup 期受控错误(dict 场景的错误信息给出 `_Dictionary_` + `record: {key}` 的正确写法);
+2. 归一化后不允许任何 update 监听仍以视图名为键——normalize 是唯一合法入口,违反即框架内部缺陷,同样 fail-fast。
+
+`addSourceMap`/`addSourceMaps`(公开生产者 API)并入同一条归一化+校验管线,未来任何第三条轨道自动被覆盖。**这条不变量就是"订阅面预言机"——在 setup 期执行,比测试期更早、覆盖面是全部用户而不只是测试作者写到的格子。**
+
+**不变量首跑的精确性修正**:虚拟 link(relation 记录自身的 source/target 端点,`${relationName}_source/_target`)只存在于 map.links、storage 从不以其名发事件(实测确认)——历史代码给 relation 嵌套端点注册的 create/delete 监听一直是**静默注册的死监听**(端点变更实际由 relation 记录整体的 create/delete 表达,那两个监听由上层注册)。不变量把这处沉睡的死注册暴露出来,已改为只对可发射事件的真实 record 注册。
+
+**行为收紧**:指向未知记录名的 dataDep/eventDep 从静默死监听变为 setup 期报错(`schedulerEdgeCases.spec.ts` 的 NonExistentEntity 用例已从"容忍"翻转为"断言 fail-fast")。
+
+### 5.3 维度登记册本体升级
+
+`WritingComputationTests.md` 登记册新增两根**机制轴**(计算轨道、监听名形态)与「路由类修复必须枚举同一声明面的全部读者」的修复清单义务(见该文件)。
+
+## 六、有意不做(含理由)
+
+- **文档示例即测试(doc-tests)基建**:对冲实现者知识诅咒的正确方向,但属独立工程(示例抽取、执行环境、断言约定),不在本轮范围;先以"用户视角声明形态"补入回归(trigger 挂视图名、input 视图名)。
+- **对 create-only 记录上的 update 监听 fail-fast**:无法确凿证明所有此类记录永不 update(activity 记录就会 update),过度断言会误伤,不做。
+- **`validateTriggerKeys` 与订阅面守卫合并**:两者关注点不同(keys 语义 vs 可达性),保留分工;守卫在 source map 层对两轨统一执行,天然覆盖 Transform eventDeps(validateTriggerKeys 只覆盖 StateMachine)。
+
+## 七、一句话总结
+
+**r17 的结论是"坐标系里缺轴";r18 的补充是:轴不仅有数据形态的,还有机制形态的——同一声明面的每一个读者都是一根轴。而比补轴更强的防线,是把"全称命题的注释"升格为"汇合点的不变量":注释没有执行力,不变量有。**

--- a/src/core/Entity.ts
+++ b/src/core/Entity.ts
@@ -1,39 +1,12 @@
 import { IInstance, SerializedData, generateUUID } from './interfaces.js';
 import { stringifyInstance, decodeFunctionValues } from './utils.js';
 import { PropertyInstance } from './Property.js';
+import { validatePropertyNamesOnCreate } from './propertyNameGuards.js';
 import type { ComputationInstance } from './types.js';
 import type { RelationInstance } from './Relation.js';
 import type { ConstraintInstance } from './Constraint.js';
 
 const validNameFormatExp = /^[a-zA-Z0-9_]+$/;
-
-// 与 storage 的 ID_ATTR/ROW_ID_ATTR 对应（core 不能反向依赖 runtime/storage，故用字面量）。
-// relation 额外保留 'source'/'target'（端点虚拟链接属性）。
-export function validatePropertyNamesOnCreate(
-  ownerName: string | undefined,
-  properties: PropertyInstance[] | undefined,
-  kind: 'Entity' | 'Relation'
-) {
-  const reserved = kind === 'Relation' ? ['id', '_rowId', 'source', 'target'] : ['id', '_rowId'];
-  const seen = new Set<string>();
-  for (const property of (properties || [])) {
-    if (reserved.includes(property.name)) {
-      throw new Error(
-        `Property name "${property.name}" on ${kind.toLowerCase()} "${ownerName}" is reserved. ` +
-        (property.name === 'id' || property.name === '_rowId'
-          ? `The framework manages the "${property.name}" column and would silently overwrite your declaration (including any defaultValue/computation on it). Use a different name, e.g. "externalId".`
-          : `"source"/"target" are the relation's endpoint attributes. Use a different name for the relation property.`)
-      );
-    }
-    if (seen.has(property.name)) {
-      throw new Error(
-        `Duplicate property name "${property.name}" on ${kind.toLowerCase()} "${ownerName}". ` +
-        `Property names must be unique per record — duplicates silently keep only the last declaration while all their computations stay registered against one column.`
-      );
-    }
-    seen.add(property.name);
-  }
-}
 
 export interface EntityInstance extends IInstance {
   name: string;
@@ -178,10 +151,7 @@ export class Entity implements EntityInstance {
     if (args.baseEntity && args.inputEntities) {
       throw new Error(`Entity "${args.name}" declares both baseEntity (filtered entity) and inputEntities (merged entity). These are mutually exclusive declaration modes — to filter a merged entity, declare the merged entity first and create a separate filtered entity on top of it.`);
     }
-    // 保留名与重复名：'id'/'_rowId'（对应 storage 的 ID_ATTR/ROW_ID_ATTR）由框架管理，
-    // 用户声明的同名属性会在 schema 编译时被静默覆盖（含其 defaultValue/computation）；
-    // 重复属性名会静默保留最后一个而计算句柄全部注册。二者都是零告警损坏，声明期直接拒绝。
-    // storage 的 DBSetup.validatePropertyNames 是同一守卫的兜底（覆盖 create 之后 push 的属性）。
+    // 保留名（id/_rowId）与重复属性名守卫：见 propertyNameGuards.ts。
     validatePropertyNamesOnCreate(args.name, args.properties, 'Entity');
 
     const instance = new Entity(args, options);

--- a/src/core/Entity.ts
+++ b/src/core/Entity.ts
@@ -7,6 +7,34 @@ import type { ConstraintInstance } from './Constraint.js';
 
 const validNameFormatExp = /^[a-zA-Z0-9_]+$/;
 
+// 与 storage 的 ID_ATTR/ROW_ID_ATTR 对应（core 不能反向依赖 runtime/storage，故用字面量）。
+// relation 额外保留 'source'/'target'（端点虚拟链接属性）。
+export function validatePropertyNamesOnCreate(
+  ownerName: string | undefined,
+  properties: PropertyInstance[] | undefined,
+  kind: 'Entity' | 'Relation'
+) {
+  const reserved = kind === 'Relation' ? ['id', '_rowId', 'source', 'target'] : ['id', '_rowId'];
+  const seen = new Set<string>();
+  for (const property of (properties || [])) {
+    if (reserved.includes(property.name)) {
+      throw new Error(
+        `Property name "${property.name}" on ${kind.toLowerCase()} "${ownerName}" is reserved. ` +
+        (property.name === 'id' || property.name === '_rowId'
+          ? `The framework manages the "${property.name}" column and would silently overwrite your declaration (including any defaultValue/computation on it). Use a different name, e.g. "externalId".`
+          : `"source"/"target" are the relation's endpoint attributes. Use a different name for the relation property.`)
+      );
+    }
+    if (seen.has(property.name)) {
+      throw new Error(
+        `Duplicate property name "${property.name}" on ${kind.toLowerCase()} "${ownerName}". ` +
+        `Property names must be unique per record — duplicates silently keep only the last declaration while all their computations stay registered against one column.`
+      );
+    }
+    seen.add(property.name);
+  }
+}
+
 export interface EntityInstance extends IInstance {
   name: string;
   properties: PropertyInstance[];
@@ -150,6 +178,11 @@ export class Entity implements EntityInstance {
     if (args.baseEntity && args.inputEntities) {
       throw new Error(`Entity "${args.name}" declares both baseEntity (filtered entity) and inputEntities (merged entity). These are mutually exclusive declaration modes — to filter a merged entity, declare the merged entity first and create a separate filtered entity on top of it.`);
     }
+    // 保留名与重复名：'id'/'_rowId'（对应 storage 的 ID_ATTR/ROW_ID_ATTR）由框架管理，
+    // 用户声明的同名属性会在 schema 编译时被静默覆盖（含其 defaultValue/computation）；
+    // 重复属性名会静默保留最后一个而计算句柄全部注册。二者都是零告警损坏，声明期直接拒绝。
+    // storage 的 DBSetup.validatePropertyNames 是同一守卫的兜底（覆盖 create 之后 push 的属性）。
+    validatePropertyNamesOnCreate(args.name, args.properties, 'Entity');
 
     const instance = new Entity(args, options);
     

--- a/src/core/Relation.ts
+++ b/src/core/Relation.ts
@@ -1,7 +1,8 @@
 import { IInstance, SerializedData, generateUUID } from './interfaces.js';
 import { stringifyInstance, decodeFunctionValues } from './utils.js';
 import { PropertyInstance, Property } from './Property.js';
-import { EntityInstance, validatePropertyNamesOnCreate } from './Entity.js';
+import { EntityInstance } from './Entity.js';
+import { validatePropertyNamesOnCreate } from './propertyNameGuards.js';
 import type { ComputationInstance } from './types.js';
 import type { ConstraintInstance } from './Constraint.js';
 

--- a/src/core/Relation.ts
+++ b/src/core/Relation.ts
@@ -1,7 +1,7 @@
 import { IInstance, SerializedData, generateUUID } from './interfaces.js';
 import { stringifyInstance, decodeFunctionValues } from './utils.js';
 import { PropertyInstance, Property } from './Property.js';
-import { EntityInstance } from './Entity.js';
+import { EntityInstance, validatePropertyNamesOnCreate } from './Entity.js';
 import type { ComputationInstance } from './types.js';
 import type { ConstraintInstance } from './Constraint.js';
 
@@ -338,6 +338,8 @@ export class Relation implements RelationInstance {
     if (args.type !== undefined && !VALID_RELATION_TYPES.includes(args.type)) {
       throw new Error(`Relation type "${args.type}" is invalid. Valid types: ${VALID_RELATION_TYPES.map(t => `'${t}'`).join(', ')}.`);
     }
+    // 保留名（id/_rowId/source/target）与重复属性名：见 Entity.create 的同族守卫说明。
+    validatePropertyNamesOnCreate(args.name ?? `${args.source?.name}_${args.sourceProperty}_${args.targetProperty}_${args.target?.name}`, args.properties, 'Relation');
     const instance = new Relation(args, options);
     
     // 检查 uuid 是否重复

--- a/src/core/propertyNameGuards.ts
+++ b/src/core/propertyNameGuards.ts
@@ -1,0 +1,34 @@
+import type { PropertyInstance } from './Property.js';
+
+// 内部共享守卫（不进入公共导出面——index.ts 不 re-export 本文件）。
+// 保留名与 storage 的 ID_ATTR('id')/ROW_ID_ATTR('_rowId') 对应（core 不能反向依赖
+// runtime/storage，故用字面量）；relation 额外保留 'source'/'target'（端点虚拟链接属性）。
+// 用户声明的同名属性会在 schema 编译时被框架列静默覆盖（含 defaultValue/computation）；
+// 重复属性名会静默保留最后一个而计算句柄全部注册（争用一列）。二者都是零告警损坏，
+// 声明期直接拒绝。storage 的 DBSetup.validatePropertyNames 是同一守卫的兜底
+// （覆盖 create 之后 push 的属性、直接 new 构造等旁路）。
+export function validatePropertyNamesOnCreate(
+  ownerName: string | undefined,
+  properties: PropertyInstance[] | undefined,
+  kind: 'Entity' | 'Relation'
+) {
+  const reserved = kind === 'Relation' ? ['id', '_rowId', 'source', 'target'] : ['id', '_rowId'];
+  const seen = new Set<string>();
+  for (const property of (properties || [])) {
+    if (reserved.includes(property.name)) {
+      throw new Error(
+        `Property name "${property.name}" on ${kind.toLowerCase()} "${ownerName}" is reserved. ` +
+        (property.name === 'id' || property.name === '_rowId'
+          ? `The framework manages the "${property.name}" column and would silently overwrite your declaration (including any defaultValue/computation on it). Use a different name, e.g. "externalId".`
+          : `"source"/"target" are the relation's endpoint attributes. Use a different name for the relation property.`)
+      );
+    }
+    if (seen.has(property.name)) {
+      throw new Error(
+        `Duplicate property name "${property.name}" on ${kind.toLowerCase()} "${ownerName}". ` +
+        `Property names must be unique per record — duplicates silently keep only the last declaration while all their computations stay registered against one column.`
+      );
+    }
+    seen.add(property.name);
+  }
+}

--- a/src/runtime/ComputationSourceMap.ts
+++ b/src/runtime/ComputationSourceMap.ts
@@ -88,35 +88,52 @@ export type ComputationPhase = typeof PHASE_BEFORE_ALL|typeof PHASE_NORMAL|typeo
 export class ComputationSourceMapManager {
     private sourceMaps: EntityEventSourceMap[] = []
     private sourceMapTree: DataSourceMapTree = {}
-    // filtered entity/relation 名 -> 物理 base 记录名（穿透嵌套 filtered 链）
+    // 视图名（filtered entity/relation、merged input）-> 物理 base 记录名
     private filteredToPhysicalName: Map<string, string> = new Map()
+    // storage 可发射事件的全部记录名（事件的 recordName 恒 ∈ 此集合）
+    private knownRecordNames: Set<string> = new Set()
 
     constructor(public controller: Controller, public scheduler: Scheduler) {
         
     }
 
-    private buildFilteredToPhysicalNameMap(): void {
+    /**
+     * 事件命名空间以 storage 编译结果（storage.schema.records）为唯一事实源。
+     *
+     * CAUTION 不能用「沿 controller.entities 的 baseEntity/baseRelation 链行走」重建这张表：
+     *  merged input 视图（inputEntities/inputRelations 声明）是在 storage 编译期才被转换成
+     *  filtered 形态的，controller 侧的实例图上看不到这层关系——手工行走会把 input 视图
+     *  当成物理记录，其 update 监听（数据驱动与事件驱动两轨）全部注册成死监听（r18）。
+     *  storage 的 resolvedBaseRecordName 覆盖全部视图形态：filtered 链、嵌套 filtered、
+     *  merged input、filtered-over-merged-input。
+     */
+    private buildEventNamespace(): void {
+        const schemaRecords = this.controller.system.storage.schema?.records
+        if (!schemaRecords?.length) {
+            throw new ComputationProtocolError(
+                'ComputationSourceMapManager.initialize was called before storage setup populated the schema. ' +
+                'The mutation-event namespace (record names, view resolution) comes from the compiled storage schema — ' +
+                'initialize the system storage first.',
+                { computationPhase: 'source-map-initialization' }
+            )
+        }
         this.filteredToPhysicalName = new Map()
-        const all: any[] = [...this.controller.entities, ...this.controller.relations]
-        for (const item of all) {
-            if (!item?.name) continue
-            let cur: any = item
-            while (cur.baseEntity || cur.baseRelation) {
-                cur = cur.baseEntity || cur.baseRelation
-            }
-            if (cur !== item && cur?.name) {
-                this.filteredToPhysicalName.set(item.name, cur.name)
+        this.knownRecordNames = new Set()
+        for (const record of schemaRecords) {
+            this.knownRecordNames.add(record.recordName)
+            if (record.resolvedBaseRecordName && record.resolvedBaseRecordName !== record.recordName) {
+                this.filteredToPhysicalName.set(record.recordName, record.resolvedBaseRecordName)
             }
         }
     }
 
     /**
-     * CAUTION filtered entity/relation 名下只有成员资格 create/delete 事件；
-     *  字段 update 事件永远以物理 base 记录名发出。注册在 filtered 名上的 update
+     * CAUTION 视图名（filtered entity/relation、merged input）下只有成员资格 create/delete
+     *  事件；字段 update 事件永远以物理 base 记录名发出。注册在视图名上的 update
      *  监听是死监听——成员字段更新会静默丢失（数据驱动计算聚合值永久陈旧、
      *  事件驱动计算的 StateMachine trigger / Transform eventDep 永不触发）。
-     *  这里把 update 监听改挂到物理名上，并记录原 filtered 名，Scheduler 路由时
-     *  按 filteredRecordName 做成员资格守卫并把事件名改写回 filtered 名。
+     *  这里把 update 监听改挂到物理名上，并记录原视图名，Scheduler 路由时
+     *  按 filteredRecordName 做成员资格守卫并把事件名改写回视图名。
      *  数据驱动（dataDep）与事件驱动（eventDep）两条轨道必须同构处理。
      */
     private normalizeFilteredUpdateSourceMap(source: EntityEventSourceMap): EntityEventSourceMap {
@@ -130,12 +147,60 @@ export class ComputationSourceMapManager {
         } as EntityEventSourceMap
     }
 
+    private describeComputation(computation: Computation): string {
+        const dataContext = computation.dataContext as { type: string, host?: { name?: string }, id: { name?: string } | string }
+        const idName = typeof dataContext.id === 'object' ? dataContext.id.name : String(dataContext.id)
+        const target = dataContext.type === 'property' ? `${dataContext.host?.name}.${idName}` : idName
+        return `${computation.args.constructor.displayName || computation.constructor.name} computation of ${dataContext.type} "${target}"`
+    }
+
+    /**
+     * 死监听不变量（订阅面守卫）：每一个注册进 source map 的监听都必须可被 storage
+     * 实际发射的事件命中。两条规则：
+     *  1. recordName 必须是 storage 已知的记录名——未知名（typo、把 global dict 名当
+     *     recordName、引用未注册进 Controller 的实体）意味着监听永远不会触发，计算
+     *     永久静默陈旧，声明期直接拒绝；
+     *  2. 归一化之后不允许任何 update 监听仍以视图名为键——normalize 是唯一合法入口，
+     *     该规则被违反说明有生产者绕过了归一化（框架内部缺陷，同样 fail-fast 而不是
+     *     留下静默死监听）。
+     * 这条不变量的存在理由见 r18 复盘：F-1（filtered update 死监听）的通用规则在 r5 就
+     * 被写进了注释，但只在数据驱动轨道上被执行——注释没有执行力，不变量有。
+     */
+    private assertListenerReachable(source: EntityEventSourceMap): void {
+        if (!this.knownRecordNames.has(source.recordName)) {
+            const dictHint = this.controller.dict.some(dictItem => dictItem.name === source.recordName)
+                ? ` "${source.recordName}" is a global dictionary: dictionary changes are emitted as events on the "${DICTIONARY_RECORD}" record — declare { recordName: '${DICTIONARY_RECORD}', type: 'update', record: { key: '${source.recordName}' } } instead.`
+                : ` Check for a typo, and make sure the entity/relation is registered on the Controller.`
+            throw new ComputationProtocolError(
+                `${this.describeComputation(source.computation)} listens to ${source.type} events of record "${source.recordName}", ` +
+                `but no such record exists in the storage schema — this listener can never fire and the computation would stay silently stale.` +
+                dictHint,
+                {
+                    handleName: source.computation.constructor.name,
+                    dataContext: source.computation.dataContext,
+                    computationPhase: 'source-map-initialization'
+                }
+            )
+        }
+        if (source.type === 'update' && this.filteredToPhysicalName.has(source.recordName)) {
+            throw new ComputationProtocolError(
+                `Internal invariant violated: an update listener of ${this.describeComputation(source.computation)} is still keyed under the view name "${source.recordName}" after normalization. ` +
+                `Views (filtered entities/relations, merged inputs) never emit field update events — every producer of source maps must route through normalizeFilteredUpdateSourceMap. This is a framework bug; please report it.`,
+                {
+                    handleName: source.computation.constructor.name,
+                    dataContext: source.computation.dataContext,
+                    computationPhase: 'source-map-initialization'
+                }
+            )
+        }
+    }
+
     /**
      * 初始化或重新初始化 SourceMap 数据
      * @param sourceMaps EntityEventSourceMap 数组
      */
     initialize(computations: Set<Computation>): void {
-        this.buildFilteredToPhysicalNameMap()
+        this.buildEventNamespace()
         const sortedERMutationEventSources: EntityEventSourceMap[][] = [[], [], []]
 
         
@@ -222,27 +287,27 @@ export class ComputationSourceMapManager {
             }
         }
 
-        // const ERMutationEventSources: EntityEventSourceMap[]= sortedERMutationEventSources.flat()
-
         this.sourceMaps = sortedERMutationEventSources.flat().map(source => this.normalizeFilteredUpdateSourceMap(source))
+        this.sourceMaps.forEach(source => this.assertListenerReachable(source))
         this.sourceMapTree = this.buildDataSourceMapTree(this.sourceMaps)
     }
     /**
-     * 添加新的 SourceMap
-     * @param sourceMap 要添加的 EntityEventSourceMap
+     * 添加新的 SourceMap。
+     * CAUTION 与 initialize 走同一条归一化 + 可达性校验管线：任何生产者都不允许绕过
+     *  normalizeFilteredUpdateSourceMap 直接入树（视图名 update 监听会成为静默死监听）。
      */
     addSourceMap(sourceMap: EntityEventSourceMap): void {
-        this.sourceMaps.push(sourceMap)
-        this.addToTree(sourceMap)
+        const normalized = this.normalizeFilteredUpdateSourceMap(sourceMap)
+        this.assertListenerReachable(normalized)
+        this.sourceMaps.push(normalized)
+        this.addToTree(normalized)
     }
 
     /**
-     * 批量添加 SourceMap
-     * @param sourceMaps 要添加的 EntityEventSourceMap 数组
+     * 批量添加 SourceMap（逐条走 addSourceMap 的归一化 + 校验管线）
      */
     addSourceMaps(sourceMaps: EntityEventSourceMap[]): void {
-        this.sourceMaps.push(...sourceMaps)
-        sourceMaps.forEach(sourceMap => this.addToTree(sourceMap))
+        sourceMaps.forEach(sourceMap => this.addSourceMap(sourceMap))
     }
 
     /**
@@ -561,23 +626,31 @@ export class ComputationSourceMapManager {
         if (context.at(-1) !== '&') {
             // 1. 先监听"关联实体关系"的 create/delete
             const realtionRecordName = this.controller.system.storage.getRelationName(baseRecordName, context.join('.'))
-            ERMutationEventsSource.push({
-                dataDep,
-                type: 'create',
-                recordName: realtionRecordName,
-                sourceRecordName: baseRecordName,
-                isRelation: true,
-                targetPath: context,
-                computation
-            }, {
-                dataDep,
-                type: 'delete',
-                recordName: realtionRecordName,
-                sourceRecordName: baseRecordName,
-                isRelation: true,
-                targetPath: context,
-                computation
-            })
+            // CAUTION 虚拟 link（relation 记录自身的 source/target 端点，isSourceRelation）
+            //  只存在于 map.links、不是 record，storage 从不以它的名字发射事件——注册在
+            //  虚拟 link 名上的 create/delete 是死监听。端点的建立/解除只能经由 relation
+            //  记录整体的 create/delete 表达，而那两个监听已由 records dataDep 在上层注册。
+            //  这里只为真实 relation record（可发射事件）注册监听；嵌套端点实体的字段
+            //  update 监听（下方步骤 2）不受影响。
+            if (this.knownRecordNames.has(realtionRecordName)) {
+                ERMutationEventsSource.push({
+                    dataDep,
+                    type: 'create',
+                    recordName: realtionRecordName,
+                    sourceRecordName: baseRecordName,
+                    isRelation: true,
+                    targetPath: context,
+                    computation
+                }, {
+                    dataDep,
+                    type: 'delete',
+                    recordName: realtionRecordName,
+                    sourceRecordName: baseRecordName,
+                    isRelation: true,
+                    targetPath: context,
+                    computation
+                })
+            }
         }
         // 2. 监听关联实体的属性 update
         if (subAttrs.length > 0) {

--- a/src/runtime/ComputationSourceMap.ts
+++ b/src/runtime/ComputationSourceMap.ts
@@ -56,6 +56,10 @@ export type DataBasedEntityEventsSourceMap = EntityCreateEventsSourceMap
 
 export type EventBasedEntityEventsSourceMap = EventDep & {
     computation: Computation,
+    // 与 EntityUpdateEventsSourceMap.filteredRecordName 同义：eventDep 监听 filtered
+    // entity/relation 名的 update 事件时，监听注册到物理 base 名上，此字段记录原 filtered 名，
+    // Scheduler 路由时做成员资格守卫并把事件名改写回 filtered 名。
+    filteredRecordName?: string
 }
 
 export type EntityEventSourceMap = DataBasedEntityEventsSourceMap | EventBasedEntityEventsSourceMap
@@ -109,20 +113,21 @@ export class ComputationSourceMapManager {
     /**
      * CAUTION filtered entity/relation 名下只有成员资格 create/delete 事件；
      *  字段 update 事件永远以物理 base 记录名发出。注册在 filtered 名上的 update
-     *  监听是死监听——成员字段更新会静默丢失（聚合值永久陈旧）。
+     *  监听是死监听——成员字段更新会静默丢失（数据驱动计算聚合值永久陈旧、
+     *  事件驱动计算的 StateMachine trigger / Transform eventDep 永不触发）。
      *  这里把 update 监听改挂到物理名上，并记录原 filtered 名，Scheduler 路由时
      *  按 filteredRecordName 做成员资格守卫并把事件名改写回 filtered 名。
+     *  数据驱动（dataDep）与事件驱动（eventDep）两条轨道必须同构处理。
      */
     private normalizeFilteredUpdateSourceMap(source: EntityEventSourceMap): EntityEventSourceMap {
-        if (source.type !== 'update' || !('dataDep' in source)) return source
-        const updateSource = source as EntityUpdateEventsSourceMap
-        const physicalName = this.filteredToPhysicalName.get(updateSource.recordName)
+        if (source.type !== 'update') return source
+        const physicalName = this.filteredToPhysicalName.get(source.recordName)
         if (!physicalName) return source
         return {
-            ...updateSource,
+            ...source,
             recordName: physicalName,
-            filteredRecordName: updateSource.recordName,
-        }
+            filteredRecordName: source.recordName,
+        } as EntityEventSourceMap
     }
 
     /**

--- a/src/runtime/Controller.ts
+++ b/src/runtime/Controller.ts
@@ -572,7 +572,10 @@ export class Controller {
             return this.system.storage.find(dataContext.id.name!, undefined, undefined, ['*'])
         } else {
             const propertyDataContext = dataContext as PropertyDataContext
-            if (record![propertyDataContext.id.name]) return record![propertyDataContext.id.name]
+            // CAUTION 按"键是否存在"判断，不能按真值：0/false/'' 是合法的计算值，
+            //  真值判断会把它们误判为缺失而绕去查库——多数时候只是浪费一次查询，
+            //  但当 record 快照比库里更新时会拿到错误的 lastValue。
+            if (record![propertyDataContext.id.name] !== undefined) return record![propertyDataContext.id.name]
 
             const item = await this.system.storage.findOne(propertyDataContext.host.name!, BoolExp.atom({key: 'id', value: ['=', record!.id]}), undefined, ['*'])
             return item[propertyDataContext.id.name]

--- a/src/runtime/Scheduler.ts
+++ b/src/runtime/Scheduler.ts
@@ -412,6 +412,104 @@ export class Scheduler {
     }
     erMutationEventSources: EntityEventSourceMap[] = []
     dataSourceMapTree: DataSourceMapTree = {}
+    // ScopedSequence 的 scope 输入不可变守卫（见 buildScopedSequenceScopeGuards）。
+    private scopedSequenceScopeGuards: Array<{
+        hostName: string,
+        propertyName: string,
+        sequenceName: string,
+        valueFields: string[],
+        // 关系属性名 -> 该关系的 record name（link delete 事件按此路由）
+        refRelations: Map<string, { relationName: string, hostIsSource: boolean }>
+    }> = []
+    /**
+     * ScopedSequence 的序号在创建时按 scope 一次性分配（getInitialValue），scope 是号码的
+     * 身份组成部分。事后修改 scope 输入字段（值字段更新 / scope 关系解除或替换）不会重新编号，
+     * 会静默产出「同一 scope 内重复号码」；配合文档推荐的 UniqueConstraint 时，目标 scope 的
+     * 后续 create 会永久撞唯一约束（计数器随事务回滚，无法自愈）。
+     * 声明式语义下 scope 输入是 create-time stable 字段——这里在 mutation 监听层 fail-fast，
+     * 把静默数据损坏转为受控错误。未编号记录（match 未命中，序号列为 null）不受限制。
+     */
+    private buildScopedSequenceScopeGuards() {
+        this.scopedSequenceScopeGuards = []
+        for (const computation of this.computationsHandles.values()) {
+            const args = computation.args as { scope?: Array<{ name: string, type: string, path: string }>, name?: string } & IInstance
+            if ((args as { _type?: string })._type !== 'ScopedSequence') continue
+            if (computation.dataContext.type !== 'property') continue
+            const dataContext = computation.dataContext as PropertyDataContext
+            const hostName = dataContext.host.name!
+            const valueFields: string[] = []
+            const refRelations = new Map<string, { relationName: string, hostIsSource: boolean }>()
+            for (const item of (args.scope || [])) {
+                const topField = item.path.split('.')[0]
+                if (item.type === 'ref') {
+                    const relation = this.controller.relations.find(r =>
+                        (r.source?.name === hostName && r.sourceProperty === topField) ||
+                        (r.target?.name === hostName && r.targetProperty === topField)
+                    )
+                    if (relation) {
+                        refRelations.set(topField, {
+                            relationName: relation.name!,
+                            hostIsSource: relation.source?.name === hostName && relation.sourceProperty === topField
+                        })
+                    } else {
+                        // ref scope 也可能以行内 id 值字段实现（如 type:'id' 的普通属性），按值字段守卫。
+                        valueFields.push(topField)
+                    }
+                } else {
+                    valueFields.push(topField)
+                }
+            }
+            this.scopedSequenceScopeGuards.push({
+                hostName,
+                propertyName: dataContext.id.name,
+                sequenceName: args.name!,
+                valueFields,
+                refRelations
+            })
+        }
+    }
+    private async assertScopedSequenceScopeUnchanged(mutationEvent: RecordMutationEvent) {
+        for (const guard of this.scopedSequenceScopeGuards) {
+            // 1. 值字段：宿主 update 事件中 scope 字段实际变化，且记录已编号 → 拒绝。
+            if (mutationEvent.type === 'update' && mutationEvent.recordName === guard.hostName) {
+                const changed = guard.valueFields.filter(field =>
+                    mutationEvent.record?.hasOwnProperty(field) &&
+                    mutationEvent.record[field] !== mutationEvent.oldRecord?.[field]
+                )
+                if (changed.length && mutationEvent.oldRecord?.[guard.propertyName] != null) {
+                    throw new ComputationProtocolError(
+                        `ScopedSequence "${guard.sequenceName}": scope field${changed.length > 1 ? 's' : ''} ${changed.map(f => `"${f}"`).join(', ')} of ${guard.hostName}.${guard.propertyName} cannot change after a sequence number is assigned. ` +
+                        `Sequence numbers are allocated once at creation per scope; moving a numbered record to another scope silently duplicates numbers there (and permanently violates a unique constraint over scope+number, if declared). ` +
+                        `Delete and recreate the record in the new scope, or model the mutable dimension outside the sequence scope.`,
+                        { handleName: 'ScopedSequence', computationPhase: 'scope-immutability-guard' }
+                    )
+                }
+            }
+            // 2. ref 字段：scope 关系的 delete 事件（解除或替换），宿主仍存在且已编号 → 拒绝。
+            //    宿主整体删除的级联 unlink 不受影响（届时宿主行已不存在）。
+            if (mutationEvent.type === 'delete') {
+                for (const [field, refInfo] of guard.refRelations) {
+                    if (mutationEvent.recordName !== refInfo.relationName) continue
+                    const hostId = (mutationEvent.record as { source?: { id?: unknown }, target?: { id?: unknown } } | undefined)?.[refInfo.hostIsSource ? 'source' : 'target']?.id
+                    if (hostId === undefined) continue
+                    const host = await this.controller.system.storage.findOne(
+                        guard.hostName,
+                        MatchExp.atom({ key: 'id', value: ['=', hostId] }),
+                        undefined,
+                        ['id', guard.propertyName]
+                    )
+                    if (host && host[guard.propertyName] != null) {
+                        throw new ComputationProtocolError(
+                            `ScopedSequence "${guard.sequenceName}": scope relation "${field}" of ${guard.hostName}.${guard.propertyName} cannot be removed or replaced after a sequence number is assigned. ` +
+                            `Sequence numbers are allocated once at creation per scope; re-scoping a numbered record silently duplicates numbers in the target scope (and permanently violates a unique constraint over scope+number, if declared). ` +
+                            `Delete and recreate the record in the new scope, or model the mutable dimension outside the sequence scope.`,
+                            { handleName: 'ScopedSequence', computationPhase: 'scope-immutability-guard' }
+                        )
+                    }
+                }
+            }
+        }
+    }
     // CAUTION 计算传播的重入守卫。计算的写回（applyResult/applyResultPatch）会在同一事务内
     //  立即重入 mutation listener，触发下游计算——这是反应式语义的主干。但循环依赖的声明
     //  （互相派生的 Transform、dataDeps 引用自身输出的 dict 等）会让这条链永不收敛：
@@ -424,6 +522,7 @@ export class Scheduler {
     private buildComputationMutationListener(): RecordMutationCallback {
         this.sourceMapManager.initialize(new Set(this.computationsHandles.values()))
         this.dataSourceMapTree = this.sourceMapManager.getSourceMapTree()
+        this.buildScopedSequenceScopeGuards()
 
         return (async (mutationEvents) => {
             const parent = this.propagationContext.getStore()
@@ -440,6 +539,7 @@ export class Scheduler {
             const trail = parent?.trail ?? []
             await this.propagationContext.run({ depth, trail }, async () => {
                 for(let mutationEvent of mutationEvents){
+                    await this.assertScopedSequenceScopeUnchanged(mutationEvent)
                     const sources = this.sourceMapManager.findSourceMapsForMutation(mutationEvent)
                     if (sources.length > 0) {
                         for(const source of sources) {
@@ -469,13 +569,16 @@ export class Scheduler {
      * filtered entity/relation 源上的 update 事件路由守卫。
      *
      * 背景：storage 的字段 update 事件只以物理 base 记录名发出；filtered 名下只有
-     * 成员资格 create/delete 事件。为了让「成员留在集合内的字段更新」也能触发聚合，
-     * source map 把 filtered 源的 update 监听注册到物理名上（携带 filteredRecordName）。
-     * 这里补上语义守卫，保证与成员资格事件不重复计算：
+     * 成员资格 create/delete 事件。为了让「成员留在集合内的字段更新」也能触发计算，
+     * source map 把 filtered 源的 update 监听注册到物理名上（携带 filteredRecordName）——
+     * 数据驱动（dataDep）与事件驱动（StateMachine trigger / Transform eventDep）两条轨道
+     * 都经过这一守卫。这里补上语义守卫，保证与成员资格事件不重复计算：
      *  1. 同一事件批次里已有该记录在该 filtered 源上的成员资格 create/delete
      *     （enter/exit 场景）→ 跳过，由成员资格事件驱动计算；
      *  2. 否则查询当前成员资格：仍是成员 → 以 filtered 名改写事件后放行（stay-in 更新）；
      *     不是成员 → 跳过（无关记录的字段更新）。
+     * 事件驱动计算收到的是改写后（filtered 名）的事件，与 trigger/eventDep 声明的
+     * recordName 一致，TransitionFinder / callback 的模式匹配才能命中。
      *
      * 带 targetPath 的（property/关联路径）监听不需要此守卫：computeDirtyDataDepRecords
      * 与各 handle 的增量分支都通过 filtered 路径查询定位记录，成员资格由查询本身保证。
@@ -488,10 +591,10 @@ export class Scheduler {
         mutationEvent: RecordMutationEvent,
         batchEvents: RecordMutationEvent[]
     ): Promise<RecordMutationEvent | null> {
-        if (!('dataDep' in source) || source.type !== 'update') return mutationEvent
-        const filteredRecordName = (source as EntityUpdateEventsSourceMap).filteredRecordName
+        if (source.type !== 'update') return mutationEvent
+        const filteredRecordName = (source as { filteredRecordName?: string }).filteredRecordName
         if (!filteredRecordName) return mutationEvent
-        if (source.targetPath?.length) return mutationEvent
+        if ('dataDep' in source && (source as EntityUpdateEventsSourceMap).targetPath?.length) return mutationEvent
 
         const recordId = mutationEvent.record?.id ?? mutationEvent.oldRecord?.id
         if (recordId === undefined) return null

--- a/src/runtime/migration.ts
+++ b/src/runtime/migration.ts
@@ -14,8 +14,11 @@ import { matchesScopedSequenceRecord, scopedSequenceMatchAttributeQuery, scopedS
 export const MIGRATION_MANIFEST_CONCEPT = "_MigrationManifest_";
 export const MIGRATION_MANIFEST_CURRENT_KEY = "current";
 // Generator "1" did not collect StateNode.computeValue / StateTransfer.computeTarget
-// into computation function signatures. Bump when signature collection semantics change.
-const MIGRATION_MANIFEST_GENERATOR_VERSION = "2";
+// into computation function signatures. Generator "2" did not collect plain-value args
+// (StateMachine trigger patterns/state-graph topology, Every.notEmpty, Transform eventDep
+// record patterns, ...) into structural signatures (argsSignature).
+// Bump when signature collection semantics change.
+const MIGRATION_MANIFEST_GENERATOR_VERSION = "3";
 const HARD_DELETION_PROPERTY_NAME = "_isDeleted_";
 
 export class MigrationError extends Error {
@@ -366,6 +369,7 @@ export type ComputationManifest = {
     outputSignature: string;
     stateSignature: string;
     structuralSignature: string;
+    argsSignature: string;
     functionSignature?: ComputationFunctionSignature;
     allocation?: {
         kind: "scoped-sequence";
@@ -799,6 +803,50 @@ function createFunctionSignature(args: Record<string, unknown>, includeText = fa
     };
 }
 
+// 实例级字段：逐进程随机（uuid）或纯注册用途，进签名会让未变更的模型被误判为变更。
+const INSTANCE_ONLY_ARG_FIELDS = new Set(["uuid", "_type", "_options"]);
+
+/**
+ * 计算语义的"普通值参数"规范化（argsSignature 的输入）。
+ *
+ * functionSignature 覆盖了回调函数体、deps/eventDeps 覆盖了数据/事件依赖的
+ * recordName/type/attributeQuery，但除此之外的普通值参数此前不进入任何签名：
+ * StateMachine 的 trigger.keys / trigger.record 模式与状态图拓扑（current/next）、
+ * Every 的 notEmpty、Transform eventDeps 的 record 模式、Count 的 direction 等。
+ * 改这些参数会改变存量数据的语义，而迁移零感知——静默放行是对「审阅即契约」的破坏。
+ *
+ * 规范化规则：
+ *  - 函数 → 位置标记 `[Function]`（不含文本哈希！函数文本由 functionSignature 单独覆盖，
+ *    进入 signature 而不进入 structuralSignature——函数文本变更必须走 "possibly-changed"/
+ *    state-only 分类，混入这里会把 createState 等状态函数的文本变化误判为结构变更）；
+ *  - 模型引用（Entity/Relation/Property/Dictionary）→ `[<type>:<name>]`：身份已由
+ *    deps/dataContext 覆盖，深入遍历会把整个模型图卷进来（含循环）；
+ *  - 其他 klass 实例（StateNode/StateTransfer/BoolExp 节点等）→ 遍历其自有语义字段；
+ *  - uuid/_type/_options 一律剔除（uuid 逐进程随机）；
+ *  - 对象键排序 + 循环守卫，保证跨进程稳定。
+ */
+function canonicalizeArgsForSignature(value: unknown, seen = new WeakSet<object>()): unknown {
+    if (typeof value === "function") return "[Function]";
+    if (value === null || typeof value !== "object") return value;
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    if (Array.isArray(value)) return value.map(item => canonicalizeArgsForSignature(item, seen));
+    const record = value as Record<string, unknown>;
+    if (typeof record._type === "string" && MODEL_REFERENCE_TYPES.includes(record._type)) {
+        return `[${record._type}:${(record as { name?: unknown }).name ?? ""}]`;
+    }
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(record).sort()) {
+        if (INSTANCE_ONLY_ARG_FIELDS.has(key)) continue;
+        output[key] = canonicalizeArgsForSignature(record[key], seen);
+    }
+    return output;
+}
+
+function createArgsSignature(args: Record<string, unknown>): string {
+    return hash(canonicalizeArgsForSignature(args));
+}
+
 function createComputationManifest(computation: Computation, includeFunctionText = false): ComputationManifest {
     const args = computation.args as Record<string, unknown>;
     const deps = serializeDataDeps(computation as Partial<DataBasedComputation>);
@@ -811,6 +859,7 @@ function createComputationManifest(computation: Computation, includeFunctionText
     const type = computationSemanticType(computation);
     const identity = createIdentity("computation", id, computation.args.uuid);
     const functionSignature = createFunctionSignature(args, includeFunctionText);
+    const argsSignature = createArgsSignature(args);
     const { allocation, scopeSignature, allocationSignature } = createScopedSequenceSignatures(args);
     const outputSignature = hash({
         type,
@@ -831,6 +880,9 @@ function createComputationManifest(computation: Computation, includeFunctionText
         deps,
         eventDeps,
         allocationSignature,
+        // 普通值参数（trigger 模式、状态图拓扑、notEmpty、direction 等）的规范化签名，
+        // 见 canonicalizeArgsForSignature。缺失时改这些参数迁移零感知（存量数据静默陈旧）。
+        argsSignature,
         callbackPaths: functionSignature?.callbackPaths || [],
         hasFunction: functionSignature?.hasFunction === true,
         hasCompute: typeof (computation as DataBasedComputation).compute === "function",
@@ -862,6 +914,7 @@ function createComputationManifest(computation: Computation, includeFunctionText
         outputSignature,
         stateSignature,
         structuralSignature,
+        argsSignature,
         functionSignature,
         allocation,
         allocationSignature,

--- a/src/storage/erstorage/Setup.ts
+++ b/src/storage/erstorage/Setup.ts
@@ -623,6 +623,75 @@ export class DBSetup {
                 }
             })
         })
+
+        // 值属性 vs 关系属性命名空间冲突：关系属性最终登记进端点 record 的属性表
+        // （populateRecordAttributes 无条件覆盖同名键）。若端点实体（或其 base 家族任一成员，
+        //  filtered 变体与 base 共享同一属性命名空间）已声明同名值属性，该值属性会被静默吞掉——
+        //  写入时标量值被当作关联记录展开（数据损坏），查询走关系语义，声明形同虚设。一律 fail-fast。
+        const familyValueProps = new Map<string, Map<string, string>>()
+        const registerValueProps = (item: EntityInstance | RelationInstance) => {
+            const rootName = this.resolveEndpointRootName(item)
+            let props = familyValueProps.get(rootName)
+            if (!props) familyValueProps.set(rootName, props = new Map())
+            for (const property of (item.properties || [])) {
+                if (!props.has(property.name)) props.set(property.name, item.name!)
+            }
+        }
+        this.entities.forEach(registerValueProps)
+        this.relations.forEach(registerValueProps)
+        const assertNoValuePropertyCollision = (endpoint: EntityInstance | RelationInstance, prop: string | undefined) => {
+            if (!prop) return
+            const declarer = familyValueProps.get(this.resolveEndpointRootName(endpoint))?.get(prop)
+            if (declarer) {
+                throw new Error(
+                    `Relation property name conflict: relation property '${prop}' on '${endpoint.name}' collides with the value property ` +
+                    `'${prop}' declared on '${declarer}'. Relation attributes and value properties share one attribute namespace per record — ` +
+                    `the relation would silently overwrite the value property (scalar writes get expanded as related-record payloads, corrupting data). ` +
+                    `Rename the relation's sourceProperty/targetProperty or the value property.`
+                )
+            }
+        }
+        this.relations.forEach(relation => {
+            assertNoValuePropertyCollision(relation.source, relation.sourceProperty)
+            assertNoValuePropertyCollision(relation.target, relation.targetProperty)
+        })
+    }
+
+    /**
+     * 保留属性名与重复属性名守卫。
+     *
+     * - ID_ATTR('id')/ROW_ID_ATTR('_rowId') 由框架管理：createRecord 会无条件写入框架主键，
+     *   用户声明的同名属性（含 defaultValue/computation）会被静默覆盖，声明形同虚设。
+     * - relation 的 'source'/'target' 是端点虚拟链接属性（populateRecordAttributes 写入），
+     *   用户值属性会被静默覆盖。
+     * - 重复属性名在 Object.fromEntries 中静默保留最后一个，先声明的属性（及其 computation）
+     *   从属性表消失，但仍会注册计算句柄——两个计算争用一列。
+     * 以上全部是零告警的 schema 损坏，必须在 setup 期 fail-fast。
+     */
+    private validatePropertyNames() {
+        const validate = (item: EntityInstance | RelationInstance, isRelation: boolean) => {
+            const reserved = new Set(isRelation ? [ID_ATTR, ROW_ID_ATTR, 'source', 'target'] : [ID_ATTR, ROW_ID_ATTR])
+            const seen = new Set<string>()
+            for (const property of (item.properties || [])) {
+                if (reserved.has(property.name)) {
+                    throw new Error(
+                        `Property name '${property.name}' on ${isRelation ? 'relation' : 'entity'} '${item.name}' is reserved: ` +
+                        (property.name === ID_ATTR || property.name === ROW_ID_ATTR
+                            ? `the framework manages the '${property.name}' column and would silently overwrite your declaration (including any defaultValue/computation on it). Use a different name, e.g. 'externalId'.`
+                            : `'source'/'target' are the relation's endpoint attributes. Use a different name for the relation property.`)
+                    )
+                }
+                if (seen.has(property.name)) {
+                    throw new Error(
+                        `Duplicate property name '${property.name}' on ${isRelation ? 'relation' : 'entity'} '${item.name}'. ` +
+                        `Property names must be unique per record — duplicates silently keep only the last declaration while all their computations stay registered against one column.`
+                    )
+                }
+                seen.add(property.name)
+            }
+        }
+        this.entities.forEach(entity => validate(entity, false))
+        this.relations.forEach(relation => validate(relation, true))
     }
 
     /**
@@ -827,6 +896,9 @@ export class DBSetup {
     buildMap() {
         // -1. 校验所有 entity/relation 的 name（name 会直接进入 SQL，必须先于一切处理）
         this.validateRecordNames();
+
+        // -0.5. 校验保留属性名（id/_rowId/source/target）与重复属性名
+        this.validatePropertyNames();
 
         // 0. 预处理：将 merged entity 和 merged relation 转化为 filtered entity/relation
         this.processMergedItems();

--- a/tests/core/entity-refactored.spec.ts
+++ b/tests/core/entity-refactored.spec.ts
@@ -148,7 +148,7 @@ describe("Entity System Refactored - compatibility test", () => {
     });
 
     test("should clone entity", () => {
-      const prop = Property.create({ name: "id", type: PropertyTypes.Number });
+      const prop = Property.create({ name: "sku", type: PropertyTypes.Number });
       const original = Entity.create({
         name: "Product",
         properties: [prop]

--- a/tests/core/entity-system.spec.ts
+++ b/tests/core/entity-system.spec.ts
@@ -103,7 +103,7 @@ describe("Entity System - createClass functionality", () => {
     });
 
     test("should clone entity", () => {
-      const prop = Property.create({ name: "id", type: PropertyTypes.Number });
+      const prop = Property.create({ name: "sku", type: PropertyTypes.Number });
       const original = Entity.create({
         name: "Product",
         properties: [prop]

--- a/tests/core/entityRelation.spec.ts
+++ b/tests/core/entityRelation.spec.ts
@@ -399,11 +399,13 @@ describe('Relation.public constraint and computed functions', () => {
         });
         expect(Relation.public.properties.constraints.eachNameUnique(relUnique)).toBe(true);
 
-        const relDup = Relation.create({
+        // r18 起 Relation.create 在声明期直接拒绝重复属性名（此前仅 public.constraints 元数据
+        // 声明了约束但从未执行，重复名静默保留最后一个）。
+        expect(() => Relation.create({
             source: s, sourceProperty: 'cys2', target: t, targetProperty: 'cx2', type: '1:n',
             properties: [p1, p3],
-        });
-        expect(Relation.public.properties.constraints.eachNameUnique(relDup)).toBe(false);
+        })).toThrowError(/Duplicate property name "a"/);
+        expect(Relation.public.properties.constraints.eachNameUnique({ properties: [p1, p3] } as any)).toBe(false);
     });
 
     test('inputRelations.constraints.mergedRelationNoProperties rejects properties on merged', () => {

--- a/tests/core/refcontainer.spec.ts
+++ b/tests/core/refcontainer.spec.ts
@@ -8,7 +8,8 @@ describe('RefContainer', () => {
     return Entity.create({
       name,
       properties: [
-        Property.create({ name: 'id', type: 'string' }),
+        // 'id' 是保留属性名（框架主键，声明期 fail-fast），测试用 'code' 代替
+        Property.create({ name: 'code', type: 'string' }),
         Property.create({ name: 'value', type: 'string' })
       ]
     });
@@ -400,7 +401,7 @@ describe('RefContainer', () => {
       const entity1 = Entity.create({
         name: 'Entity1',
         properties: [
-          Property.create({ name: 'id', type: 'string' }),
+          Property.create({ name: 'code', type: 'string' }),
           Property.create({ name: 'name', type: 'string' }),
           Property.create({ name: 'value', type: 'number' })
         ]
@@ -411,7 +412,7 @@ describe('RefContainer', () => {
       const newEntity = Entity.create({
         name: 'NewEntity',
         properties: [
-          Property.create({ name: 'id', type: 'string' }),
+          Property.create({ name: 'code', type: 'string' }),
           Property.create({ name: 'title', type: 'string' })
         ]
       });
@@ -421,7 +422,7 @@ describe('RefContainer', () => {
       const result = container.getAll();
       
       expect(result.entities[0].properties).toHaveLength(2);
-      expect(result.entities[0].properties[0].name).toBe('id');
+      expect(result.entities[0].properties[0].name).toBe('code');
       expect(result.entities[0].properties[1].name).toBe('title');
     });
   });

--- a/tests/runtime/WritingComputationTests.md
+++ b/tests/runtime/WritingComputationTests.md
@@ -286,6 +286,16 @@ test('should handle negative values correctly', async () => {
 | 操作 | create / update-replace / **update 原地（同 id）** / **抢夺（引用已被占用的排他目标）** / delete 实体 / addRelation / removeRelation | r6-F3、r17 F-1 |
 | 路径跳数 | 1 跳 / **2 跳（含连续对称段）** / 3 跳 | r17 F-4 |
 | 观察面 | 查询面 / **事件面（用 tests/storage/helpers/eventCompleteness.ts 的预言机）** / 计算面（与朴素重算对照） / 不变量面（无悬挂端点、x:1 排他唯一） | r17 F-2 |
+| 计算轨道（机制轴） | 数据驱动（dataDeps）/ **事件驱动（StateMachine trigger / Transform eventDeps）** / **migration 签名（第三个读者：同一声明在 manifest 里是否可见）** | r18 F-1、r18 F-2 |
+| 监听名形态（机制轴） | 物理 base 名 / **filtered entity/relation 名** / **merged input 视图名** / 嵌套 filtered 链 | r18 F-1、r18 merged-input 亲缘 bug |
+
+**机制轴说明（r18 复盘引入）**：前七根轴描述"声明的数据形状"，后两根描述"同一声明被哪个机制消费"。
+同一个声明面（如 trigger/eventDep 的 `recordName + type`）的**每一个读者都是一根轴**——bug 住在读者之间的
+差集里，按特性组织的测试与行覆盖率对此都失明。**路由/订阅类修复的强制清单**：修复某一读者的路由缺陷时，
+必须枚举同一声明面的全部读者（数据驱动轨、事件驱动轨、migration 签名、`addSourceMap` 等扩展点）并逐一验证；
+能在汇合点收口（共用同一条归一化/校验管线）的优先于逐读者修补。setup 期的死监听不变量
+（`ComputationSourceMapManager.assertListenerReachable`）是订阅面的结构性守卫——新增事件生产者/消费者时
+它会自动拒绝不可达监听，测试矩阵无需为"监听可达性"逐格铺点。
 
 配套设施：
 - `tests/storage/helpers/eventCompleteness.ts` — 事件完备性预言机（数据 diff ⟺ 事件流）、

--- a/tests/runtime/data/activity/index.ts
+++ b/tests/runtime/data/activity/index.ts
@@ -345,11 +345,10 @@ export function createData() {
                 collection: false,
                 computation: resultStateMachine
             }),
-            Property.create({
-                name: 'message',
-                type: 'string',
-                collection: false,
-            }),
+            // r18 起值属性与关系属性共享命名空间的冲突会在声明期 fail-fast：
+            // 此前这里声明的标量 message(string) 被 messageToRequestRelation 的
+            // sourceProperty 'message' 静默覆盖（死声明），Transform 写入的
+            // payload.message 实际走关系语义创建 Message 记录。删除死声明，保留关系。
             Property.create({
                 name: 'activityId',
                 type: 'string',

--- a/tests/runtime/review-fixes-2026-07-11-r18.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-11-r18.spec.ts
@@ -1,0 +1,404 @@
+import { describe, expect, test } from "vitest";
+import {
+    Controller, MonoSystem, Entity, Property, Relation, MatchExp,
+    StateMachine, StateNode, StateTransfer, Transform, Every, Dictionary,
+    ScopedSequence, UniqueConstraint, InteractionEventEntity
+} from 'interaqt';
+import { PGLiteDB } from '@drivers';
+import { createMigrationManifest } from '../../src/runtime/migration.js';
+
+// 第十八轮深度 review 的修复回归（见 agentspace/output/deep-review-2026-07-11-r18.md）。
+//
+// F-1 事件驱动计算（StateMachine trigger / Transform eventDeps）监听 filtered
+//     entity/relation 名的 update 事件：storage 只以物理 base 名发字段 update 事件，
+//     此前该监听是死监听（转移/派生永不触发、零告警）。修复：ComputationSourceMap
+//     把事件驱动的 filtered update 监听与数据驱动同构地挂到物理名上，Scheduler
+//     路由时做成员资格守卫并把事件名改写回 filtered 名。
+// F-2 migration manifest 对"普通值参数"全盲：trigger.keys / trigger.record 模式、
+//     StateMachine 状态图拓扑（next 状态）、Every.notEmpty、Transform eventDeps 的
+//     record 模式等都不进入签名——改这些参数迁移零感知，存量数据带旧语义静默放行。
+//     修复：argsSignature（规范化普通值参数）进入 structuralSignature，
+//     manifest generator 版本 2 → 3。
+// F-4 ScopedSequence 的 scope 输入字段在编号后被修改：序号不重分配，目标 scope 出现
+//     重复号码；配合文档推荐的 UniqueConstraint(scope+number) 时目标 scope 的后续
+//     create 永久撞唯一约束（计数器随事务回滚，不可自愈）。修复：scope 输入不可变
+//     守卫（值字段 update / scope 关系 delete 均 fail-fast；未编号记录不受限）。
+
+describe('r18 F-1: filtered update listeners for event-based computations', () => {
+    test('StateMachine transfer with update trigger on filtered entity name fires on member field update', async () => {
+        const active = StateNode.create({ name: "active" });
+        const done = StateNode.create({ name: "done" });
+        const sm = StateMachine.create({
+            states: [active, done],
+            initialState: active,
+            transfers: [StateTransfer.create({
+                trigger: { recordName: 'R18ActiveTicket', type: 'update', keys: ['title'] },
+                current: active,
+                next: done,
+                computeTarget: (e: any) => ({ id: e.record.id }),
+            })],
+        });
+        const Ticket = Entity.create({
+            name: 'R18Ticket',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' }),
+                Property.create({ name: 'phase', type: 'string', computation: sm }),
+            ],
+        });
+        const ActiveTicket = Entity.create({
+            name: 'R18ActiveTicket',
+            baseEntity: Ticket,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }),
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Ticket, ActiveTicket], relations: [], eventSources: [] });
+        await controller.setup(true);
+
+        const read = async (id: unknown) => system.storage.findOne('R18Ticket', MatchExp.atom({ key: 'id', value: ['=', id] }), undefined, ['*']);
+
+        // 成员记录的字段更新 → 触发转移
+        const member = await system.storage.create('R18Ticket', { title: 'a', isActive: true });
+        expect((await read(member.id)).phase).toBe('active');
+        await system.storage.update('R18Ticket', MatchExp.atom({ key: 'id', value: ['=', member.id] }), { title: 'b' });
+        expect((await read(member.id)).phase).toBe('done');
+
+        // 非成员记录的字段更新 → 成员资格守卫拦截，不触发
+        const outsider = await system.storage.create('R18Ticket', { title: 'x', isActive: false });
+        await system.storage.update('R18Ticket', MatchExp.atom({ key: 'id', value: ['=', outsider.id] }), { title: 'y' });
+        expect((await read(outsider.id)).phase).toBe('active');
+        await system.destroy();
+    });
+
+    test('Transform with eventDeps update on filtered entity name derives on member field update only', async () => {
+        const Ticket = Entity.create({
+            name: 'R18TTicket',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' }),
+            ],
+        });
+        const ActiveTicket = Entity.create({
+            name: 'R18TActiveTicket',
+            baseEntity: Ticket,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }),
+        });
+        const AuditLog = Entity.create({
+            name: 'R18AuditLog',
+            properties: [Property.create({ name: 'note', type: 'string' })],
+            computation: Transform.create({
+                eventDeps: {
+                    activeUpdated: { recordName: 'R18TActiveTicket', type: 'update' },
+                },
+                callback: function (event: any) {
+                    // 改写后的事件必须以 filtered 名到达 callback
+                    return { note: `${event.recordName}:${event.record?.id}` };
+                },
+            }),
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Ticket, ActiveTicket, AuditLog], relations: [], eventSources: [] });
+        await controller.setup(true);
+
+        const member = await system.storage.create('R18TTicket', { title: 'a', isActive: true });
+        const outsider = await system.storage.create('R18TTicket', { title: 'x', isActive: false });
+        await system.storage.update('R18TTicket', MatchExp.atom({ key: 'id', value: ['=', member.id] }), { title: 'b' });
+        await system.storage.update('R18TTicket', MatchExp.atom({ key: 'id', value: ['=', outsider.id] }), { title: 'y' });
+
+        const logs = await system.storage.find('R18AuditLog', undefined, undefined, ['*']);
+        expect(logs.length).toBe(1);
+        expect(logs[0].note).toBe(`R18TActiveTicket:${member.id}`);
+        await system.destroy();
+    });
+
+    test('update that ENTERS the filtered set is driven by the membership create event, not double-fired', async () => {
+        const idle = StateNode.create({ name: "idle" });
+        const entered = StateNode.create({ name: "entered" });
+        const updatedInSet = StateNode.create({ name: "updatedInSet" });
+        const sm = StateMachine.create({
+            states: [idle, entered, updatedInSet],
+            initialState: idle,
+            transfers: [
+                StateTransfer.create({
+                    trigger: { recordName: 'R18EnterActive', type: 'create' },
+                    current: idle,
+                    next: entered,
+                    computeTarget: (e: any) => ({ id: e.record.id }),
+                }),
+                StateTransfer.create({
+                    // keys 限定 label：不带 keys 的 update trigger 会连状态机自身写 phase 的
+                    // 回声事件也匹配（宿主自更新回声是既有语义，与 filtered 路由无关）。
+                    trigger: { recordName: 'R18EnterActive', type: 'update', keys: ['label'] },
+                    current: entered,
+                    next: updatedInSet,
+                    computeTarget: (e: any) => ({ id: e.record.id }),
+                }),
+            ],
+        });
+        const Item = Entity.create({
+            name: 'R18EnterItem',
+            properties: [
+                Property.create({ name: 'label', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' }),
+                Property.create({ name: 'phase', type: 'string', computation: sm }),
+            ],
+        });
+        const Active = Entity.create({
+            name: 'R18EnterActive',
+            baseEntity: Item,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }),
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Item, Active], relations: [], eventSources: [] });
+        await controller.setup(true);
+        const read = async (id: unknown) => system.storage.findOne('R18EnterItem', MatchExp.atom({ key: 'id', value: ['=', id] }), undefined, ['*']);
+
+        // 进入集合的 update：只由成员资格 create 事件驱动（idle→entered），update 监听不重复触发
+        const item = await system.storage.create('R18EnterItem', { label: 'a', isActive: false });
+        await system.storage.update('R18EnterItem', MatchExp.atom({ key: 'id', value: ['=', item.id] }), { isActive: true });
+        expect((await read(item.id)).phase).toBe('entered');
+
+        // 集合内的后续字段更新走 update 监听（entered→updatedInSet）
+        await system.storage.update('R18EnterItem', MatchExp.atom({ key: 'id', value: ['=', item.id] }), { label: 'b' });
+        expect((await read(item.id)).phase).toBe('updatedInSet');
+        await system.destroy();
+    });
+});
+
+describe('r18 F-2: migration manifest captures plain-value args (argsSignature)', () => {
+    function buildStateMachineController(opts: { keys: string[], nextName: string }) {
+        const open = StateNode.create({ name: "open" });
+        const next = StateNode.create({ name: opts.nextName });
+        const sm = StateMachine.create({
+            states: [open, next],
+            initialState: open,
+            transfers: [StateTransfer.create({
+                trigger: { recordName: 'R18MTicket', type: 'update', keys: opts.keys },
+                current: open,
+                next,
+                computeTarget: (e: any) => ({ id: e.record.id }),
+            })],
+        });
+        const Ticket = Entity.create({
+            name: 'R18MTicket',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'priority', type: 'number' }),
+                Property.create({ name: 'status', type: 'string', computation: sm }),
+            ],
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Ticket], relations: [], eventSources: [] });
+        return { controller, system };
+    }
+
+    async function signatureOf(build: () => { controller: Controller, system: MonoSystem }, pick: (c: any) => boolean) {
+        const { controller, system } = build();
+        const manifest = createMigrationManifest(controller);
+        const computation = manifest.computations.find(pick)!;
+        await system.destroy();
+        return computation.signature;
+    }
+
+    test('StateMachine trigger.keys change is visible in the signature', async () => {
+        const s1 = await signatureOf(() => buildStateMachineController({ keys: ['title'], nextName: 'closed' }), c => c.outputProperty === 'status');
+        const s2 = await signatureOf(() => buildStateMachineController({ keys: ['priority'], nextName: 'closed' }), c => c.outputProperty === 'status');
+        expect(s1).not.toBe(s2);
+    });
+
+    test('StateMachine transfer next-state (state-graph topology) change is visible in the signature', async () => {
+        const s1 = await signatureOf(() => buildStateMachineController({ keys: ['title'], nextName: 'closed' }), c => c.outputProperty === 'status');
+        const s2 = await signatureOf(() => buildStateMachineController({ keys: ['title'], nextName: 'archived' }), c => c.outputProperty === 'status');
+        expect(s1).not.toBe(s2);
+    });
+
+    test('unchanged model keeps a stable signature across processes (uuid must not leak in)', async () => {
+        const s1 = await signatureOf(() => buildStateMachineController({ keys: ['title'], nextName: 'closed' }), c => c.outputProperty === 'status');
+        const s2 = await signatureOf(() => buildStateMachineController({ keys: ['title'], nextName: 'closed' }), c => c.outputProperty === 'status');
+        expect(s1).toBe(s2);
+    });
+
+    function buildEveryController(notEmpty: boolean) {
+        const Item = Entity.create({
+            name: 'R18EItem',
+            properties: [Property.create({ name: 'ok', type: 'boolean' })],
+        });
+        const dict = [Dictionary.create({
+            name: 'r18AllOk',
+            type: 'boolean',
+            collection: false,
+            computation: Every.create({
+                record: Item,
+                attributeQuery: ['ok'],
+                notEmpty,
+                callback: (item: any) => !!item.ok,
+            }),
+        })];
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Item], relations: [], eventSources: [], dict });
+        return { controller, system };
+    }
+
+    test('Every.notEmpty change is visible in the signature', async () => {
+        const s1 = await signatureOf(() => buildEveryController(false), c => c.dataContext.includes('r18AllOk'));
+        const s2 = await signatureOf(() => buildEveryController(true), c => c.dataContext.includes('r18AllOk'));
+        expect(s1).not.toBe(s2);
+    });
+
+    function buildTransformController(interactionName: string) {
+        const Log = Entity.create({
+            name: 'R18TLog',
+            properties: [Property.create({ name: 'note', type: 'string' })],
+            computation: Transform.create({
+                eventDeps: {
+                    interactionCreated: {
+                        recordName: InteractionEventEntity.name,
+                        type: 'create',
+                        record: { interactionName },
+                    },
+                },
+                callback: (event: any) => ({ note: event.record?.interactionName }),
+            }),
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Log], relations: [], eventSources: [] });
+        return { controller, system };
+    }
+
+    test('Transform eventDeps record-pattern change is visible in the signature', async () => {
+        const s1 = await signatureOf(() => buildTransformController('CreatePost'), c => c.outputRecord === 'R18TLog');
+        const s2 = await signatureOf(() => buildTransformController('DeletePost'), c => c.outputRecord === 'R18TLog');
+        expect(s1).not.toBe(s2);
+    });
+
+    test('function-text-only change stays out of structuralSignature (state-only classification preserved)', async () => {
+        // createState 文本变化只应影响 stateSignature/functionSignature，不应把
+        // structuralSignature 也改掉（否则 state-only 迁移被误判为结构变更）。
+        const build = (variant: 1 | 2) => {
+            const Item = Entity.create({
+                name: 'R18FnItem',
+                properties: [Property.create({ name: 'ok', type: 'boolean' })],
+            });
+            // 两个字面量不同的函数体（闭包变量不改变函数文本，必须是不同的源码）
+            const callback = variant === 1
+                ? (item: any) => !!item.ok
+                : (item: any) => item.ok === true;
+            const dict = [Dictionary.create({
+                name: 'r18FnAllOk',
+                type: 'boolean',
+                collection: false,
+                computation: Every.create({
+                    record: Item,
+                    attributeQuery: ['ok'],
+                    callback,
+                }),
+            })];
+            const system = new MonoSystem(new PGLiteDB());
+            const controller = new Controller({ system, entities: [Item], relations: [], eventSources: [], dict });
+            return { controller, system };
+        };
+        const v1 = build(1);
+        const v2 = build(2);
+        const c1 = createMigrationManifest(v1.controller).computations.find(c => c.dataContext.includes('r18FnAllOk'))!;
+        const c2 = createMigrationManifest(v2.controller).computations.find(c => c.dataContext.includes('r18FnAllOk'))!;
+        await v1.system.destroy();
+        await v2.system.destroy();
+        expect(c1.structuralSignature).toBe(c2.structuralSignature);
+        expect(c1.functionSignature?.hash).not.toBe(c2.functionSignature?.hash);
+        expect(c1.signature).not.toBe(c2.signature);
+    });
+});
+
+describe('r18 F-4: ScopedSequence scope inputs are immutable after numbering', () => {
+    test('value-scope field change on a numbered record fails fast; scope stays usable', async () => {
+        const Task = Entity.create({
+            name: 'R18SeqTask',
+            properties: [
+                Property.create({ name: 'project', type: 'string' }),
+                Property.create({
+                    name: 'seq',
+                    type: 'number',
+                    computation: ScopedSequence.create({
+                        name: 'R18SeqTaskSeq',
+                        scope: [{ name: 'project', type: 'string', path: 'project' }],
+                    }),
+                }),
+            ],
+            constraints: [
+                UniqueConstraint.create({ name: 'uniqProjectSeq', properties: ['project', 'seq'] }),
+            ],
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Task], relations: [], eventSources: [] });
+        await controller.setup(true);
+        const read = async (id: unknown) => system.storage.findOne('R18SeqTask', MatchExp.atom({ key: 'id', value: ['=', id] }), undefined, ['*']);
+
+        const a1 = await system.storage.create('R18SeqTask', { project: 'A' });
+        const a2 = await system.storage.create('R18SeqTask', { project: 'A' });
+        await system.storage.create('R18SeqTask', { project: 'B' });
+
+        // 修复前：a2 带着 seq=2 静默进入 B（B 的计数器仍是 1）→ B 的下一次 create 永久撞
+        // uniqProjectSeq 唯一约束（计数器随事务回滚）。修复后：scope 变更 fail-fast。
+        await expect(
+            system.storage.update('R18SeqTask', MatchExp.atom({ key: 'id', value: ['=', a2.id] }), { project: 'B' })
+        ).rejects.toThrowError(/scope field.*"project".*cannot change after a sequence number is assigned/s);
+
+        expect((await read(a2.id)).project).toBe('A');
+        const b2 = await system.storage.create('R18SeqTask', { project: 'B' });
+        expect((await read(b2.id)).seq).toBe(2);
+
+        // 非 scope 字段照常可更新（守卫只看 scope 输入的实际变化）
+        await system.storage.update('R18SeqTask', MatchExp.atom({ key: 'id', value: ['=', a1.id] }), { project: 'A' });
+        await system.destroy();
+    });
+
+    test('ref-scope relation replacement fails fast; record deletion is unaffected', async () => {
+        const Project = Entity.create({
+            name: 'R18RefProject',
+            properties: [Property.create({ name: 'name', type: 'string' })],
+        });
+        const Media = Entity.create({
+            name: 'R18RefMedia',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({
+                    name: 'serial',
+                    type: 'number',
+                    computation: ScopedSequence.create({
+                        name: 'R18RefMediaSerial',
+                        scope: [{ name: 'project', type: 'ref', base: Project, path: 'project' }],
+                    }),
+                }),
+            ],
+        });
+        const rel = Relation.create({
+            source: Media,
+            sourceProperty: 'project',
+            target: Project,
+            targetProperty: 'medias',
+            type: 'n:1',
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Project, Media], relations: [rel], eventSources: [] });
+        await controller.setup(true);
+        const read = async (id: unknown) => system.storage.findOne('R18RefMedia', MatchExp.atom({ key: 'id', value: ['=', id] }), undefined, ['*']);
+
+        const p1 = await system.storage.create('R18RefProject', { name: 'p1' });
+        const p2 = await system.storage.create('R18RefProject', { name: 'p2' });
+        const m1 = await system.storage.create('R18RefMedia', { title: 'm1', project: { id: p1.id } });
+        expect((await read(m1.id)).serial).toBe(1);
+
+        await expect(
+            system.storage.update('R18RefMedia', MatchExp.atom({ key: 'id', value: ['=', m1.id] }), { project: { id: p2.id } })
+        ).rejects.toThrowError(/scope relation "project".*cannot be removed or replaced/s);
+        expect((await read(m1.id)).serial).toBe(1);
+
+        // 宿主删除（级联解除 scope 关系）不受守卫影响
+        await system.storage.delete('R18RefMedia', MatchExp.atom({ key: 'id', value: ['=', m1.id] }));
+        expect(await read(m1.id)).toBeUndefined();
+
+        const m2 = await system.storage.create('R18RefMedia', { title: 'm2', project: { id: p1.id } });
+        expect((await read(m2.id)).serial).toBe(2);
+        await system.destroy();
+    });
+});

--- a/tests/runtime/review-fixes-2026-07-11-r18.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-11-r18.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
     Controller, MonoSystem, Entity, Property, Relation, MatchExp,
-    StateMachine, StateNode, StateTransfer, Transform, Every, Dictionary,
+    StateMachine, StateNode, StateTransfer, Transform, Every, Count, Summation, Dictionary,
     ScopedSequence, UniqueConstraint, InteractionEventEntity
 } from 'interaqt';
 import { PGLiteDB } from '@drivers';
@@ -306,6 +306,177 @@ describe('r18 F-2: migration manifest captures plain-value args (argsSignature)'
         expect(c1.structuralSignature).toBe(c2.structuralSignature);
         expect(c1.functionSignature?.hash).not.toBe(c2.functionSignature?.hash);
         expect(c1.signature).not.toBe(c2.signature);
+    });
+});
+
+// r18 结构层（复盘产物，见 agentspace/output/r18-test-blindness-retrospective.md）：
+// - 事件命名空间统一：视图名→物理名的解析改以 storage 编译结果（storage.schema.records 的
+//   resolvedBaseRecordName）为唯一事实源。此前沿 controller 实例图行走 baseEntity/baseRelation
+//   链的实现看不到 merged input 视图（inputEntities 在 storage 编译期才转换为 filtered 形态），
+//   input 视图上的 update 监听（数据驱动与事件驱动两轨）全部是死监听——F-1 的同族亲缘 bug，
+//   由本轮结构层改造直接消灭。
+// - 死监听不变量（订阅面守卫）：每个注册进 source map 的监听的 recordName 必须是 storage
+//   已知记录名（typo/未注册实体/误把 dict 名当 recordName → setup 期 fail-fast 而不是永久
+//   静默陈旧）；归一化后不允许任何 update 监听仍以视图名为键（防未来生产者绕过归一化）。
+describe('r18 structural: unified event namespace + dead-listener invariant', () => {
+    test('data-based aggregation over a merged INPUT view reacts to member field updates', async () => {
+        const Car = Entity.create({
+            name: 'R18MICar',
+            properties: [Property.create({ name: 'speed', type: 'number' })],
+        });
+        const Truck = Entity.create({
+            name: 'R18MITruck',
+            properties: [Property.create({ name: 'load', type: 'number' })],
+        });
+        const Vehicle = Entity.create({ name: 'R18MIVehicle', inputEntities: [Car, Truck] });
+        const dict = [Dictionary.create({
+            name: 'r18MITotalSpeed',
+            type: 'number',
+            collection: false,
+            computation: Summation.create({ record: Car, attributeQuery: ['speed'] }),
+        })];
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Vehicle, Car, Truck], relations: [], eventSources: [], dict });
+        await controller.setup(true);
+
+        const car = await system.storage.create('R18MICar', { speed: 10 });
+        expect(await system.storage.dict.get('r18MITotalSpeed')).toBe(10);
+        await system.storage.update('R18MICar', MatchExp.atom({ key: 'id', value: ['=', car.id] }), { speed: 25 });
+        expect(await system.storage.dict.get('r18MITotalSpeed')).toBe(25);
+        await system.destroy();
+    });
+
+    test('StateMachine update trigger on a merged INPUT view name fires on member field update', async () => {
+        const idle = StateNode.create({ name: 'idle' });
+        const touched = StateNode.create({ name: 'touched' });
+        const sm = StateMachine.create({
+            states: [idle, touched],
+            initialState: idle,
+            transfers: [StateTransfer.create({
+                trigger: { recordName: 'R18MI2Car', type: 'update', keys: ['speed'] },
+                current: idle,
+                next: touched,
+                computeTarget: (e: any) => ({ id: e.record.id }),
+            })],
+        });
+        const Car = Entity.create({
+            name: 'R18MI2Car',
+            properties: [
+                Property.create({ name: 'speed', type: 'number' }),
+                Property.create({ name: 'phase', type: 'string', computation: sm }),
+            ],
+        });
+        const Truck = Entity.create({
+            name: 'R18MI2Truck',
+            properties: [Property.create({ name: 'load', type: 'number' })],
+        });
+        const Vehicle = Entity.create({ name: 'R18MI2Vehicle', inputEntities: [Car, Truck] });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Vehicle, Car, Truck], relations: [], eventSources: [] });
+        await controller.setup(true);
+
+        const car = await system.storage.create('R18MI2Car', { speed: 10 });
+        await system.storage.update('R18MI2Car', MatchExp.atom({ key: 'id', value: ['=', car.id] }), { speed: 25 });
+        const after = await system.storage.findOne('R18MI2Car', MatchExp.atom({ key: 'id', value: ['=', car.id] }), undefined, ['*']);
+        expect(after.phase).toBe('touched');
+        await system.destroy();
+    });
+
+    test('a typo in trigger.recordName fails fast at setup instead of staying a silent dead listener', async () => {
+        const open = StateNode.create({ name: 'open' });
+        const closed = StateNode.create({ name: 'closed' });
+        const sm = StateMachine.create({
+            states: [open, closed],
+            initialState: open,
+            transfers: [StateTransfer.create({
+                trigger: { recordName: 'R18TypoTickett', type: 'update' },   // typo!
+                current: open,
+                next: closed,
+                computeTarget: (e: any) => ({ id: e.record.id }),
+            })],
+        });
+        const Ticket = Entity.create({
+            name: 'R18TypoTicket',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'status', type: 'string', computation: sm }),
+            ],
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Ticket], relations: [], eventSources: [] });
+        await expect(controller.setup(true)).rejects.toThrowError(/R18TypoTickett.*can never fire/s);
+        await system.destroy();
+    });
+
+    test('a global dictionary name used as trigger.recordName fails fast with routing guidance', async () => {
+        const Item = Entity.create({
+            name: 'R18DictItem',
+            properties: [Property.create({ name: 'ok', type: 'boolean' })],
+        });
+        const counter = Dictionary.create({
+            name: 'r18DictCounter',
+            type: 'number',
+            collection: false,
+            computation: Count.create({ record: Item }),
+        });
+        const open = StateNode.create({ name: 'open' });
+        const closed = StateNode.create({ name: 'closed' });
+        const sm = StateMachine.create({
+            states: [open, closed],
+            initialState: open,
+            transfers: [StateTransfer.create({
+                // dict 变更事件以 DICTIONARY_RECORD 发出（record.key = dict 名），
+                // 直接把 dict 名当 recordName 是死监听 → 必须 fail-fast 并给出正确写法。
+                trigger: { recordName: 'r18DictCounter', type: 'update' },
+                current: open,
+                next: closed,
+                computeTarget: (e: any) => ({ id: e.record.id }),
+            })],
+        });
+        const Watcher = Entity.create({
+            name: 'R18DictWatcher',
+            properties: [Property.create({ name: 'phase', type: 'string', computation: sm })],
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Item, Watcher], relations: [], eventSources: [], dict: [counter] });
+        await expect(controller.setup(true)).rejects.toThrowError(/is a global dictionary.*_Dictionary_/s);
+        await system.destroy();
+    });
+
+    test('addSourceMap (public producer API) routes through normalization — no bypass into the tree', async () => {
+        const Ticket = Entity.create({
+            name: 'R18NormTicket',
+            properties: [
+                Property.create({ name: 'title', type: 'string' }),
+                Property.create({ name: 'isActive', type: 'boolean' }),
+            ],
+        });
+        const ActiveTicket = Entity.create({
+            name: 'R18NormActiveTicket',
+            baseEntity: Ticket,
+            matchExpression: MatchExp.atom({ key: 'isActive', value: ['=', true] }),
+        });
+        const system = new MonoSystem(new PGLiteDB());
+        const controller = new Controller({ system, entities: [Ticket, ActiveTicket], relations: [], eventSources: [] });
+        await controller.setup(true);
+
+        const manager = (controller.scheduler as any).sourceMapManager;
+        const fakeComputation = {
+            args: { constructor: { displayName: 'Fake' } },
+            constructor: { name: 'FakeHandle' },
+            dataContext: { type: 'global', id: { name: 'fake' } },
+        };
+        manager.addSourceMap({
+            type: 'update',
+            recordName: 'R18NormActiveTicket',   // 视图名——必须被归一化到物理名
+            computation: fakeComputation,
+        });
+        const tree = manager.getSourceMapTree();
+        expect(tree['R18NormActiveTicket']?.['update']).toBeUndefined();
+        const normalized = (tree['R18NormTicket']?.['update'] || []).find((s: any) => s.computation === fakeComputation);
+        expect(normalized).toBeTruthy();
+        expect((normalized as any).filteredRecordName).toBe('R18NormActiveTicket');
+        await system.destroy();
     });
 });
 

--- a/tests/runtime/schedulerEdgeCases.spec.ts
+++ b/tests/runtime/schedulerEdgeCases.spec.ts
@@ -157,7 +157,9 @@ describe('Scheduler.resolveDataDeps edge cases', () => {
 });
 
 describe('Scheduler.runComputation error handling', () => {
-    test('wraps data dependency resolution error in ComputationDataDepError', async () => {
+    test('a records dataDep on an unregistered entity fails fast at setup (dead-listener invariant)', async () => {
+        // r18 结构层起：指向 storage 未知记录名的 dataDep 监听在 setup 期被死监听
+        // 不变量拒绝（此前是静默死监听——计算永不触发、无任何报错）。
         const TestEntity = Entity.create({
             name: 'DataDepErrEntity',
             properties: [
@@ -195,10 +197,7 @@ describe('Scheduler.runComputation error handling', () => {
             dict: [dict],
         });
 
-        await controller.setup(true);
-
-        await system.storage.create('DataDepErrEntity', { val: 1 });
-        await new Promise(resolve => setTimeout(resolve, 500));
+        await expect(controller.setup(true)).rejects.toThrowError(/NonExistentEntity___.*can never fire/s);
 
         await system.destroy();
     });

--- a/tests/storage/review-fixes-2026-07-11-r18.spec.ts
+++ b/tests/storage/review-fixes-2026-07-11-r18.spec.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+import { Entity, Property, Relation } from '@core';
+import { DBSetup } from "@storage";
+import { SQLiteDB } from '@drivers';
+
+// 第十八轮深度 review 的声明期守卫回归（见 agentspace/output/deep-review-2026-07-11-r18.md）。
+//
+// F-3 值属性 vs 关系属性命名空间冲突：populateRecordAttributes 把关系属性无条件写进端点
+//     record 的属性表，同名值属性被静默吞掉——写入时标量值被当作关联记录 payload 展开
+//     （实测字符串被逐字符摊开成对象并创建了假关联记录），查询走关系语义。零告警数据损坏。
+// 附带守卫：保留属性名（id/_rowId，relation 另加 source/target）与同记录重复属性名，
+//     此前分别被框架主键静默覆盖 / Object.fromEntries 静默保留最后一个。
+//     Entity.create/Relation.create 声明期拒绝 + DBSetup.validatePropertyNames 兜底
+//     （覆盖 create 之后 push 属性、直接 new 构造等旁路）。
+
+describe('r18 F-3: value property vs relation property namespace collision', () => {
+    test('relation sourceProperty colliding with a scalar property on the source entity fails fast at setup', async () => {
+        const Contact = Entity.create({
+            name: 'R18C1Contact',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+        });
+        const User = Entity.create({
+            name: 'R18C1User',
+            properties: [Property.create({ name: 'email', type: 'string' })],
+        });
+        const rel = Relation.create({
+            source: User,
+            sourceProperty: 'email',   // 与标量属性 email 同名
+            target: Contact,
+            targetProperty: 'owner',
+            type: '1:n',
+        });
+        const db = new SQLiteDB(':memory:');
+        await db.open();
+        expect(() => new DBSetup([User, Contact], [rel], db))
+            .toThrowError(/relation property 'email' on 'R18C1User' collides with the value property/);
+        await db.close();
+    });
+
+    test('relation targetProperty colliding with a scalar property on the target entity fails fast at setup', async () => {
+        const Tag = Entity.create({
+            name: 'R18C2Tag',
+            properties: [Property.create({ name: 'name', type: 'string' })],
+        });
+        const Post = Entity.create({
+            name: 'R18C2Post',
+            properties: [Property.create({ name: 'tags', type: 'string' })],
+        });
+        const rel = Relation.create({
+            source: Tag,
+            sourceProperty: 'posts',
+            target: Post,
+            targetProperty: 'tags',    // 与 Post 的标量属性 tags 同名
+            type: 'n:n',
+        });
+        const db = new SQLiteDB(':memory:');
+        await db.open();
+        expect(() => new DBSetup([Tag, Post], [rel], db))
+            .toThrowError(/relation property 'tags' on 'R18C2Post' collides with the value property/);
+        await db.close();
+    });
+
+    test('collision with a filtered variant of the endpoint family is also rejected (shared namespace)', async () => {
+        const Base = Entity.create({
+            name: 'R18C3Base',
+            properties: [
+                Property.create({ name: 'kind', type: 'string' }),
+                Property.create({ name: 'assignee', type: 'string' }),
+            ],
+        });
+        const ActiveBase = Entity.create({
+            name: 'R18C3ActiveBase',
+            baseEntity: Base,
+            matchExpression: { key: 'kind', value: ['=', 'active'] } as any,
+        });
+        const Person = Entity.create({
+            name: 'R18C3Person',
+            properties: [Property.create({ name: 'name', type: 'string' })],
+        });
+        // filtered 端点上声明的关系属性与 base 的值属性同名 —— 家族共享命名空间，必须拒绝
+        const rel = Relation.create({
+            source: ActiveBase,
+            sourceProperty: 'assignee',
+            target: Person,
+            targetProperty: 'items',
+            type: 'n:1',
+        });
+        const db = new SQLiteDB(':memory:');
+        await db.open();
+        expect(() => new DBSetup([Base, ActiveBase, Person], [rel], db))
+            .toThrowError(/collides with the value property/);
+        await db.close();
+    });
+
+    test('non-colliding names keep working', async () => {
+        const Contact = Entity.create({
+            name: 'R18C4Contact',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+        });
+        const User = Entity.create({
+            name: 'R18C4User',
+            properties: [Property.create({ name: 'email', type: 'string' })],
+        });
+        const rel = Relation.create({
+            source: User,
+            sourceProperty: 'contacts',
+            target: Contact,
+            targetProperty: 'owner',
+            type: '1:n',
+        });
+        const db = new SQLiteDB(':memory:');
+        await db.open();
+        const setup = new DBSetup([User, Contact], [rel], db);
+        await setup.createTables();
+        await db.close();
+    });
+});
+
+describe('r18 reserved and duplicate property names', () => {
+    test('Entity.create rejects a property named id', () => {
+        expect(() => Entity.create({
+            name: 'R18ReservedId',
+            properties: [Property.create({ name: 'id', type: 'string' })],
+        })).toThrowError(/Property name "id" .* is reserved/);
+    });
+
+    test('Entity.create rejects duplicate property names', () => {
+        expect(() => Entity.create({
+            name: 'R18DupProp',
+            properties: [
+                Property.create({ name: 'total', type: 'number' }),
+                Property.create({ name: 'total', type: 'number' }),
+            ],
+        })).toThrowError(/Duplicate property name "total"/);
+    });
+
+    test('Relation.create rejects properties named source/target', () => {
+        const A = Entity.create({ name: 'R18RelResA' });
+        const B = Entity.create({ name: 'R18RelResB' });
+        expect(() => Relation.create({
+            source: A,
+            sourceProperty: 'bs',
+            target: B,
+            targetProperty: 'as',
+            type: 'n:n',
+            properties: [Property.create({ name: 'source', type: 'string' })],
+        })).toThrowError(/Property name "source" .* is reserved/);
+    });
+
+    test('DBSetup safety net catches properties pushed after create', async () => {
+        const Sneaky = Entity.create({
+            name: 'R18Sneaky',
+            properties: [Property.create({ name: 'label', type: 'string' })],
+        });
+        // create 之后 push（绕过 create 守卫的合法路径），由 DBSetup 兜底
+        Sneaky.properties.push(Property.create({ name: '_rowId', type: 'string' }));
+        const db = new SQLiteDB(':memory:');
+        await db.open();
+        expect(() => new DBSetup([Sneaky], [], db))
+            .toThrowError(/Property name '_rowId' on entity 'R18Sneaky' is reserved/);
+        await db.close();
+    });
+
+    test('a plain entity property named __type on a non-merged entity stays legal', () => {
+        // 与 r9 的判定一致：非 merged 家族没有判别列，用户自定义 __type 不受保留名限制
+        const Legacy = Entity.create({
+            name: 'R18LegacyType',
+            properties: [Property.create({ name: '__type', type: 'string' })],
+        });
+        expect(Legacy.properties.some(p => p.name === '__type')).toBe(true);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 第十八轮全代码库深度 Review + 复盘结构层 + 制度化

报告:`agentspace/output/deep-review-2026-07-11-r18.md`;复盘:`agentspace/output/r18-test-blindness-retrospective.md`。四路并行深度探查(storage / runtime / **migration+ScopedSequence 专项** / core+builtins+drivers),全部致命候选亲自编写最小复现实际运行确认后修复。

### 致命修复(4 项,全部已复现确认)

- **F-1 事件驱动计算的 filtered update 死监听**:StateMachine trigger / Transform eventDeps 在 filtered entity/relation 名上声明 `type:'update'` 时永不触发(storage 只以物理 base 名发字段 update 事件)。`ComputationSourceMap` 现把事件驱动 update 监听与数据驱动同构地挂到物理名,`Scheduler` 的成员资格守卫把路由后的事件改写回 filtered 名(enter/exit 由成员资格事件驱动、不双跳)。
- **F-2 migration manifest 对普通值参数全盲**:改 `trigger.keys` / `trigger.record` 模式 / 状态图拓扑(next 状态)/ `Every.notEmpty` / Transform eventDep record 模式 ⇒ 签名不变 ⇒ 迁移零 diff、存量数据带旧语义静默放行。`structuralSignature` 现纳入 `argsSignature`(规范化普通值参数)。**manifest generator 版本 2 → 3**(旧基线按既定政策拒绝并指引重建)。
- **F-3 值属性 vs 关系属性命名空间静默覆盖**:同名时值属性被静默吞掉——实测标量字符串被逐字符摊开成假关联记录(数据损坏)。`Setup.validateRelations` 现按端点家族 fail-fast。仓库自己的 activity 测试夹具即带此冲突,已一并修正。
- **F-4 ScopedSequence scope 输入编号后可变**:把已编号记录改到另一 scope 会静默重复编号;配合文档推荐的 `UniqueConstraint` 时目标 scope 的 create **永久**撞唯一约束(计数器随事务回滚,不可自愈)。新增 mutation 监听层守卫:值型 scope 字段变更 / ref 型 scope 关系解除或替换均 fail-fast;未编号记录不受限;宿主删除不受影响。

### 复盘结构层(「为什么 17 轮 + 结构层没测出 F-1」的制度化回应)

复盘结论:测试体系的全部坐标系建立在**数据形态**上,而 F-1 住在**机制形态**里——同一声明面(`recordName+type`)、两条消费轨道,不变量只在一条上执行;通用规则 r5 起就在注释里,注释没有执行力。落地:

- **事件命名空间统一**:视图名→物理名解析改以 storage 编译结果(`schema.records.resolvedBaseRecordName`)为唯一事实源。首跑即消灭 F-1 的同族亲缘 bug——**merged input 视图的 update 监听在两条轨道上都是死监听**(实测 Summation over input view 永久陈旧)。
- **死监听不变量(订阅面守卫)**:归一化后每个监听的 recordName 必须 ∈ storage 已知记录名(typo / dict 名误用 / 未注册实体 → setup 期受控错误,含正确写法指引);update 监听不得以视图名为键;`addSourceMap(s)` 并入同一管线。顺带清除历史静默死注册(虚拟 link `_source/_target` 监听)。
- **登记册本体升级**:`WritingComputationTests.md` 新增两根机制轴(计算轨道、监听名形态)+「路由类修复必须枚举同一声明面全部读者」清单义务。
- **制度化收口**:`AGENTS.md` 新增「Bug fixing: fix the class, not the instance」五点强制清单(枚举声明面全部读者 / 汇合点收口 / 全称规则升格为不变量 / 邻域扫描+登记册回灌 / 逃逸复盘必须落为机制);`.cursor/rules/interaqt-project.mdc`(always-apply)同步精简版——此前"体系化修复"方法论只存在于归档报告中,任何指令文件都没有引用,正是复盘诊断的"被记录、未被制度化"模式。

### 重要修复(2 项)

- 保留属性名(`id`/`_rowId`,relation 另加 `source`/`target`)与重复属性名:声明期拒绝 + `DBSetup` 兜底。
- `retrieveLastValue` 按键存在性判断,0/false/'' 不再被误判缺失。

### 升级注意(behavior tightening)

- migration 基线需重建(generator 2→3,错误信息含指引)。
- 此前被静默接受的冲突声明(值/关系属性同名、保留名、重复属性名)现在 fail-fast。
- filtered / merged-input 视图名上的 update 监听从死监听变为按成员资格语义触发;**指向未知记录名的 dataDep/eventDep 从静默死监听变为 setup 期报错**。

### 测试

- ✅ `npm run check` 与 `npm run check:all`
- ✅ `npm test` 全量 **1896 passed / 26 skipped**(基线 1871,净增 25 个回归用例,零既有用例回归)
- 回归:`tests/runtime/review-fixes-2026-07-11-r18.spec.ts`(16 用例)+ `tests/storage/review-fixes-2026-07-11-r18.spec.ts`(9 用例)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12fb52d8-f0b4-43f2-af71-fccbc06d7a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12fb52d8-f0b4-43f2-af71-fccbc06d7a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

