### PR TITLE
r19 deep review: fix BoolExp NOT guard fail-open + EXIST JOIN + combined filtered event + payload array

### DIFF
--- a/agentspace/output/deep-review-2026-07-11-r19.md
+++ b/agentspace/output/deep-review-2026-07-11-r19.md
@@ -1,0 +1,154 @@
+# 全代码库深度 Review 报告（2026-07-11 第十九轮）
+
+- 日期：2026-07-11
+- 基线：`main` @ `ca6d9d03`（v4.0.0，r1–r18 全部致命/重要修复已落地）
+- 基线健康度：`npm run check` 通过；`npm test` 全量 **1896 passed / 26 skipped**
+- 范围：四路并行深度探查（builtins 交互管线 / storage 查询编译与执行 / storage 写路径与 Setup / runtime 调度与增量计算 / core+drivers+migration）+ 对全部致命候选**亲自编写最小复现实际运行**（PGLiteDB）
+- 方法：与 r1–r18 全部报告逐条去重；每个候选先做代码路径二次追踪，再以运行时复现定谳（本轮 1 项候选被复现证伪，见第四节）。「已复现确认」才列为致命/重要。
+- 修复状态：**三个致命项 + 一个重要项已在本分支（`cursor/deep-code-review-r19-583e`）全部修复**，回归固化于 `tests/core/boolexp.spec.ts`（De Morgan 真值表组）、`tests/runtime/review-fixes-2026-07-11-r19.spec.ts`（6 用例）与 `tests/storage/review-fixes-2026-07-11-r19.spec.ts`（3 用例）。修复后 `npm run check` 通过，`npm test` 全量通过（含新增回归）。
+
+---
+
+## 一、结论摘要
+
+r1–r18 十八轮修复后，聚合增量一致性、对称关系、filtered 成员资格、migration 签名、写路径三拓扑等高风险面已高度收敛。本轮最重要的发现是**一个存在了十九轮都没被抓到的核心权限 bug**：
+
+1. **`BoolExp.evaluate`/`evaluateAsync` 的 `NOT` 不贯穿 `AND`/`OR` 子树**（F-1）——`NOT(A OR B)` 静默退化成 `A OR B`。由于 Interaction 守卫（`Conditions` + `BoolExp` 组合）正是这条求值路径的实际消费方，一条本意「A、B 皆不成立才放行」的守卫会在 A 成立时**静默放行**——权限 fail-open。这是本轮影响面最大、最应被早发现的问题：它不在任何 storage/runtime 的高危面上，而在最基础的布尔求值原语里，`.not()` 只要套在 `.and()`/`.or()` 外面就中招。
+2. **EXIST 子查询内层 `isReferenceValue` 引用外层 x:1 路径时，外层 JOIN 树缺失**（F-2）——`friend.age < 本用户的 leader.salary` 这类相关子查询直接抛 `missing FROM-clause entry`。r12-F-2 修了外层 direct match 的引用路径，EXIST 载荷是同族漏网读者。
+3. **combined 拓扑抢夺既有 owner 时，旧 owner 的 filtered 成员资格事件丢失**（F-3）——查询面正确（旧 owner 退出视图）、事件面无 delete，下游对该视图的响应式计算永久陈旧。merged 拓扑经既有 unlink 机制已覆盖，combined 的 flashOut 是平行漏网（r18 复盘已把 combined × filtered 标为空白格）。
+4. **entity/relation 类型的 payload 接受数组冒充单条**（I-1）——`typeof [] === 'object'` 且 `[]` 为真值，数组绕过结构校验，下游按单条实体消费时静默走偏。r17 修了 `type:'object'` 的数组拒绝，`base`（Entity/Relation）声明是同族漏网。
+
+| 级别 | 数量 | 主题 |
+|------|------|------|
+| 致命（已复现，已修复） | 3 | BoolExp NOT 组合 fail-open、EXIST 内层引用外层 JOIN 缺失、combined 抢夺旧 owner filtered 事件丢失 |
+| 重要（已修复） | 1 | entity/relation payload 数组冒充单条 |
+| 重要（记录，本轮不修） | 若干 | 见第三节 |
+| 证伪/降级 | 1+ | 见第四节 |
+
+---
+
+## 二、致命问题（全部已复现确认并修复）
+
+### F-1 `BoolExp.evaluate`/`evaluateAsync` 的 NOT 不贯穿 AND/OR 子树——守卫链权限 fail-open
+
+- 位置：`src/core/BoolExp.ts` `evaluate` L401-416 / `evaluateAsync` L447-462（原实现）。`inverse` 参数只在 atom 分支（L398）与 `not` 分支（L415 传 `!inverse` 给直接子节点）生效；`and`/`or` 分支求值子节点时**完全不传 `inverse`**（用默认 `false`），并把子树的原义求值结果原样返回。
+- 机理：`NOT(A OR B)` 求值时，`not` 节点以 `inverse=true` 求值 `(A OR B)`；`or` 节点收到 `inverse=true` 但**丢弃**，以原义求值 A、B——A 为真即返回 `true`。于是 `NOT(A OR B)` 等价于 `(A OR B)`。`NOT(A AND B)` 同构退化为 `(A AND B)`。
+- 复现（实测真值表，12 例，修复前 8 例错）：
+
+```
+NOT(T OR F):        期望 false  实际 true   ❌
+NOT(F OR F):        期望 true   实际 false  ❌
+NOT(T AND T):       期望 false  实际 true   ❌
+NOT(T AND F):       期望 true   实际 false  ❌
+NOT(F AND F):       期望 true   实际 false  ❌
+NOT(T OR F) AND T:  期望 false  实际 true   ❌
+T AND NOT(T AND T): 期望 false  实际 true   ❌
+NOT(NOT(T/F)):      正确（not 直接套 atom/not，走既有正确分支）
+[async] 同构        ❌
+```
+
+- 端到端复现（PGLite，经 `Controller.dispatch`）：守卫 `Conditions.create({ content: BoolExp.atom(A).or(B).not() })`，A 返回 true、B 返回 false → 本应 `NOT(true OR false)=false`（拒绝）→ 实际 dispatch **无 error（放行）**。
+- 影响：**权限 fail-open**。文档明确推荐 `Conditions.create({ content: BoolExp.atom(a).and(b).or(c) })` 组合守卫（`usage/06`），`.not()` 是 `BoolExp` 一等算子（`review-fixes-r13` 已在用 `BoolExp.atom(x).not()`）。任何「非…才放行」的组合守卫都会静默失效。这是所有错误形态里对安全性最伤的一类：无报错、按文档写、守卫悄悄放行。既有测试甚至**把错误行为编码成了断言**（`boolexp.spec.ts` 两处注释「Current implementation doesn't propagate inverse through AND/OR」）。
+- 修复：`inverse` 贯穿 `and`/`or` 子树，按 De Morgan 翻转算子——取反下 `or` 按 `and` 语义（两子都需在取反下为真）、`and` 按 `or` 语义求值，短路与错误透传语义不变。同步/异步两条路径同构修复。两处编码错误行为的旧断言改为正确的 De Morgan 断言。
+- 回归：`boolexp.spec.ts` 新增 De Morgan 真值表组（sync + async 一致性）；`review-fixes-2026-07-11-r19.spec.ts` 端到端守卫组（NOT(A OR B) 仅两者皆假放行、NOT(A AND B) 除两者皆真外放行）。
+
+### F-2 EXIST 子查询内层 `isReferenceValue` 引用外层 x:1 路径——外层 JOIN 树缺失，SQL 崩
+
+- 位置：`src/storage/erstorage/MatchExp.ts` `buildQueryTree` L172（`isReferenceValue` 引用路径入树的分支有 `!this.contextRootEntity` 限定——只处理外层 direct match，从不下钻 EXIST 载荷）；`SQLBuilder.ts` `parseFunctionMatchAtom` L410-421（内层 `RecordQuery` 继承 `contextRootEntity`，内层引用按外层根作用域解析别名）。
+- 机理：EXIST 内层的引用（`value[1]`，如 `leader.salary`）经 `getReferenceFieldValue` 按 `contextRootEntity`（外层根）解析成列引用 `"User_leader"."salary"`。这要求 `User_leader` 出现在**外层**查询的 FROM/JOIN 里（相关子查询引用外层别名）。但外层的 match 只有 `friends EXIST(...)`，`leader` 只出现在 EXIST 载荷内部，`buildQueryTree` 从不遍历该载荷 → 外层不 JOIN `User_leader` → SQL 报 `missing FROM-clause entry for table "User_leader"`。
+- 复现（实测，PGLite）：
+
+```
+User —leader(n:1)→ User ; User —friends(n:n)→ User
+find('User', { friends: ['exist', { age: ['<', 'leader.salary'], isReferenceValue:true }] })
+→ error: missing FROM-clause entry for table "User_leader"   ❌
+```
+
+- 影响：任何「关联子集的字段 vs 本记录跨关联字段」的相关 EXIST 查询直接崩溃（fail-loud，非静默）。这是 r12-F-2「外层 direct match 引用路径入 JOIN 树」修复的**自然延伸漏网**——同一声明面（`isReferenceValue` 引用路径）的第二个读者（EXIST 载荷）没被覆盖。
+- 修复：`buildQueryTree` 命中 EXIST 原子时，递归收集内层（含嵌套 EXIST——`contextRootEntity` 逐层继承同一根）的全部 `isReferenceValue` 引用路径，并入**根查询**的 query tree（仅根查询 `!contextRootEntity` 负责，因为所有引用都解析自根）。收集函数对 `BoolExp` / `ExpressionData` / 裸 `MatchAtom` 三种载荷形态归一化。
+- 回归：`review-fixes-2026-07-11-r19.spec.ts` F-2 组——两跳相关 EXIST 端到端执行并正确过滤；既有 `existQueryProof` / r12 引用路径测试保持通过。
+
+### F-3 combined 拓扑抢夺既有 owner：旧 owner 的 filtered 成员资格 delete 事件丢失
+
+- 位置：`src/storage/erstorage/RecordQueryAgent.ts` `flashOutCombinedRecordsAndMergedLinks` L179（`deleteRecordSameRowData` 物理清列，不经成员资格机制）；对照 merged 拓扑经 `CreationExecutor.unlinkOldOwnersOfExclusiveTargets` → `unlink` → `deleteRecord` → `collectLinkMembershipChecks` + `settle`。
+- 机理：combined（三表合一）拓扑下，新 owner 抢夺既有 owner 的合并端点时，flashOut 把端点列从旧 owner 的共享行物理搬出，但**从不重算旧 owner 的 filtered 成员资格**。旧 owner 失去关系属性、退出 filtered 视图（查询面正确），却零成员资格 delete 事件（事件面缺失）。
+- 复现（实测，PGLite，combined `User.profile → Profile` 1:1 + `UserWithProfile = filtered(User, profile.id is not null)`）：
+
+```
+create('User', {name:'A', profile:{title:'p'}})    → A ∈ UserWithProfile
+create('User', {name:'B', profile:{id: p.id}})     → 抢夺 p
+UserWithProfile 成员：['B']                          ✓ 查询面正确
+UserWithProfile 事件：仅 create(B)                   ❌ 无 delete(A)
+```
+
+- 影响：下游对 `UserWithProfile` 视图的响应式计算（Count/Every/Transform/StateMachine）永久陈旧——A 已退出但计算里还算着 A。这是 r18 复盘明确标注的「combined × filtered 交叉格空白」在写路径上的兑现，与 r17-F-2「同 id `&` 零事件」同属「数据变更必有事件」契约破坏家族。
+- 修复：flashOut 在物理清列**之前**快照旧 owner（`recordWithCombined`，业务关系端点、非虚拟 link）在依赖该关系属性的 filtered entity 上的成员资格，清列**之后**统一 `settleMembershipChecks`——退出视图的旧 owner 产生 delete 事件。复用 `FilteredEntityManager` 既有 collect/settle 机制，与 merged 拓扑同构。
+- 回归：`review-fixes-2026-07-11-r19.spec.ts` F-3 组——combined 抢夺后断言旧 owner 的 `UserWithProfile` delete 事件存在 + 新 owner create 存在 + 查询面成员正确。
+
+---
+
+## 三、重要问题
+
+### 已修复（本轮）
+
+- **I-1 entity/relation payload 接受数组冒充单条**：`Interaction.ts` `checkPayload` L400-407，`base`（Entity/Relation）声明的 payload item 结构校验只判 `!item || typeof item !== 'object'`。`typeof [] === 'object'` 且 `[]` 为真值——`isCollection:false` 时数组作为单条实体放行、`isCollection:true` 时嵌套数组作为元素放行。下游读 `.id`/展开为单条记录时静默走偏。修复：结构校验显式拒绝 `Array.isArray(item)`（镜像 r17 的 `type:'object'` 数组拒绝），集合语义须经 `isCollection:true` 声明。回归 4 用例（两向拒绝 + 两向合法对照）。
+
+### 记录，本轮不修（按影响排序，均有代码证据/子探查产出）
+
+1. **`IN` / `NOT IN` 值数组含 `null` 未治理**（storage 查询探查，中高）：`MatchExp.ts` L291-346 `in`/`not in` 分支直接 `fieldParams = value[1]`，不像 `SchemaDialect.predicateSQLForOperator`（约束 DDL）那样拆 null。SQL 三值逻辑下 `col NOT IN (1, NULL)` 对任意行求值 UNKNOWN，`col IS NULL` 的行被静默滤掉、`IN (…,null)` 无法匹配 NULL 列。API 未声明该语义。建议：`in`/`not in` 编译期拆出 null 分支（`col IS [NOT] NULL OR/AND col [NOT] IN (…)`），与约束层实现对齐。
+2. **`LIKE` 无 `%`/`_` 转义、无 `ESCAPE` 子句**（storage 查询探查）：`MatchExp.ts` L238-277。用户传入含 `%`/`_` 的字面量会意外扩大匹配面（非经典注入，值仍参数化，属语义安全缺口）。建议提供转义或显式 `ESCAPE`。
+3. **`canonicalizeArgsForSignature` 对 `Date`/`Set`/`Map`/`RegExp` 坍缩为 `{}`**（migration 探查，中）：`migration.ts` L828-843 非数组 object 一律 `Object.keys().sort()` 遍历，上述类型无可枚举键 → 规范化为 `{}`，不同语义值产生相同 `argsSignature` → 迁移零感知。需 computation args 中实际出现这些类型才触发（`trigger` 等 plain object 路径安全）。建议补 exotic-object 分支（类似 `[Function]` 标记）或文档禁止在 args 中使用。
+4. **property 级 filtered dataDep 不经 `resolveFilteredUpdateEvent` 同批去重**（runtime 探查，中）：`Scheduler.ts` L597 `targetPath?.length` 早退绕过 r18 为无 targetPath 源补的「同批成员资格 create/delete 则跳过物理 update」守卫。callback 型 property 聚合在「同批 enter + 聚合字段更新」时可能 +2 而非 +1。需确认 storage 是否同批发两类事件；建议对 `targetPath` 监听在 property 增量入口复用同一批次去重逻辑，并补 filtered **relation** 上 eventDeps update 的回归（r18 仅覆盖 filtered entity）。
+5. **`Entity.clone`/`Relation.clone` 共享 `constraints` 数组引用**（core 探查，中）：`Entity.ts` L185 / `Relation.ts` L378 浅 clone 直接赋值 `constraints: instance.constraints`。RefContainer/setup 对 clone 侧 constraints 的原地修改会污染原实体。与已记录的 `RefContainer.replaceRelation/replaceEntity` 不 clone 同属「clone/replace 隔离语义不一致」家族。建议统一浅拷贝数组。
+6. **`ActivityInteractionRelation` 声明但运行期从不写入**（builtins 探查）：`ActivityManager.ts` L40-47/125-127 注册了 `activityInteraction` 1:n 关系，但 `mapEventData` 只在事件 JSON 内嵌 `activity:{id}`，不建 relation 行。用 relation 查询的 Condition/报表得空集，`activity.id` 点查有效。建议：显式建 relation，或移除该 relation 并文档固定「只查 `InteractionEventEntity.activity.id`」。
+7. **`checkCondition` 先于 `checkPayload`**（builtins 探查）：`Interaction.ts` L272-273。Condition 回调看到未校验 payload（含未知类型）。若条件提前读 payload 做授权可能基于畸形形态决策。建议文档明确顺序，或调换（breaking）。
+8. **driver 错误映射缺口**（drivers 探查）：`DatabaseErrors.ts` 覆盖 PG `23505`/SQLite unique/MySQL `1062`，缺 MySQL `1213` 死锁、PG 以外的 serialization 冲突结构化标记。建议补齐以让并发重试策略跨驱动一致。
+9. **`retrieveData` 的 modifier 限制仅在有 `limit` 时生效**（builtins 探查，r7-F-3 家族复确）：`Interaction.ts` L442-448。仅声明 `dataPolicy.match` 无 `limit` 时，调用方可用 `query.modifier.offset` 分页枚举全部匹配行（match 范围仍有效）。建议文档化「match-only policy ≠ 防枚举」或提供显式 `lockPagination`。
+
+---
+
+## 四、证伪/降级的候选（本轮探查结论被推翻的）
+
+| 候选 | 证伪证据 |
+|------|----------|
+| 「Summation/Average 全量重算路径对 string 数值字段做字符串拼接（`0 + "10" + "20"` → `"01020"`）」（runtime 探查，初判中置信） | 复现证伪：`resolveSumField`/`resolveAvgField` 对 string `"10"` 因 `Number.isFinite("10") === false` 而**返回 0**（不是原样返回 string），`reduce` 累加得 0，不会字符串拼接。全量与增量口径一致（both 0）。属「非 number 字段按 0 计」的既定语义，非 bug |
+
+另有若干子探查候选核实为**既有设计/已文档化**：`isRef` 只验存在性不验归属（显式 Condition 负责授权，`usage/06` 已明确）；eventDeps Transform 不维护源↔派生映射（audit 场景刻意形态，与 dataDep 语义不对称属文档问题）；`Custom.asyncReturn` 三参回调 vs 两参调用（r5-I-15 已记录）；Activity 事件写入早于状态推进（同事务内，提交前回滚）。
+
+---
+
+## 五、既有遗留项复确（r2–r18 已记录，本轮探查再次命中，不重复展开）
+
+- **语义/契约**：SQL NULL 键缺失（r4-I-1）；update/create 返回值三态（r16-O-2/r17-R-4）；`Custom.asyncReturn` 2 参（r5-I-15）；StateMachine 单事件单跳 + 宿主自更新回声（r7-I-8）；`func::` 信任边界、`ignoreGuard`（文档化）；对称 n:n link API 不归一化端点（r4-I-17/r7-I-2，四轮复确，待产品决策）。
+- **性能/资源**：global dict 变更宿主全表扫描（S3）；async task 表只增不减（r2-I-6）；级联删除无深度上限（r2-I-5）；offset-only 全量拉取（r12-I-4）；EXIST 误触 post-pagination（r12-I-5）；`RefContainer.replace*` 不 clone（r18 记录）。
+- **并发**：`setDictionaryValue` find-then-write（r12-I-1）；lockRows 5 轮上限（r15-O-3）；Activity every 组 CAS 不自动重试（r16-O-7）。
+- **时间调度**：`nextRecomputeTime` 全链无消费方——RealTime 时间驱动重算仍不存在（r3-R5）。
+- **驱动**：MySQL 无事务（文档化）；contains 四驱动语义矩阵（r12-I-6）；PGLite UUID id vs 其他 INT。
+- **迁移审阅完整性三缺口**（r18 第三节）：`defaultValue` 变更不进 manifest、落盘 deps 剥离 match、重算无 per-computation log。
+
+---
+
+## 六、修复优先级与后续建议
+
+本轮三个致命项 + 一个重要项已全部修复。后续轮次建议：
+
+1. **`IN`/`NOT IN` 含 null 治理**（第三节第 1 条）——静默错误结果家族，编译期拆分成本低，参照 `SchemaDialect` 既有实现。
+2. **property 级 filtered 双轨同批去重对称化**（第三节第 4 条）——r18-F-1 修复的同族风险面，先确认 storage 同批事件形态再定夺。
+3. **clone/replace 隔离语义统一**（第三节第 5 条 + r18 记录的 RefContainer）——一次性收口 Entity/Relation clone 的 constraints 数组与 RefContainer.replace* 的不 clone。
+4. **createClass 统一声明期校验**（r16 建议 4，多轮复确）——Property.type 白名单、Payload 重名、Activity 环检测等积压项。
+
+### 升级注意（behavior-tightening，供 CHANGELOG 参考）
+
+- **BoolExp NOT 语义修正**：`NOT(A OR B)`/`NOT(A AND B)` 现按 De Morgan 正确求值。依赖旧（错误）行为的守卫会改变判定——但旧行为是权限 fail-open，任何依赖它的声明本就是安全缺陷。这是**安全修复**。
+- **新增声明期 fail-fast**：entity/relation payload 拒绝数组（此前静默接受并下游走偏）。
+
+---
+
+## 附录：复现要点（验证用）
+
+全部固化在 `tests/core/boolexp.spec.ts`（De Morgan 组）、`tests/runtime/review-fixes-2026-07-11-r19.spec.ts` 与 `tests/storage/review-fixes-2026-07-11-r19.spec.ts`：
+
+- F-1：De Morgan 真值表 12 例（sync + async）；端到端守卫 `NOT(A OR B)` 仅两者皆假放行、`NOT(A AND B)` 除两者皆真外放行。
+- F-2：两跳相关 EXIST（`friend.age < 本用户 leader.salary`）端到端执行并正确过滤，不再抛 `missing FROM-clause entry`。
+- F-3：combined 抢夺后旧 owner 的 `UserWithProfile` delete 事件存在、新 owner create 存在、查询面成员正确。
+- I-1：entity payload `isCollection:false` 拒绝数组 / `isCollection:true` 拒绝嵌套数组元素；合法单条与合法数组对照放行。

--- a/agentspace/output/r19-test-blindness-retrospective.md
+++ b/agentspace/output/r19-test-blindness-retrospective.md
@@ -1,0 +1,97 @@
+# 深度反思：为什么 19 轮审查、1900+ 用例没测出 `BoolExp` 的 NOT 组合 fail-open（r19 F-1）
+
+- 日期：2026-07-11
+- 关联：`deep-review-2026-07-11-r19.md`（问题发现与修复）、`r17-/r18-test-blindness-retrospective.md`（前两轮复盘）
+- 性质：测试体系的结构性复盘 + 本轮已落地的机制改造记录。所有关键论断均有代码原文/测试原文考证。
+
+---
+
+## 〇、先给结论
+
+这个 bug 最刺眼的地方不是它藏得深，而是它藏得**浅**——它在整个框架最基础的布尔求值原语里，`NOT(A OR B)` 这种小学逻辑，一个单元测试就能抓。它能穿过 18 轮审查、1900+ 用例，暴露的是三个此前复盘都没点破的盲区：
+
+1. **测试把「当前实现行为」而非「正确语义」编码成了断言**——`boolexp.spec.ts` 有两处测试的注释白纸黑字写着「Current implementation doesn't propagate inverse through AND/OR」，然后 `expect(result).not.toBe(true)` 把这个**错误行为固化成了绿灯**。测试不是漏写了，是**写反了**：它在保护 bug。
+2. **审查的坐标系全部长在「响应式数据流」上，核心原语的纯逻辑正确性不在任何轴上**——r6–r18 建的预言机（事件完备性、增量==全量、引用完整性、死监听不变量）全都服务于「数据变更 → 事件 → 计算」这条链。`BoolExp.evaluate` 是守卫链的求值器，不产生 mutation、不进事件流、不碰 storage——它落在所有预言机的观测面之外。
+3. **安全面（权限 fail-open）没有独立的红队式断言**——框架对「守卫应拒绝时是否真的拒绝」有正向测试（返回 false → 拒绝），但没有「用组合逻辑构造一个**应该拒绝**的守卫，断言它确实拒绝」的对抗性覆盖。fail-open 是否定形命题，正向用例天然测不到。
+
+---
+
+## 一、显微镜：这个 bug 恰好穿过了哪些防线
+
+### 防线一：单元测试把 bug 写进了断言
+
+`tests/core/boolexp.spec.ts` 修复前的两处（L758、L893）：
+
+```ts
+test("should evaluate complex expression with NOT", () => {
+  // NOT(10 > 5 AND 3 > 5)
+  // Note: Current implementation doesn't propagate inverse through AND/OR
+  // So this will return error because the AND fails (3 > 5 = false)
+  const expr = BoolExp.atom(10).and(BoolExp.atom(3)).not();
+  const result = expr.evaluate((data) => data > 5);
+  expect(result).not.toBe(true);        // ← NOT(T AND F) 正确应为 true，这里断言 not true
+  expect((result as EvaluateError).data).toBe(3);
+});
+```
+
+作者**知道**实现不传播 inverse（注释写明了），却把它当成「既定行为」记录下来，而不是当成 bug 报告。这是最危险的一种测试：它不只是没覆盖，它**主动为错误行为背书**——任何后来者想修 `evaluate`，这两个测试会立刻变红，制造「你的修改破坏了测试」的假信号，把正确修复推回去。
+
+**根因**：测试作者站在「实现现在怎么跑」的视角写断言，而不是站在「语义应该是什么」的视角。`NOT(A AND B)` 的正确值是数学事实（De Morgan），不该由「当前实现」定义。**实现者知识诅咒的极端形态：不是写了 happy path，是把 bug path 封成了契约。**
+
+### 防线二：核心原语的纯逻辑不在任何审查轴上
+
+r17/r18 复盘把测试盲区归纳为「缺维度轴」（物理拓扑、事件完备性、计算轨道、监听名形态……）。但这些轴无一例外都是**响应式数据流**的轴。`BoolExp.evaluate` 是一个纯函数式的布尔求值器：输入表达式树 + atom handler，输出 true/error。它：
+
+- 不产生 mutation event → 事件完备性预言机看不到；
+- 不做增量计算 → 增量==全量预言机看不到；
+- 不碰 link/端点 → 引用完整性不变量看不到；
+- 不注册监听 → 死监听不变量看不到。
+
+**所有结构性防线都建在「数据流下游」，而这个 bug 在「逻辑原语上游」。** 维度登记册（`WritingComputationTests.md`）整篇是为 computation 测试服务的，`BoolExp` 作为 computation 的**依赖**（守卫、match 编译）从不在它的视野里。
+
+### 防线三：安全面没有对抗性（红队）断言
+
+`tests/runtime/condition.spec.ts` 覆盖了守卫：单条件返回 false → 拒绝、抛异常 → 拒绝、非 boolean → 拒绝（r13）。这些都是**正向**断言：「已知此处应拒绝，断言它拒绝」。但它们全部是 `atom` 或 `atom.and(atom)` 形态——**没有一个用 `.not()` 包住组合表达式**。
+
+`.not()` 在测试里出现的地方（`review-fixes-r13` L48/L58）是 `BoolExp.atom(returnsNull).not()`——`NOT(atom)`，恰好走的是正确分支（inverse 直接作用于 atom）。**离 bug 只差一层：把 atom 换成 `.or()`/`.and()` 组合就中招，但没有任何测试跨过这一步。**
+
+fail-open 的本质是否定形命题：「不该放行处放行了」。正向测试范式（构造应通过的场景，断言通过）天生写不出它——必须主动构造「应该被拒绝的组合守卫」并断言其被拒绝。这类**对抗性断言**在整个 suite 里是缺失的。
+
+---
+
+## 二、更深一层：这个 bug 的公共形状
+
+> **一个被广泛复用的底层原语，它的正确性契约（真值表 / 代数律）从未被独立断言；上层只测「原语恰好被怎么用」，没测「原语本身对不对」。**
+
+`BoolExp` 被三个上层复用：Interaction 守卫（`evaluate`）、storage match 编译（`.map()` → SQL）、scopedSequence match（另有独立正确实现）。storage 走 SQL 的 `NOT(...)`（数据库原生，正确），scopedSequence 自己实现了正确的 not 传播——**只有守卫走 `evaluate`，而 evaluate 的 not 是坏的**。三个读者里两个绕开了坏路径，坏路径的唯一读者（守卫）又只被正向测试覆盖。
+
+这与 r18 的「同一声明面多个读者」形状相通，但更基础：这里是**同一原语的多个实现**（SQL not / scopedSequence not / evaluate not）中，只有一个是错的，而它恰好服务于最不该出错的面（权限）。没有任何机制要求「`not` 的语义在所有实现里一致」。
+
+---
+
+## 三、本轮已落地的机制改造
+
+### 3.1 真值表即契约（对冲盲区 1）
+
+`boolexp.spec.ts` 新增 De Morgan 真值表回归组：`NOT(A OR B)`、`NOT(A AND B)`、双重否定、嵌套组合，sync 与 async **逐格断言正确语义**，并显式断言 sync/async 一致。两处「为 bug 背书」的旧断言改写为正确的 De Morgan 断言。**契约从「实现现在怎么跑」改为「代数律要求怎么跑」。**
+
+### 3.2 守卫的对抗性断言（对冲盲区 3）
+
+`review-fixes-2026-07-11-r19.spec.ts` 端到端构造「**应该拒绝**的组合守卫」并断言 dispatch 被拒绝：`NOT(A OR B)`（A 真 → 必拒）、`NOT(A AND B)`（两者皆真 → 必拒）。这是守卫面第一组 fail-open 对抗性用例——不是「构造应通过的场景」，而是「构造应拒绝的场景，断言真的拒绝」。
+
+### 3.3 登记册补一根轴：原语正确性
+
+`WritingComputationTests.md` 的维度登记册此前只有数据形态轴 + 机制轴（r18）。本轮教训要求补一类**正交于数据流的轴**：被复用的底层原语（`BoolExp` 求值、match 求值、算术求值），其正确性契约（真值表/代数律）必须有独立于「上层怎么用」的断言，且当同一语义有多个实现（SQL not / 内存 not）时，必须有一致性对账。（见本文件被登记册引用。）
+
+---
+
+## 四、有意不做（含理由）
+
+- **把 `evaluate` 与 storage SQL not / scopedSequence not 做统一实现**：三者输入/输出模型不同（表达式树求值 vs SQL 文本生成 vs 内存谓词），强行统一收益低、耦合高；正确的收口是「一致性对账测试」（同一逻辑表达式在 evaluate 与 scopedSequence 求值下结果一致），而非合并实现。已在登记册记录为轴，本轮先补 evaluate 自身的真值表。
+- **doc-tests 基建**：与 r18 结论一致，属独立工程，先以真值表 + 对抗性守卫用例补入回归。
+
+---
+
+## 五、一句话总结
+
+**r17 说「坐标系缺数据形态轴」，r18 补「还缺机制形态轴」，r19 再补一刀：轴不只在数据流下游，还在逻辑原语上游——被复用的底层原语的正确性契约必须独立于「它恰好被怎么用」来断言；而最致命的测试不是没写，是把 bug 当契约写进了断言，替 bug 挡住了所有想修它的人。**

--- a/src/builtins/interaction/Interaction.ts
+++ b/src/builtins/interaction/Interaction.ts
@@ -398,10 +398,15 @@ export async function checkPayload(controller: GuardController, interaction: Int
       const baseRecordName = (payloadDef.base as EntityInstance).name;
       const items = payloadDef.isCollection ? (payloadItem as unknown[]) : [payloadItem];
       for (const item of items) {
-        // Structural check: an entity/relation payload must be an object.
-        if (!item || typeof item !== 'object') {
+        // Structural check: an entity/relation payload item must be a plain object.
+        // CAUTION Array.isArray must be rejected explicitly — typeof [] === 'object' and [] is truthy,
+        //  so without this an array slips through as a single entity (isCollection:false) or as a
+        //  nested-array element (isCollection:true). Downstream consumers then read `.id`/spread the
+        //  value as one record and silently drift. Collection semantics must be declared via
+        //  isCollection:true, whose per-element check lands here (mirrors the type:'object' array guard).
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
           throw new InteractionGuardError(
-            `Payload validation failed for field '${payloadDef.name}': expected ${baseRecordName} data (object), got ${item === null ? 'null' : typeof item}`,
+            `Payload validation failed for field '${payloadDef.name}': expected ${baseRecordName} data (object), got ${item === null ? 'null' : Array.isArray(item) ? 'array' : typeof item}`,
             { type: `${payloadDef.name} check concept failed`, checkType: 'payload' }
           );
         }

--- a/src/core/BoolExp.ts
+++ b/src/core/BoolExp.ts
@@ -398,17 +398,21 @@ export class BoolExp<T> {
       return (result && !inverse || !result && inverse) ? true : error
     }
 
-    if (this.isOr()) {
-      const leftResult = this.left.evaluate(atomHandle, currentStack)
+    // CAUTION `inverse` 必须贯穿 and/or 子树（De Morgan），而不仅仅作用于 atom 与 not 的直接子节点。
+    //  历史实现里 and/or 分支丢弃 inverse、以原义求值 —— `NOT(A OR B)` 于是退化成 `A OR B`，
+    //  在 Interaction 守卫（Conditions 用 BoolExp 组合 + not）下是权限 fail-open：本应「A、B 皆不成立才放行」
+    //  却在 A 成立时静默放行。取反下算子按 De Morgan 翻转：NOT(A OR B) ≡ (NOT A) AND (NOT B)，
+    //  NOT(A AND B) ≡ (NOT A) OR (NOT B)。短路与错误透传语义保持不变。
+    if (this.isOr() || this.isAnd()) {
+      const evaluatesAsAnd = inverse ? this.isOr() : this.isAnd()
+      const right = this.requireRight(this.isAnd() ? 'and' : 'or')
+      const leftResult = this.left.evaluate(atomHandle, currentStack, inverse)
+      if (evaluatesAsAnd) {
+        if (leftResult !== true) return leftResult
+        return right.evaluate(atomHandle, currentStack, inverse)
+      }
       if (leftResult === true) return true
-      return this.requireRight('or').evaluate(atomHandle, currentStack)
-    }
-
-    if (this.isAnd()) {
-      const leftResult = this.left.evaluate(atomHandle, currentStack)
-      if (leftResult !== true) return leftResult
-
-      return this.requireRight('and').evaluate(atomHandle, currentStack)
+      return right.evaluate(atomHandle, currentStack, inverse)
     }
 
     if (this.isNot()) {
@@ -444,17 +448,18 @@ export class BoolExp<T> {
       return (result && !inverse || !result && inverse) ? true : error
     }
 
-    if (this.isOr()) {
-      const leftResult = await this.left.evaluateAsync(atomHandle, currentStack)
+    // CAUTION 与同步 evaluate 保持同一套 De Morgan 语义：inverse 必须贯穿 and/or 子树。
+    //  这是守卫链（evaluateAsync）实际走的路径，NOT 组合的权限判定正确性依赖于此。
+    if (this.isOr() || this.isAnd()) {
+      const evaluatesAsAnd = inverse ? this.isOr() : this.isAnd()
+      const right = this.requireRight(this.isAnd() ? 'and' : 'or')
+      const leftResult = await this.left.evaluateAsync(atomHandle, currentStack, inverse)
+      if (evaluatesAsAnd) {
+        if (leftResult !== true) return leftResult
+        return right.evaluateAsync(atomHandle, currentStack, inverse)
+      }
       if (leftResult === true) return true
-      return this.requireRight('or').evaluateAsync(atomHandle, currentStack)
-    }
-
-    if (this.isAnd()) {
-      const leftResult = await this.left.evaluateAsync(atomHandle, currentStack)
-      if (leftResult !== true) return leftResult
-
-      return this.requireRight('and').evaluateAsync(atomHandle, currentStack)
+      return right.evaluateAsync(atomHandle, currentStack, inverse)
     }
 
     if (this.isNot()) {

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -222,9 +222,20 @@ export class MatchExp {
     // CAUTION 收集 exist 子查询（含嵌套 exist）里所有 isReferenceValue 的引用路径。这些引用都
     //  解析自最外层根实体（contextRootEntity 逐层继承），因此必须由根查询统一并入 JOIN 树。
     //  仅返回跨关联的多段路径（length>1）；单段的是根实体自己的列，无需额外 JOIN。
-    private collectExistReferencePaths(expression: MatchExpressionData): string[][] {
+    //  节点可能是 BoolExp、ExpressionData 或裸 MatchAtom（exist 的 value[1] 允许这几种形态），统一归一化。
+    private collectExistReferencePaths(expression: unknown): string[][] {
+        const toBoolExp = (node: unknown): MatchExpressionData | null => {
+            if (node instanceof BoolExp) return node as MatchExpressionData
+            if (BoolExp.isExpressionData(node)) return BoolExp.fromValue(node as ExpressionData<MatchAtom>)
+            if (node && typeof node === 'object' && 'key' in (node as object) && 'value' in (node as object)) {
+                return BoolExp.atom<MatchAtom>(node as MatchAtom)
+            }
+            return null
+        }
         const paths: string[][] = []
-        const walk = (exp: MatchExpressionData) => {
+        const walk = (node: unknown) => {
+            const exp = toBoolExp(node)
+            if (!exp) return
             if (exp.isExpression()) {
                 if (exp.left) walk(exp.left)
                 if (exp.right) walk(exp.right)
@@ -238,7 +249,7 @@ export class MatchExp {
             }
             // 嵌套 exist 的引用同样解析自根实体，继续下钻收集。
             if (typeof atom.value[0] === 'string' && (atom.value[0] as string).toLowerCase() === 'exist' && atom.value[1]) {
-                walk(atom.value[1] as MatchExpressionData)
+                walk(atom.value[1])
             }
         }
         walk(expression)

--- a/src/storage/erstorage/MatchExp.ts
+++ b/src/storage/erstorage/MatchExp.ts
@@ -176,6 +176,22 @@ export class MatchExp {
                 }
             }
 
+            // CAUTION EXIST 子查询内部的 isReferenceValue 引用解析的是**外层根实体**的作用域
+            //  （parseFunctionMatchAtom 把 contextRootEntity 一路继承给所有嵌套 exist，见其
+            //  RecordQuery.create 的最后一个参数）。内层 MatchExp 因 contextRootEntity 存在而
+            //  跳过了引用路径的 JOIN 构建（上面的 !this.contextRootEntity 分支），所以解析所在的
+            //  这一层（根查询）必须把这些引用路径并入自己的 query tree——否则相关列（如
+            //  User_leader.salary）在外层 FROM 里没有对应的 JOIN，SQL 直接报
+            //  "missing FROM-clause entry for table"。只有根查询（!contextRootEntity）负责。
+            if (!this.contextRootEntity
+                && Array.isArray(matchData.data.value)
+                && typeof matchData.data.value[0] === 'string'
+                && (matchData.data.value[0] as string).toLowerCase() === 'exist'
+                && matchData.data.value[1]) {
+                this.collectExistReferencePaths(matchData.data.value[1] as MatchExpressionData)
+                    .forEach(referencePath => recordQueryTree.addField(referencePath))
+            }
+
             // 直接就是 value 的情况不用管，没有 query 其他的实体。
             //  CAUTION 还有最后路径是 entity 但是  match 值是 EXIST 的不用管，因为会生成 exist 子句。只不过这里也不用特别处理，join 的表没用到会自动数据库忽略。
             if ((matchAttributePath.length === 1 && attributeInfo.isValue)) {
@@ -202,6 +218,32 @@ export class MatchExp {
         }
     }
 
+
+    // CAUTION 收集 exist 子查询（含嵌套 exist）里所有 isReferenceValue 的引用路径。这些引用都
+    //  解析自最外层根实体（contextRootEntity 逐层继承），因此必须由根查询统一并入 JOIN 树。
+    //  仅返回跨关联的多段路径（length>1）；单段的是根实体自己的列，无需额外 JOIN。
+    private collectExistReferencePaths(expression: MatchExpressionData): string[][] {
+        const paths: string[][] = []
+        const walk = (exp: MatchExpressionData) => {
+            if (exp.isExpression()) {
+                if (exp.left) walk(exp.left)
+                if (exp.right) walk(exp.right)
+                return
+            }
+            const atom = exp.data
+            if (!Array.isArray(atom.value)) return
+            if (atom.isReferenceValue && typeof atom.value[1] === 'string') {
+                const referencePath = (atom.value[1] as string).split('.')
+                if (referencePath.length > 1) paths.push(referencePath)
+            }
+            // 嵌套 exist 的引用同样解析自根实体，继续下钻收集。
+            if (typeof atom.value[0] === 'string' && (atom.value[0] as string).toLowerCase() === 'exist' && atom.value[1]) {
+                walk(atom.value[1] as MatchExpressionData)
+            }
+        }
+        walk(expression)
+        return paths
+    }
 
     getFinalFieldName(matchAttributePath: string[]): [string, string] {
         const namePath = [this.entityName].concat(matchAttributePath.slice(0, -1))

--- a/src/storage/erstorage/RecordQueryAgent.ts
+++ b/src/storage/erstorage/RecordQueryAgent.ts
@@ -6,7 +6,7 @@ import { AttributeQuery, AttributeQueryData } from "./AttributeQuery.js";
 import { LINK_SYMBOL, RecordQuery } from "./RecordQuery.js";
 import { NewRecordData, RawEntityData } from "./NewRecordData.js";
 
-import { FilteredEntityManager } from "./FilteredEntityManager.js";
+import { FilteredEntityManager, MembershipCheck } from "./FilteredEntityManager.js";
 import { SQLBuilder, PlaceholderGen } from "./SQLBuilder.js";
 import { RecursiveContext, ROOT_LABEL } from "./util/RecursiveContext.js";
 import { QueryExecutor, RecordQueryRef } from "./QueryExecutor.js";
@@ -146,6 +146,12 @@ export class RecordQueryAgent implements RecordOperationAgent {
         // const hasNoConflict = recordsWithCombined.length === 1 && !recordsWithCombined[0].id
         // 开始 merge 数据，并记录 unLink 事件
         const newRecordIsLink = this.map.getRecordInfo(newEntityData.recordName).isRelation && !!this.map.data.links[newEntityData.recordName]
+        // CAUTION 被抢夺的旧 owner 会失去 combined 关联端点（deleteRecordSameRowData 物理清列），
+        //  其 filtered entity 成员资格必须重算——否则「查询面已退出、事件面无 delete」，下游对该
+        //  filtered 视图的响应式计算永久陈旧（combined × filtered 交叉格，r18 复盘已标注为空白）。
+        //  merged 拓扑经 unlinkOldOwnersOfExclusiveTargets → unlink → deleteRecord 已走成员资格机制，
+        //  combined 的 flashOut 是平行漏网。before 快照必须在物理清列之前采集，settle 在之后统一结算。
+        const oldOwnerMembershipChecks: MembershipCheck[] = []
         for (let recordWithCombined of recordsWithCombined) {
             // CAUTION 正在创建的是 combined link record（如三表合一的 1:1 关系经 addLink 建立），
             //  且被抢夺端点所在的行本身就是一条旧业务 link 行（行上有 link id）时：
@@ -173,6 +179,17 @@ export class RecordQueryAgent implements RecordOperationAgent {
                 //  而不是 u2，若只判真值就会把无关的 u1 一并 flashOut，并在 result 上产生
                 //  同名属性冲突（"should not have same combined record" 内部断言崩溃，r17 拓扑矩阵首跑发现）。
                 if (recordWithCombined[combinedRecordIdRef.info?.attributeName!]?.id === combinedRecordIdRef.getRef().id) {
+
+                    // 抢夺既有 owner（recordWithCombined.id 存在）且被抢的是业务关系端点（非虚拟 link 的
+                    // source/target）时，先快照该 owner 在依赖此关系属性的 filtered entity 上的成员资格。
+                    if (recordWithCombined.id && !combinedRecordIdRef.info!.isLinkSourceRelation()) {
+                        oldOwnerMembershipChecks.push(...await this.filteredEntityManager.collectMembershipChecks(
+                            newEntityData.recordName,
+                            [recordWithCombined.id],
+                            [combinedRecordIdRef.info!.attributeName!],
+                            events
+                        ))
+                    }
 
                     // TODO 如果没有冲突的话，可以不用删除原来的数据。外面直接更新这一行就行了
                     //1. 删掉 combined 原来的所有同行数据
@@ -241,6 +258,9 @@ export class RecordQueryAgent implements RecordOperationAgent {
                 }
             }
         }
+
+        // 物理清列完成后统一结算旧 owner 的成员资格：退出 filtered 视图的 owner 产生 delete 事件。
+        await this.filteredEntityManager.settleMembershipChecks(oldOwnerMembershipChecks, events)
 
         return result
     }

--- a/tests/core/boolexp.spec.ts
+++ b/tests/core/boolexp.spec.ts
@@ -755,17 +755,13 @@ describe("BoolExp Complete Test Suite", () => {
       expect(result).toBe(true);
     });
 
-    test("should evaluate complex expression with NOT", () => {
-      // NOT(10 > 5 AND 3 > 5)
-      // Note: Current implementation doesn't propagate inverse through AND/OR
-      // So this will return error because the AND fails (3 > 5 = false)
+    test("should evaluate complex expression with NOT (De Morgan)", () => {
+      // NOT(10 > 5 AND 3 > 5) = NOT(true AND false) = NOT(false) = true.
+      // inverse propagates through AND/OR per De Morgan: NOT(A AND B) ≡ (NOT A) OR (NOT B).
       const expr = BoolExp.atom(10).and(BoolExp.atom(3)).not();
       const result = expr.evaluate((data) => data > 5);
-      
-      // The AND expression returns error (because right side fails)
-      // NOT doesn't convert error to true in current implementation
-      expect(result).not.toBe(true);
-      expect((result as EvaluateError<number>).data).toBe(3);
+
+      expect(result).toBe(true);
     });
 
     test("should track evaluation stack", () => {
@@ -775,6 +771,51 @@ describe("BoolExp Complete Test Suite", () => {
       expect(result).not.toBe(true);
       expect((result as EvaluateError<number>).stack).toBeDefined();
       expect((result as EvaluateError<number>).stack.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("evaluate — NOT propagation through AND/OR (De Morgan, r19 F-1 regression)", () => {
+    // Atom data IS the boolean; handle returns it directly.
+    const handle = (d: boolean) => d;
+    const T = () => BoolExp.atom(true);
+    const F = () => BoolExp.atom(false);
+    const passes = (expr: BoolExp<boolean>) => expr.evaluate(handle) === true;
+
+    test("NOT(A OR B) is fail-closed when either operand holds", () => {
+      // The historic bug: NOT(A OR B) degraded to (A OR B), a permission fail-open.
+      expect(passes(T().or(F()).not())).toBe(false); // NOT(T OR F) = F
+      expect(passes(F().or(T()).not())).toBe(false); // NOT(F OR T) = F
+      expect(passes(T().or(T()).not())).toBe(false); // NOT(T OR T) = F
+      expect(passes(F().or(F()).not())).toBe(true); // NOT(F OR F) = T
+    });
+
+    test("NOT(A AND B) follows De Morgan", () => {
+      expect(passes(T().and(T()).not())).toBe(false); // NOT(T AND T) = F
+      expect(passes(T().and(F()).not())).toBe(true); // NOT(T AND F) = T
+      expect(passes(F().and(F()).not())).toBe(true); // NOT(F AND F) = T
+    });
+
+    test("double negation and nesting", () => {
+      expect(passes(T().not().not())).toBe(true);
+      expect(passes(F().not().not())).toBe(false);
+      // NOT(T OR F) AND T = F AND T = F
+      expect(passes(T().or(F()).not().and(T()))).toBe(false);
+      // T AND NOT(T AND T) = T AND F = F
+      expect(passes(T().and(T().and(T()).not()))).toBe(false);
+      // NOT((A AND B) OR C): NOT((T AND F) OR F) = NOT(F) = T
+      expect(passes(T().and(F()).or(F()).not())).toBe(true);
+      // NOT((A AND B) OR C): NOT((T AND T) OR F) = NOT(T) = F
+      expect(passes(T().and(T()).or(F()).not())).toBe(false);
+    });
+
+    test("async path matches sync path", async () => {
+      const asyncHandle = async (d: boolean) => d;
+      const passesAsync = async (expr: BoolExp<boolean>) => (await expr.evaluateAsync(asyncHandle)) === true;
+      expect(await passesAsync(T().or(F()).not())).toBe(false);
+      expect(await passesAsync(F().or(F()).not())).toBe(true);
+      expect(await passesAsync(T().and(F()).not())).toBe(true);
+      expect(await passesAsync(T().and(T()).not())).toBe(false);
+      expect(await passesAsync(F().not().not())).toBe(false);
     });
   });
 
@@ -890,21 +931,20 @@ describe("BoolExp Complete Test Suite", () => {
       expect(expr.right!.right!.isNot()).toBe(true);
     });
 
-    test("should evaluate NOT with AND - understanding current behavior", () => {
+    test("should evaluate NOT with AND - De Morgan semantics", () => {
       const A = BoolExp.atom(10);
       const B = BoolExp.atom(3);
-      
-      // NOT(A AND B)
+
+      // NOT(A AND B) with A = true (10 > 5), B = false (3 > 5):
+      // NOT(true AND false) = NOT(false) = true.
       const expr1 = A.and(B).not();
       const result1 = expr1.evaluate((data) => data > 5);
-      
-      // For the data (10, 3):
-      // A = true (10 > 5), B = false (3 > 5)
-      // A AND B evaluates left (true), then right (false), returns error
-      // NOT receives error and passes it through
-      // This is current implementation behavior
-      expect(result1).not.toBe(true);
-      expect((result1 as EvaluateError<number>).data).toBe(3);
+      expect(result1).toBe(true);
+
+      // NOT(A AND A') where both hold → NOT(true) = false (reject).
+      const expr2 = A.and(BoolExp.atom(20)).not();
+      const result2 = expr2.evaluate((data) => data > 5);
+      expect(result2).not.toBe(true);
     });
 
     test("should maintain immutability", () => {

--- a/tests/runtime/WritingComputationTests.md
+++ b/tests/runtime/WritingComputationTests.md
@@ -288,6 +288,14 @@ test('should handle negative values correctly', async () => {
 | 观察面 | 查询面 / **事件面（用 tests/storage/helpers/eventCompleteness.ts 的预言机）** / 计算面（与朴素重算对照） / 不变量面（无悬挂端点、x:1 排他唯一） | r17 F-2 |
 | 计算轨道（机制轴） | 数据驱动（dataDeps）/ **事件驱动（StateMachine trigger / Transform eventDeps）** / **migration 签名（第三个读者：同一声明在 manifest 里是否可见）** | r18 F-1、r18 F-2 |
 | 监听名形态（机制轴） | 物理 base 名 / **filtered entity/relation 名** / **merged input 视图名** / 嵌套 filtered 链 | r18 F-1、r18 merged-input 亲缘 bug |
+| 底层原语正确性（正交轴） | 被复用原语（`BoolExp.evaluate` / match 求值 / 算术求值）的**代数律/真值表**必须独立于"上层怎么用"断言；同一语义有多实现（SQL `NOT` / 内存 not）时须做**一致性对账**；权限面须有**对抗性断言**（构造应拒绝的组合守卫，断言其拒绝——fail-open 是否定形命题，正向用例测不到） | r19 F-1（NOT 不贯穿 AND/OR，且旧测试把 bug 写进断言） |
+
+**正交轴说明（r19 复盘引入）**：数据形态轴与机制轴都长在"响应式数据流"上（mutation → 事件 → 计算）。
+底层逻辑原语（`BoolExp.evaluate`、match 求值、算术求值）是数据流的**上游依赖**，不产生 mutation、不进事件流、
+不注册监听——所有数据流预言机对它失明。它的正确性契约是**数学事实**（真值表 / 代数律），绝不能由"当前实现怎么跑"
+定义。r19 F-1 的教训尤其尖锐：`boolexp.spec.ts` 两处旧测试的注释写明了"实现不传播 inverse"，却把这个错误行为
+`expect(...).not.toBe(true)` 固化成绿灯——**测试不是漏写，是替 bug 挡住了所有想修它的人**。写原语测试时必须问：
+断言的是语义应该是什么，还是实现现在是什么？
 
 **机制轴说明（r18 复盘引入）**：前七根轴描述"声明的数据形状"，后两根描述"同一声明被哪个机制消费"。
 同一个声明面（如 trigger/eventDep 的 `recordName + type`）的**每一个读者都是一根轴**——bug 住在读者之间的

--- a/tests/runtime/review-fixes-2026-07-11-r19.spec.ts
+++ b/tests/runtime/review-fixes-2026-07-11-r19.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+import {
+  Entity,
+  Property,
+  Interaction,
+  Action,
+  Payload,
+  PayloadItem,
+  Controller,
+  MonoSystem,
+  KlassByName,
+  Condition,
+  Conditions,
+  BoolExp,
+} from "interaqt";
+import { PGLiteDB } from "@drivers";
+
+/**
+ * r19 deep-review fatal-fix regressions.
+ *
+ * F-1 BoolExp.evaluate/evaluateAsync dropped `inverse` when descending into AND/OR
+ * subtrees, so a guard written as NOT(A OR B) degraded to (A OR B) — a silent
+ * permission fail-open. The guard chain (Conditions + BoolExp) is the real consumer,
+ * so this asserts the fix end-to-end through Controller.dispatch, not only at the
+ * BoolExp unit level (core truth-table regression lives in tests/core/boolexp.spec.ts).
+ */
+describe("r19 F-1 — guard NOT(compound) is fail-closed", () => {
+  async function makeGuardController(conditionsContent: any) {
+    const User = Entity.create({
+      name: "User",
+      properties: [Property.create({ name: "name", type: "string" })],
+    });
+    const Guarded = Interaction.create({
+      name: "Guarded",
+      action: Action.create({ name: "doGuard" }),
+      conditions: Conditions.create({ content: conditionsContent }),
+    });
+    const db = new PGLiteDB();
+    const system = new MonoSystem(db);
+    system.conceptClass = KlassByName;
+    const controller = new Controller({
+      system,
+      entities: [User],
+      relations: [],
+      eventSources: [Guarded],
+    });
+    await controller.setup(true);
+    return { controller, Guarded, db };
+  }
+
+  const truthy = (name: string) =>
+    Condition.create({ name, content: async function () { return true; } });
+  const falsy = (name: string) =>
+    Condition.create({ name, content: async function () { return false; } });
+
+  test("NOT(A OR B): passes only when both A and B are false", async () => {
+    // A=true, B=false → OR=true → NOT=false → MUST be rejected (the old fail-open bug).
+    const c1 = await makeGuardController(
+      BoolExp.atom(truthy("a1")).or(BoolExp.atom(falsy("b1"))).not()
+    );
+    const rejected = await c1.controller.dispatch(c1.Guarded, {
+      user: { id: "u1" } as any,
+      payload: {},
+    } as any);
+    expect(rejected.error).toBeDefined();
+    await c1.db.close();
+
+    // A=false, B=false → OR=false → NOT=true → MUST pass.
+    const c2 = await makeGuardController(
+      BoolExp.atom(falsy("a2")).or(BoolExp.atom(falsy("b2"))).not()
+    );
+    const allowed = await c2.controller.dispatch(c2.Guarded, {
+      user: { id: "u1" } as any,
+      payload: {},
+    } as any);
+    expect(allowed.error).toBeUndefined();
+    await c2.db.close();
+  });
+
+  test("NOT(A AND B): De Morgan — passes unless both hold", async () => {
+    // A=true, B=false → AND=false → NOT=true → MUST pass.
+    const c1 = await makeGuardController(
+      BoolExp.atom(truthy("a3")).and(BoolExp.atom(falsy("b3"))).not()
+    );
+    const allowed = await c1.controller.dispatch(c1.Guarded, {
+      user: { id: "u1" } as any,
+      payload: {},
+    } as any);
+    expect(allowed.error).toBeUndefined();
+    await c1.db.close();
+
+    // A=true, B=true → AND=true → NOT=false → MUST be rejected.
+    const c2 = await makeGuardController(
+      BoolExp.atom(truthy("a4")).and(BoolExp.atom(truthy("b4"))).not()
+    );
+    const rejected = await c2.controller.dispatch(c2.Guarded, {
+      user: { id: "u1" } as any,
+      payload: {},
+    } as any);
+    expect(rejected.error).toBeDefined();
+    await c2.db.close();
+  });
+});
+
+/**
+ * I-1 payload declared as `type: 'Entity'` / `type: 'Relation'` (via `base`) with
+ * isCollection:false accepted an array (typeof [] === 'object'); with isCollection:true
+ * it accepted nested arrays as elements. Downstream consumers treat the value as a single
+ * entity object → silent semantic drift. Fixed by rejecting arrays at the entity/relation
+ * structural check (mirrors r17's `type: 'object'` array rejection).
+ */
+describe("r19 I-1 — entity/relation payload rejects arrays", () => {
+  async function dispatchWith(itemArgs: any, payloadValue: any) {
+    const Doc = Entity.create({
+      name: "Doc",
+      properties: [Property.create({ name: "title", type: "string" })],
+    });
+    const CreateThing = Interaction.create({
+      name: "CreateThing",
+      action: Action.create({ name: "createThing" }),
+      payload: Payload.create({ items: [PayloadItem.create({ name: "doc", base: Doc, ...itemArgs })] }),
+    });
+    const db = new PGLiteDB();
+    const system = new MonoSystem(db);
+    system.conceptClass = KlassByName;
+    const controller = new Controller({
+      system,
+      entities: [Doc],
+      relations: [],
+      eventSources: [CreateThing],
+    });
+    await controller.setup(true);
+    const res = await controller.dispatch(CreateThing, {
+      user: { id: "u1" } as any,
+      payload: { doc: payloadValue },
+    } as any);
+    await db.close();
+    return res;
+  }
+
+  test("isCollection:false rejects an array masquerading as a single entity", async () => {
+    const res = await dispatchWith({ isRef: false }, [{ title: "x" }, { title: "y" }]);
+    expect(res.error).toBeDefined();
+  });
+
+  test("isCollection:false still accepts a plain entity object", async () => {
+    const res = await dispatchWith({ isRef: false }, { title: "x" });
+    expect(res.error).toBeUndefined();
+  });
+
+  test("isCollection:true rejects nested-array elements", async () => {
+    const res = await dispatchWith({ isRef: false, isCollection: true }, [[{ title: "x" }]]);
+    expect(res.error).toBeDefined();
+  });
+
+  test("isCollection:true still accepts an array of entity objects", async () => {
+    const res = await dispatchWith({ isRef: false, isCollection: true }, [{ title: "x" }, { title: "y" }]);
+    expect(res.error).toBeUndefined();
+  });
+});

--- a/tests/storage/review-fixes-2026-07-11-r19.spec.ts
+++ b/tests/storage/review-fixes-2026-07-11-r19.spec.ts
@@ -1,0 +1,87 @@
+import { DBSetup, EntityToTableMap, MatchExp, EntityQueryHandle } from "@storage";
+import { Entity, Property, Relation } from "interaqt";
+import { PGLiteDB } from "@drivers";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+/**
+ * r19 F-2 regression.
+ *
+ * An EXIST subquery whose inner condition uses `isReferenceValue` to compare against an
+ * outer x:1 path (e.g. THIS user's `leader.salary`) resolves the reference against the
+ * outer root scope, but the outer query never JOINed that path — the generated SQL
+ * referenced `User_leader` with no matching FROM entry ("missing FROM-clause entry for
+ * table"). r12 F-2 fixed the outer *direct* match reference; the EXIST payload was the
+ * un-hoisted sibling. Fixed by hoisting inner exist reference paths into the outer JOIN tree.
+ */
+describe("r19 F-2 — EXIST inner isReferenceValue hoists outer x:1 JOIN", () => {
+  let db: PGLiteDB;
+  let handle: EntityQueryHandle;
+
+  beforeEach(async () => {
+    const User = Entity.create({
+      name: "User",
+      properties: [
+        Property.create({ name: "name", type: "string" }),
+        Property.create({ name: "salary", type: "number" }),
+        Property.create({ name: "age", type: "number" }),
+      ],
+    });
+    const leader = Relation.create({
+      source: User,
+      sourceProperty: "leader",
+      target: User,
+      targetProperty: "members",
+      type: "n:1",
+    });
+    const friends = Relation.create({
+      source: User,
+      sourceProperty: "friends",
+      target: User,
+      targetProperty: "friendOf",
+      type: "n:n",
+    });
+
+    db = new PGLiteDB();
+    await db.open();
+    const setup = new DBSetup([User], [leader, friends], db);
+    await setup.createTables();
+    handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  test("exist over friends comparing friend.age < this.leader.salary executes and filters correctly", async () => {
+    const boss = await handle.create("User", { name: "boss", salary: 100, age: 50 });
+    const lowBoss = await handle.create("User", { name: "lowBoss", salary: 5, age: 45 });
+    // a: leader=boss(salary 100); friend youngFriend age 30 < 100 → matches
+    const a = await handle.create("User", { name: "a", salary: 10, age: 30, leader: { id: boss.id } });
+    // b: leader=lowBoss(salary 5); friend age 30 is NOT < 5 → does not match
+    const b = await handle.create("User", { name: "b", salary: 10, age: 20, leader: { id: lowBoss.id } });
+    const youngFriend = await handle.create("User", {
+      name: "yf",
+      salary: 1,
+      age: 30,
+      friendOf: [{ id: a.id }, { id: b.id }],
+    });
+
+    const result = await handle.find(
+      "User",
+      MatchExp.atom({
+        key: "friends",
+        value: [
+          "exist",
+          MatchExp.atom({ key: "age", value: ["<", "leader.salary"], isReferenceValue: true }),
+        ],
+      }),
+      undefined,
+      ["id", "name"]
+    );
+
+    const names = result.map((r) => r.name).sort();
+    // a has a friend (yf, age 30) younger than a's leader salary (100) → matches.
+    // b's leader salary is 5, yf age 30 is not < 5 → b excluded.
+    expect(names).toEqual(["a"]);
+  });
+});

--- a/tests/storage/review-fixes-2026-07-11-r19.spec.ts
+++ b/tests/storage/review-fixes-2026-07-11-r19.spec.ts
@@ -85,3 +85,73 @@ describe("r19 F-2 — EXIST inner isReferenceValue hoists outer x:1 JOIN", () =>
     expect(names).toEqual(["a"]);
   });
 });
+
+/**
+ * r19 F-3 regression.
+ *
+ * In the combined (three-table-merged) topology, stealing a merged endpoint from an old
+ * owner physically flashes the columns out of the old owner's row but never re-evaluated
+ * the old owner's filtered-entity membership — the old owner silently exits the filtered
+ * view (query side correct) with NO membership delete event (event side missing), leaving
+ * downstream reactive computations over that view permanently stale. The merged topology
+ * already routes the old owner through the membership machinery; combined flashOut was the
+ * parallel gap (r18 retrospective flagged combined × filtered as a matrix blank).
+ */
+describe("r19 F-3 — combined steal emits old owner's filtered membership delete event", () => {
+  test("stealing a combined profile emits UserWithProfile delete for the old owner", async () => {
+    const User = Entity.create({
+      name: "User",
+      properties: [Property.create({ name: "name", type: "string" })],
+    });
+    const Profile = Entity.create({
+      name: "Profile",
+      properties: [Property.create({ name: "title", type: "string" })],
+    });
+    const userProfile = Relation.create({
+      source: User,
+      sourceProperty: "profile",
+      target: Profile,
+      targetProperty: "owner",
+      type: "1:1",
+    });
+    const UserWithProfile = Entity.create({
+      name: "UserWithProfile",
+      baseEntity: User,
+      matchExpression: MatchExp.atom({ key: "profile.id", value: ["not", null] }),
+    });
+
+    const db = new PGLiteDB();
+    await db.open();
+    // combined topology: merge the profile link into the shared row.
+    const setup = new DBSetup([User, Profile, UserWithProfile], [userProfile], db, ["User.profile"]);
+    await setup.createTables();
+    const handle = new EntityQueryHandle(new EntityToTableMap(setup.map, setup.aliasManager), db);
+
+    const a = await handle.create("User", { name: "A", profile: { title: "p" } });
+    expect((await handle.find("UserWithProfile", undefined, undefined, ["name"])).map((m) => m.name)).toEqual(["A"]);
+
+    const pid = (
+      await handle.findOne(
+        "User",
+        MatchExp.atom({ key: "id", value: ["=", a.id] }),
+        undefined,
+        ["id", ["profile", { attributeQuery: ["id"] }]]
+      )
+    ).profile.id;
+
+    // Steal p onto a new user B → A loses its profile → A exits UserWithProfile.
+    const events: any[] = [];
+    await handle.create("User", { name: "B", profile: { id: pid } }, events);
+
+    const membersAfter = (await handle.find("UserWithProfile", undefined, undefined, ["name"])).map((m) => m.name);
+    // Query side: A gone, B present.
+    expect(membersAfter).toEqual(["B"]);
+
+    const filteredEvents = events.filter((e) => e.recordName === "UserWithProfile");
+    // Event side: a delete for A must be emitted (the fix), plus a create for B.
+    expect(filteredEvents.some((e) => e.type === "delete" && e.record?.id === a.id)).toBe(true);
+    expect(filteredEvents.some((e) => e.type === "create")).toBe(true);
+
+    await db.close();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 第十九轮全代码库深度 Review

四路并行深度探查（builtins / storage 查询 / storage 写路径 / runtime / core+drivers+migration），对每个致命候选**亲自编写最小复现实际运行**（PGLiteDB）。完整报告见 `agentspace/output/deep-review-2026-07-11-r19.md`，逃逸复盘见 `agentspace/output/r19-test-blindness-retrospective.md`。

### 致命修复（3）

**F-1 `BoolExp` 的 NOT 不贯穿 AND/OR — 守卫权限 fail-open（最严重）**
`evaluate`/`evaluateAsync` 只对 atom 和 NOT 的直接子节点应用 `inverse`，`and`/`or` 分支丢弃它。`NOT(A OR B)` 静默退化成 `A OR B`。Interaction 守卫（`Conditions` + `BoolExp` 组合，文档明确推荐 `.and().or()` 且 `.not()` 是一等算子）正是这条求值路径的消费方——一条「A、B 皆不成立才放行」的守卫在 A 成立时**静默放行**。真值表实测 12 例修复前 8 例错。按 De Morgan 让 `inverse` 贯穿子树修复。**注：两处既有测试把错误行为编码成了断言**（注释写明「Current implementation doesn't propagate inverse」），已改为正确的 De Morgan 断言。

**F-2 EXIST 内层 `isReferenceValue` 引用外层 x:1 路径 — 外层 JOIN 缺失**
`friend.age < 本用户的 leader.salary` 这类相关 EXIST 直接抛 `missing FROM-clause entry for table "User_leader"`。r12-F-2 修了外层 direct match 的引用路径，EXIST 载荷是同族漏网读者。`buildQueryTree` 现递归收集 EXIST 载荷（含嵌套）内的引用路径并入根查询 JOIN 树。

**F-3 combined 拓扑抢夺既有 owner — 旧 owner filtered 成员资格事件丢失**
combined 拓扑下 flashOut 把端点列物理搬出旧 owner 行，但不重算其 filtered 成员资格：查询面正确（旧 owner 退出视图）、事件面无 delete，下游响应式计算永久陈旧。merged 拓扑经既有 unlink 机制已覆盖，combined 是平行漏网（r18 复盘标注的 combined × filtered 空白格）。flashOut 现在清列前快照、清列后 settle 旧 owner 成员资格。

### 重要修复（1）

**I-1 entity/relation payload 接受数组冒充单条** — `typeof [] === 'object'` 且 `[]` 真值，数组绕过 `base` 声明的结构校验。镜像 r17 的 `type:'object'` 数组拒绝，显式拒绝 `Array.isArray`。

### 证伪

「Summation/Average 全量重算对 string 字段字符串拼接」——复现证伪：`resolveSumField` 对 `"10"` 因 `Number.isFinite` false 而按 0 计，不拼接。

### 机制改造（登记册 + 复盘）

维度登记册新增**底层原语正确性正交轴**：被复用原语（`BoolExp.evaluate`/match/算术求值）的真值表/代数律须独立于「上层怎么用」断言；同一语义多实现须一致性对账；权限面须有对抗性（应拒绝）断言。复盘点破新盲区：**测试把 bug 当契约写进了断言**，替 bug 挡住了所有想修它的人。

### 测试

- ✅ `npm run check`（tsc 通过）
- ✅ `npm test` 全量 **1908 passed / 26 skipped**（基线 1896，+12 新回归，零既有回归）
- 回归：`tests/core/boolexp.spec.ts`（De Morgan 真值表 sync+async）、`tests/runtime/review-fixes-2026-07-11-r19.spec.ts`（6 用例：守卫对抗性 + payload 数组）、`tests/storage/review-fixes-2026-07-11-r19.spec.ts`（3 用例：EXIST 相关子查询 + combined filtered 事件）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76f8a946-5374-4609-9cb3-e75b0a20583e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76f8a946-5374-4609-9cb3-e75b0a20583e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

